### PR TITLE
Creating an oracle registry

### DIFF
--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -39,5 +39,5 @@ jobs:
         env:
           ETH_RPC_URL: ${{ secrets.CI_DEPLOY_RPC_URL }}
           ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY }}
-          RPC_URL_BASE_FORK: ${{ secrets.CI_DEPLOY_BASE_RPC_URL }}
+          RPC_URL_BASE_FORK: ${{ vars.CI_DEPLOY_BASE_RPC_URL }}
         run: nix develop -c ${{ matrix.task }}

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -12,6 +12,7 @@ path = [
     "foundry.toml",
     "REUSE.toml",
     "foundry.lock",
+    "lib/**",
 ]
 SPDX-FileCopyrightText = "Copyright (c) 2020 Rain Open Source Software Ltd"
 SPDX-License-Identifier = "LicenseRef-DCL-1.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -12,7 +12,14 @@ path = [
     "foundry.toml",
     "REUSE.toml",
     "foundry.lock",
-    "lib/**",
+    "CLAUDE.md",
+    "SPEC.md",
 ]
 SPDX-FileCopyrightText = "Copyright (c) 2020 Rain Open Source Software Ltd"
 SPDX-License-Identifier = "LicenseRef-DCL-1.0"
+
+[[annotations]]
+path = "lib/**"
+SPDX-FileCopyrightText = "Various contributors"
+SPDX-License-Identifier = "MIT AND Apache-2.0"
+precedence = "override"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -14,6 +14,7 @@ path = [
     "foundry.lock",
     "CLAUDE.md",
     "SPEC.md",
+    "slither.config.json"
 ]
 SPDX-FileCopyrightText = "Copyright (c) 2020 Rain Open Source Software Ltd"
 SPDX-License-Identifier = "LicenseRef-DCL-1.0"

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,4 @@
+{
+    "detectors_to_exclude": "assembly-usage,solc-version,unused-imports,pragma,naming-convention",
+    "filter_paths": "lib,test"
+}

--- a/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
@@ -66,8 +66,8 @@ contract MorphoProtocolAdapterBeaconSetDeployer {
 
         if (
             adapter.initialize(
-                abi.encode(MorphoProtocolAdapterConfig({registry: registry, vault: vault, admin: admin}))
-            ) != ICLONEABLE_V2_SUCCESS
+                    abi.encode(MorphoProtocolAdapterConfig({registry: registry, vault: vault, admin: admin}))
+                ) != ICLONEABLE_V2_SUCCESS
         ) {
             revert InitializeAdapterFailed();
         }

--- a/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
@@ -56,6 +56,7 @@ contract MorphoProtocolAdapterBeaconSetDeployer {
     /// @param vault The vault address this adapter serves.
     /// @param admin The admin address.
     /// @return adapter The deployed MorphoProtocolAdapter proxy.
+    // slither-disable-next-line reentrancy-events
     function newMorphoProtocolAdapter(OracleRegistry registry, address vault, address admin)
         external
         returns (MorphoProtocolAdapter)

--- a/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
@@ -7,7 +7,7 @@ import {UpgradeableBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/U
 import {BeaconProxy} from "openzeppelin-contracts/contracts/proxy/beacon/BeaconProxy.sol";
 import {ICLONEABLE_V2_SUCCESS} from "rain.factory/interface/ICloneableV2.sol";
 import {MorphoProtocolAdapter, MorphoProtocolAdapterConfig} from "src/concrete/protocol/MorphoProtocolAdapter.sol";
-import {AggregatorV3Interface} from "src/interface/IAggregatorV3.sol";
+import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 
 /// @dev Error raised when a zero address is provided for the implementation.
 error ZeroImplementation();
@@ -52,10 +52,11 @@ contract MorphoProtocolAdapterBeaconSetDeployer {
     }
 
     /// @notice Deploys and initializes a new MorphoProtocolAdapter proxy.
-    /// @param oracle The oracle adapter address.
+    /// @param registry The oracle registry address.
+    /// @param vault The vault address this adapter serves.
     /// @param admin The admin address.
     /// @return adapter The deployed MorphoProtocolAdapter proxy.
-    function newMorphoProtocolAdapter(AggregatorV3Interface oracle, address admin)
+    function newMorphoProtocolAdapter(OracleRegistry registry, address vault, address admin)
         external
         returns (MorphoProtocolAdapter)
     {
@@ -63,8 +64,9 @@ contract MorphoProtocolAdapterBeaconSetDeployer {
             MorphoProtocolAdapter(address(new BeaconProxy(address(I_MORPHO_PROTOCOL_ADAPTER_BEACON), "")));
 
         if (
-            adapter.initialize(abi.encode(MorphoProtocolAdapterConfig({oracle: oracle, admin: admin})))
-                != ICLONEABLE_V2_SUCCESS
+            adapter.initialize(
+                abi.encode(MorphoProtocolAdapterConfig({registry: registry, vault: vault, admin: admin}))
+            ) != ICLONEABLE_V2_SUCCESS
         ) {
             revert InitializeAdapterFailed();
         }

--- a/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
@@ -66,8 +66,8 @@ contract MorphoProtocolAdapterBeaconSetDeployer {
 
         if (
             adapter.initialize(
-                    abi.encode(MorphoProtocolAdapterConfig({registry: registry, vault: vault, admin: admin}))
-                ) != ICLONEABLE_V2_SUCCESS
+                abi.encode(MorphoProtocolAdapterConfig({registry: registry, vault: vault, admin: admin}))
+            ) != ICLONEABLE_V2_SUCCESS
         ) {
             revert InitializeAdapterFailed();
         }

--- a/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
+++ b/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
@@ -52,6 +52,7 @@ contract OracleRegistryBeaconSetDeployer {
     /// @notice Deploys and initializes a new OracleRegistry proxy.
     /// @param config The initialization configuration.
     /// @return registry The deployed OracleRegistry proxy.
+    // slither-disable-next-line reentrancy-events
     function newOracleRegistry(OracleRegistryConfig memory config) external returns (OracleRegistry) {
         OracleRegistry registry = OracleRegistry(address(new BeaconProxy(address(I_ORACLE_REGISTRY_BEACON), "")));
 

--- a/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
+++ b/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
+import {UpgradeableBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import {BeaconProxy} from "openzeppelin-contracts/contracts/proxy/beacon/BeaconProxy.sol";
+import {ICLONEABLE_V2_SUCCESS} from "rain.factory/interface/ICloneableV2.sol";
+import {OracleRegistry, OracleRegistryConfig} from "src/concrete/registry/OracleRegistry.sol";
+
+/// @dev Error raised when a zero address is provided for the implementation.
+error ZeroImplementation();
+
+/// @dev Error raised when a zero address is provided for the initial beacon
+/// owner.
+error ZeroBeaconOwner();
+
+/// @dev Error raised when initialization of the oracle registry fails.
+error InitializeRegistryFailed();
+
+/// @title OracleRegistryBeaconSetDeployerConfig
+/// @notice Configuration for the OracleRegistryBeaconSetDeployer construction.
+/// @param initialOwner The initial owner of the beacon.
+/// @param initialOracleRegistryImplementation The initial implementation.
+struct OracleRegistryBeaconSetDeployerConfig {
+    address initialOwner;
+    address initialOracleRegistryImplementation;
+}
+
+/// @title OracleRegistryBeaconSetDeployer
+/// @notice Deploys and manages a beacon set for OracleRegistry contracts.
+/// Follows the st0x.deploy BeaconSetDeployer pattern.
+contract OracleRegistryBeaconSetDeployer {
+    /// Emitted when a new OracleRegistry is deployed.
+    event Deployment(address sender, address oracleRegistry);
+
+    /// The beacon for the OracleRegistry implementation contracts.
+    IBeacon public immutable I_ORACLE_REGISTRY_BEACON;
+
+    constructor(OracleRegistryBeaconSetDeployerConfig memory config) {
+        if (config.initialOracleRegistryImplementation == address(0)) {
+            revert ZeroImplementation();
+        }
+        if (config.initialOwner == address(0)) {
+            revert ZeroBeaconOwner();
+        }
+
+        I_ORACLE_REGISTRY_BEACON =
+            new UpgradeableBeacon(config.initialOracleRegistryImplementation, config.initialOwner);
+    }
+
+    /// @notice Deploys and initializes a new OracleRegistry proxy.
+    /// @param config The initialization configuration.
+    /// @return registry The deployed OracleRegistry proxy.
+    function newOracleRegistry(OracleRegistryConfig memory config) external returns (OracleRegistry) {
+        OracleRegistry registry = OracleRegistry(address(new BeaconProxy(address(I_ORACLE_REGISTRY_BEACON), "")));
+
+        if (registry.initialize(abi.encode(config)) != ICLONEABLE_V2_SUCCESS) {
+            revert InitializeRegistryFailed();
+        }
+
+        emit Deployment(msg.sender, address(registry));
+
+        return registry;
+    }
+}

--- a/src/concrete/deploy/OracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/OracleUnifiedDeployer.sol
@@ -28,6 +28,7 @@ contract OracleUnifiedDeployer {
     /// @param priceId The Pyth price feed ID for the underlying asset.
     /// @param maxAge Maximum acceptable price age in seconds.
     /// @param registry The oracle registry. Admin must call registry.setOracle() separately.
+    // slither-disable-next-line reentrancy-events
     function newOracleAndProtocolAdapters(address vault, bytes32 priceId, uint256 maxAge, OracleRegistry registry)
         external
     {

--- a/src/concrete/deploy/OracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/OracleUnifiedDeployer.sol
@@ -3,8 +3,9 @@
 pragma solidity =0.8.25;
 
 import {PythOracleAdapterBeaconSetDeployer} from "src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
-import {PassthroughProtocolAdapterBeaconSetDeployer} from
-    "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
+import {
+    PassthroughProtocolAdapterBeaconSetDeployer
+} from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
 import {MorphoProtocolAdapterBeaconSetDeployer} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
 import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
 import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
@@ -34,20 +35,21 @@ contract OracleUnifiedDeployer {
     {
         // 1. Deploy oracle adapter
         PythOracleAdapter oracleAdapter = PythOracleAdapterBeaconSetDeployer(
-            LibProdDeploy.PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER
-        ).newPythOracleAdapter(
-            PythOracleAdapterConfig({vault: vault, priceId: priceId, maxAge: maxAge, admin: msg.sender})
-        );
+                LibProdDeploy.PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER
+            )
+            .newPythOracleAdapter(
+                PythOracleAdapterConfig({vault: vault, priceId: priceId, maxAge: maxAge, admin: msg.sender})
+            );
 
         // 2. Deploy Morpho protocol adapter
         MorphoProtocolAdapter morphoAdapter = MorphoProtocolAdapterBeaconSetDeployer(
-            LibProdDeploy.MORPHO_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER
-        ).newMorphoProtocolAdapter(registry, vault, msg.sender);
+                LibProdDeploy.MORPHO_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER
+            ).newMorphoProtocolAdapter(registry, vault, msg.sender);
 
         // 3. Deploy passthrough protocol adapter (for Aave/Compound)
         PassthroughProtocolAdapter passthroughAdapter = PassthroughProtocolAdapterBeaconSetDeployer(
-            LibProdDeploy.PASSTHROUGH_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER
-        ).newPassthroughProtocolAdapter(registry, vault, msg.sender);
+                LibProdDeploy.PASSTHROUGH_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER
+            ).newPassthroughProtocolAdapter(registry, vault, msg.sender);
 
         emit Deployment(msg.sender, address(oracleAdapter), address(morphoAdapter), address(passthroughAdapter));
     }

--- a/src/concrete/deploy/OracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/OracleUnifiedDeployer.sol
@@ -3,9 +3,8 @@
 pragma solidity =0.8.25;
 
 import {PythOracleAdapterBeaconSetDeployer} from "src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
-import {
-    PassthroughProtocolAdapterBeaconSetDeployer
-} from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
+import {PassthroughProtocolAdapterBeaconSetDeployer} from
+    "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
 import {MorphoProtocolAdapterBeaconSetDeployer} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
 import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
 import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
@@ -35,21 +34,20 @@ contract OracleUnifiedDeployer {
     {
         // 1. Deploy oracle adapter
         PythOracleAdapter oracleAdapter = PythOracleAdapterBeaconSetDeployer(
-                LibProdDeploy.PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER
-            )
-            .newPythOracleAdapter(
-                PythOracleAdapterConfig({vault: vault, priceId: priceId, maxAge: maxAge, admin: msg.sender})
-            );
+            LibProdDeploy.PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER
+        ).newPythOracleAdapter(
+            PythOracleAdapterConfig({vault: vault, priceId: priceId, maxAge: maxAge, admin: msg.sender})
+        );
 
         // 2. Deploy Morpho protocol adapter
         MorphoProtocolAdapter morphoAdapter = MorphoProtocolAdapterBeaconSetDeployer(
-                LibProdDeploy.MORPHO_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER
-            ).newMorphoProtocolAdapter(registry, vault, msg.sender);
+            LibProdDeploy.MORPHO_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER
+        ).newMorphoProtocolAdapter(registry, vault, msg.sender);
 
         // 3. Deploy passthrough protocol adapter (for Aave/Compound)
         PassthroughProtocolAdapter passthroughAdapter = PassthroughProtocolAdapterBeaconSetDeployer(
-                LibProdDeploy.PASSTHROUGH_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER
-            ).newPassthroughProtocolAdapter(registry, vault, msg.sender);
+            LibProdDeploy.PASSTHROUGH_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER
+        ).newPassthroughProtocolAdapter(registry, vault, msg.sender);
 
         emit Deployment(msg.sender, address(oracleAdapter), address(morphoAdapter), address(passthroughAdapter));
     }

--- a/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
@@ -10,7 +10,7 @@ import {
     PassthroughProtocolAdapter,
     PassthroughProtocolAdapterConfig
 } from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
-import {AggregatorV3Interface} from "src/interface/IAggregatorV3.sol";
+import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 
 /// @dev Error raised when a zero address is provided for the implementation.
 error ZeroImplementation();
@@ -57,10 +57,11 @@ contract PassthroughProtocolAdapterBeaconSetDeployer {
     }
 
     /// @notice Deploys and initializes a new PassthroughProtocolAdapter proxy.
-    /// @param oracle The oracle adapter address.
+    /// @param registry The oracle registry address.
+    /// @param vault The vault address this adapter serves.
     /// @param admin The admin address.
     /// @return adapter The deployed PassthroughProtocolAdapter proxy.
-    function newPassthroughProtocolAdapter(AggregatorV3Interface oracle, address admin)
+    function newPassthroughProtocolAdapter(OracleRegistry registry, address vault, address admin)
         external
         returns (PassthroughProtocolAdapter)
     {
@@ -68,8 +69,9 @@ contract PassthroughProtocolAdapterBeaconSetDeployer {
             PassthroughProtocolAdapter(address(new BeaconProxy(address(I_PASSTHROUGH_PROTOCOL_ADAPTER_BEACON), "")));
 
         if (
-            adapter.initialize(abi.encode(PassthroughProtocolAdapterConfig({oracle: oracle, admin: admin})))
-                != ICLONEABLE_V2_SUCCESS
+            adapter.initialize(
+                abi.encode(PassthroughProtocolAdapterConfig({registry: registry, vault: vault, admin: admin}))
+            ) != ICLONEABLE_V2_SUCCESS
         ) {
             revert InitializeAdapterFailed();
         }

--- a/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
@@ -66,13 +66,14 @@ contract PassthroughProtocolAdapterBeaconSetDeployer {
         external
         returns (PassthroughProtocolAdapter)
     {
-        PassthroughProtocolAdapter adapter =
-            PassthroughProtocolAdapter(address(new BeaconProxy(address(I_PASSTHROUGH_PROTOCOL_ADAPTER_BEACON), "")));
+        PassthroughProtocolAdapter adapter = PassthroughProtocolAdapter(
+            address(new BeaconProxy(address(I_PASSTHROUGH_PROTOCOL_ADAPTER_BEACON), ""))
+        );
 
         if (
             adapter.initialize(
-                abi.encode(PassthroughProtocolAdapterConfig({registry: registry, vault: vault, admin: admin}))
-            ) != ICLONEABLE_V2_SUCCESS
+                    abi.encode(PassthroughProtocolAdapterConfig({registry: registry, vault: vault, admin: admin}))
+                ) != ICLONEABLE_V2_SUCCESS
         ) {
             revert InitializeAdapterFailed();
         }

--- a/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
@@ -61,6 +61,7 @@ contract PassthroughProtocolAdapterBeaconSetDeployer {
     /// @param vault The vault address this adapter serves.
     /// @param admin The admin address.
     /// @return adapter The deployed PassthroughProtocolAdapter proxy.
+    // slither-disable-next-line reentrancy-events
     function newPassthroughProtocolAdapter(OracleRegistry registry, address vault, address admin)
         external
         returns (PassthroughProtocolAdapter)

--- a/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
@@ -66,14 +66,13 @@ contract PassthroughProtocolAdapterBeaconSetDeployer {
         external
         returns (PassthroughProtocolAdapter)
     {
-        PassthroughProtocolAdapter adapter = PassthroughProtocolAdapter(
-            address(new BeaconProxy(address(I_PASSTHROUGH_PROTOCOL_ADAPTER_BEACON), ""))
-        );
+        PassthroughProtocolAdapter adapter =
+            PassthroughProtocolAdapter(address(new BeaconProxy(address(I_PASSTHROUGH_PROTOCOL_ADAPTER_BEACON), "")));
 
         if (
             adapter.initialize(
-                    abi.encode(PassthroughProtocolAdapterConfig({registry: registry, vault: vault, admin: admin}))
-                ) != ICLONEABLE_V2_SUCCESS
+                abi.encode(PassthroughProtocolAdapterConfig({registry: registry, vault: vault, admin: admin}))
+            ) != ICLONEABLE_V2_SUCCESS
         ) {
             revert InitializeAdapterFailed();
         }

--- a/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol
@@ -53,6 +53,7 @@ contract PythOracleAdapterBeaconSetDeployer {
     /// @notice Deploys and initializes a new PythOracleAdapter proxy.
     /// @param config The initialization configuration.
     /// @return adapter The deployed PythOracleAdapter proxy.
+    // slither-disable-next-line reentrancy-events
     function newPythOracleAdapter(PythOracleAdapterConfig memory config) external returns (PythOracleAdapter) {
         PythOracleAdapter adapter =
             PythOracleAdapter(address(new BeaconProxy(address(I_PYTH_ORACLE_ADAPTER_BEACON), "")));

--- a/src/concrete/oracle/PythOracleAdapter.sol
+++ b/src/concrete/oracle/PythOracleAdapter.sol
@@ -132,16 +132,19 @@ contract PythOracleAdapter is AggregatorV3Interface, ICloneableV2, Initializable
     }
 
     /// @inheritdoc AggregatorV3Interface
+    // slither-disable-next-line pyth-unchecked-confidence
     function latestAnswer() external view override returns (int256) {
         _validateNotPaused();
 
         IPyth pyth = LibPyth.getPriceFeedContract(block.chainid);
         PythStructs.Price memory priceData = pyth.getPriceNoOlderThan(priceId, maxAge);
 
+        // Confidence is checked in _vaultSharePrice -> _conservativeScaledPrice
         return _vaultSharePrice(priceData);
     }
 
     /// @inheritdoc AggregatorV3Interface
+    // slither-disable-next-line pyth-unchecked-confidence
     function latestRoundData()
         external
         view
@@ -151,6 +154,7 @@ contract PythOracleAdapter is AggregatorV3Interface, ICloneableV2, Initializable
         _validateNotPaused();
 
         IPyth pyth = LibPyth.getPriceFeedContract(block.chainid);
+        // Confidence is checked in _vaultSharePrice -> _conservativeScaledPrice
         PythStructs.Price memory priceData = pyth.getPriceNoOlderThan(priceId, maxAge);
 
         int256 scaledPrice = _vaultSharePrice(priceData);

--- a/src/concrete/oracle/PythOracleAdapter.sol
+++ b/src/concrete/oracle/PythOracleAdapter.sol
@@ -36,6 +36,9 @@ error ZeroAdmin();
 /// @dev Error raised when the vault has zero total supply (no shares minted).
 error ZeroVaultSupply();
 
+/// @dev Error raised when the computed vault share price is zero.
+error ZeroVaultSharePrice();
+
 /// @title PythOracleAdapterConfig
 /// @notice Configuration for PythOracleAdapter initialization.
 /// @param vault The ERC-4626 vault address this oracle prices shares for.
@@ -79,6 +82,8 @@ contract PythOracleAdapter is AggregatorV3Interface, ICloneableV2, Initializable
     event PythOracleAdapterInitialized(address indexed sender, PythOracleAdapterConfig config);
     /// @dev Emitted when the pause state changes.
     event PauseSet(bool isPaused);
+    /// @dev Emitted when the admin is changed.
+    event AdminSet(address indexed oldAdmin, address indexed newAdmin);
 
     constructor() {
         _disableInitializers();
@@ -174,6 +179,14 @@ contract PythOracleAdapter is AggregatorV3Interface, ICloneableV2, Initializable
         emit PauseSet(isPaused);
     }
 
+    /// @notice Update the admin address. Admin only.
+    /// @param newAdmin The new admin address.
+    function setAdmin(address newAdmin) external onlyAdmin {
+        if (newAdmin == address(0)) revert ZeroAdmin();
+        emit AdminSet(admin, newAdmin);
+        admin = newAdmin;
+    }
+
     /// @dev Reverts if the oracle is paused.
     function _validateNotPaused() internal view {
         if (paused) revert OraclePaused();
@@ -219,6 +232,10 @@ contract PythOracleAdapter is AggregatorV3Interface, ICloneableV2, Initializable
         // Multiply before divide for precision. The 18-decimal units of
         // totalAssets and totalSupply cancel out, preserving the 8-decimal
         // scale of price8. Checked arithmetic guards against overflow.
-        return int256(uint256(price8) * totalAssets / totalSupply);
+        int256 vaultSharePrice = int256(uint256(price8) * totalAssets / totalSupply);
+
+        if (vaultSharePrice == 0) revert ZeroVaultSharePrice();
+
+        return vaultSharePrice;
     }
 }

--- a/src/concrete/protocol/MorphoProtocolAdapter.sol
+++ b/src/concrete/protocol/MorphoProtocolAdapter.sol
@@ -10,6 +10,9 @@ import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 /// @dev Error raised when the caller is not the admin.
 error OnlyAdmin();
 
+/// @dev Error raised when a zero address is provided for the admin.
+error ZeroAdmin();
+
 /// @dev Error raised when a zero address is provided for the registry.
 error ZeroRegistry();
 
@@ -56,6 +59,8 @@ contract MorphoProtocolAdapter is IOracle, ICloneableV2, Initializable {
     event MorphoProtocolAdapterInitialized(address indexed sender, MorphoProtocolAdapterConfig config);
     /// @dev Emitted when the registry reference is updated.
     event RegistrySet(address indexed oldRegistry, address indexed newRegistry);
+    /// @dev Emitted when the admin is changed.
+    event AdminSet(address indexed oldAdmin, address indexed newAdmin);
 
     constructor() {
         _disableInitializers();
@@ -75,6 +80,7 @@ contract MorphoProtocolAdapter is IOracle, ICloneableV2, Initializable {
 
         if (address(config.registry) == address(0)) revert ZeroRegistry();
         if (config.vault == address(0)) revert ZeroVault();
+        if (config.admin == address(0)) revert ZeroAdmin();
 
         registry = config.registry;
         vault = config.vault;
@@ -95,6 +101,14 @@ contract MorphoProtocolAdapter is IOracle, ICloneableV2, Initializable {
         if (address(newRegistry) == address(0)) revert ZeroRegistry();
         emit RegistrySet(address(registry), address(newRegistry));
         registry = newRegistry;
+    }
+
+    /// @notice Update the admin address. Admin only.
+    /// @param newAdmin The new admin address.
+    function setAdmin(address newAdmin) external onlyAdmin {
+        if (newAdmin == address(0)) revert ZeroAdmin();
+        emit AdminSet(admin, newAdmin);
+        admin = newAdmin;
     }
 
     /// @notice Returns the price scaled to 36 decimals as required by Morpho

--- a/src/concrete/protocol/PassthroughProtocolAdapter.sol
+++ b/src/concrete/protocol/PassthroughProtocolAdapter.sol
@@ -112,6 +112,7 @@ contract PassthroughProtocolAdapter is ICloneableV2, Initializable {
     }
 
     /// @notice Returns the latest round data from the underlying oracle.
+    // slither-disable-next-line unused-return
     function latestRoundData()
         external
         view

--- a/src/concrete/protocol/PassthroughProtocolAdapter.sol
+++ b/src/concrete/protocol/PassthroughProtocolAdapter.sol
@@ -5,38 +5,49 @@ pragma solidity =0.8.25;
 import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain.factory/interface/ICloneableV2.sol";
 import {Initializable} from "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
 import {AggregatorV3Interface} from "src/interface/IAggregatorV3.sol";
+import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 
 /// @dev Error raised when the caller is not the admin.
 error OnlyAdmin();
 
-/// @dev Error raised when a zero address is provided for the oracle.
-error ZeroOracle();
+/// @dev Error raised when a zero address is provided for the registry.
+error ZeroRegistry();
+
+/// @dev Error raised when a zero address is provided for the vault.
+error ZeroVault();
+
+/// @dev Error raised when no oracle is found for the vault in the registry.
+error OracleNotFound();
 
 /// @title PassthroughProtocolAdapterConfig
 /// @notice Configuration for PassthroughProtocolAdapter initialization.
-/// @param oracle The initial oracle adapter address.
+/// @param registry The oracle registry address.
+/// @param vault The vault address this adapter serves.
 /// @param admin The admin address.
 struct PassthroughProtocolAdapterConfig {
-    AggregatorV3Interface oracle;
+    OracleRegistry registry;
+    address vault;
     address admin;
 }
 
 /// @title PassthroughProtocolAdapter
 /// @notice Protocol adapter for Aave V3, Compound V3, and any future
 /// Chainlink-compatible protocol. Passes through all AggregatorV3Interface
-/// calls to the underlying oracle adapter. The oracle reference is updatable
+/// calls to the underlying oracle adapter. The registry reference is updatable
 /// by the admin, allowing oracle swaps without protocol governance.
 /// Deploy multiple proxy instances from the same beacon for different protocols.
 contract PassthroughProtocolAdapter is ICloneableV2, Initializable {
-    /// @dev The underlying oracle adapter implementing AggregatorV3Interface.
-    AggregatorV3Interface public oracle;
+    /// @dev The oracle registry for looking up the oracle adapter.
+    OracleRegistry public registry;
+    /// @dev The vault address this adapter serves.
+    address public vault;
     /// @dev Admin address for governance actions.
     address public admin;
 
     /// @dev Emitted when the adapter is initialized.
     event PassthroughProtocolAdapterInitialized(address indexed sender, PassthroughProtocolAdapterConfig config);
-    /// @dev Emitted when the oracle reference is updated.
-    event OracleSet(address indexed oldOracle, address indexed newOracle);
+    /// @dev Emitted when the registry reference is updated.
+    event RegistrySet(address indexed oldRegistry, address indexed newRegistry);
 
     constructor() {
         _disableInitializers();
@@ -54,9 +65,11 @@ contract PassthroughProtocolAdapter is ICloneableV2, Initializable {
     function initialize(bytes calldata data) external initializer returns (bytes32) {
         PassthroughProtocolAdapterConfig memory config = abi.decode(data, (PassthroughProtocolAdapterConfig));
 
-        if (address(config.oracle) == address(0)) revert ZeroOracle();
+        if (address(config.registry) == address(0)) revert ZeroRegistry();
+        if (config.vault == address(0)) revert ZeroVault();
 
-        oracle = config.oracle;
+        registry = config.registry;
+        vault = config.vault;
         admin = config.admin;
 
         emit PassthroughProtocolAdapterInitialized(msg.sender, config);
@@ -69,26 +82,33 @@ contract PassthroughProtocolAdapter is ICloneableV2, Initializable {
         _;
     }
 
-    /// @notice Update the oracle reference. Admin only.
-    function setOracle(AggregatorV3Interface newOracle) external onlyAdmin {
-        if (address(newOracle) == address(0)) revert ZeroOracle();
-        emit OracleSet(address(oracle), address(newOracle));
-        oracle = newOracle;
+    /// @notice Update the registry reference. Admin only.
+    function setRegistry(OracleRegistry newRegistry) external onlyAdmin {
+        if (address(newRegistry) == address(0)) revert ZeroRegistry();
+        emit RegistrySet(address(registry), address(newRegistry));
+        registry = newRegistry;
+    }
+
+    /// @dev Internal helper to get the oracle from registry and revert if not found.
+    function _getOracle() internal view returns (AggregatorV3Interface) {
+        AggregatorV3Interface oracle = registry.getOracle(vault);
+        if (address(oracle) == address(0)) revert OracleNotFound();
+        return oracle;
     }
 
     /// @notice Returns the number of decimals from the underlying oracle.
     function decimals() external view returns (uint8) {
-        return oracle.decimals();
+        return _getOracle().decimals();
     }
 
     /// @notice Returns the description from the underlying oracle.
     function description() external view returns (string memory) {
-        return oracle.description();
+        return _getOracle().description();
     }
 
     /// @notice Returns the latest answer from the underlying oracle.
     function latestAnswer() external view returns (int256) {
-        return oracle.latestAnswer();
+        return _getOracle().latestAnswer();
     }
 
     /// @notice Returns the latest round data from the underlying oracle.
@@ -97,6 +117,6 @@ contract PassthroughProtocolAdapter is ICloneableV2, Initializable {
         view
         returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
-        return oracle.latestRoundData();
+        return _getOracle().latestRoundData();
     }
 }

--- a/src/concrete/protocol/PassthroughProtocolAdapter.sol
+++ b/src/concrete/protocol/PassthroughProtocolAdapter.sol
@@ -10,6 +10,9 @@ import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 /// @dev Error raised when the caller is not the admin.
 error OnlyAdmin();
 
+/// @dev Error raised when a zero address is provided for the admin.
+error ZeroAdmin();
+
 /// @dev Error raised when a zero address is provided for the registry.
 error ZeroRegistry();
 
@@ -36,7 +39,7 @@ struct PassthroughProtocolAdapterConfig {
 /// calls to the underlying oracle adapter. The registry reference is updatable
 /// by the admin, allowing oracle swaps without protocol governance.
 /// Deploy multiple proxy instances from the same beacon for different protocols.
-contract PassthroughProtocolAdapter is ICloneableV2, Initializable {
+contract PassthroughProtocolAdapter is AggregatorV3Interface, ICloneableV2, Initializable {
     /// @dev The oracle registry for looking up the oracle adapter.
     OracleRegistry public registry;
     /// @dev The vault address this adapter serves.
@@ -48,6 +51,8 @@ contract PassthroughProtocolAdapter is ICloneableV2, Initializable {
     event PassthroughProtocolAdapterInitialized(address indexed sender, PassthroughProtocolAdapterConfig config);
     /// @dev Emitted when the registry reference is updated.
     event RegistrySet(address indexed oldRegistry, address indexed newRegistry);
+    /// @dev Emitted when the admin is changed.
+    event AdminSet(address indexed oldAdmin, address indexed newAdmin);
 
     constructor() {
         _disableInitializers();
@@ -67,6 +72,7 @@ contract PassthroughProtocolAdapter is ICloneableV2, Initializable {
 
         if (address(config.registry) == address(0)) revert ZeroRegistry();
         if (config.vault == address(0)) revert ZeroVault();
+        if (config.admin == address(0)) revert ZeroAdmin();
 
         registry = config.registry;
         vault = config.vault;
@@ -89,6 +95,14 @@ contract PassthroughProtocolAdapter is ICloneableV2, Initializable {
         registry = newRegistry;
     }
 
+    /// @notice Update the admin address. Admin only.
+    /// @param newAdmin The new admin address.
+    function setAdmin(address newAdmin) external onlyAdmin {
+        if (newAdmin == address(0)) revert ZeroAdmin();
+        emit AdminSet(admin, newAdmin);
+        admin = newAdmin;
+    }
+
     /// @dev Internal helper to get the oracle from registry and revert if not found.
     function _getOracle() internal view returns (AggregatorV3Interface) {
         AggregatorV3Interface oracle = registry.getOracle(vault);
@@ -96,26 +110,32 @@ contract PassthroughProtocolAdapter is ICloneableV2, Initializable {
         return oracle;
     }
 
-    /// @notice Returns the number of decimals from the underlying oracle.
-    function decimals() external view returns (uint8) {
+    /// @inheritdoc AggregatorV3Interface
+    function decimals() external view override returns (uint8) {
         return _getOracle().decimals();
     }
 
-    /// @notice Returns the description from the underlying oracle.
-    function description() external view returns (string memory) {
+    /// @inheritdoc AggregatorV3Interface
+    function description() external view override returns (string memory) {
         return _getOracle().description();
     }
 
-    /// @notice Returns the latest answer from the underlying oracle.
-    function latestAnswer() external view returns (int256) {
+    /// @inheritdoc AggregatorV3Interface
+    function version() external view override returns (uint256) {
+        return _getOracle().version();
+    }
+
+    /// @inheritdoc AggregatorV3Interface
+    function latestAnswer() external view override returns (int256) {
         return _getOracle().latestAnswer();
     }
 
-    /// @notice Returns the latest round data from the underlying oracle.
+    /// @inheritdoc AggregatorV3Interface
     // slither-disable-next-line unused-return
     function latestRoundData()
         external
         view
+        override
         returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
         return _getOracle().latestRoundData();

--- a/src/concrete/registry/OracleRegistry.sol
+++ b/src/concrete/registry/OracleRegistry.sol
@@ -43,6 +43,8 @@ contract OracleRegistry is ICloneableV2, Initializable {
     event OracleRegistryInitialized(address indexed sender, OracleRegistryConfig config);
     /// @dev Emitted when an oracle is set for a vault.
     event OracleSet(address indexed vault, address indexed oldOracle, address indexed newOracle);
+    /// @dev Emitted when the admin is changed.
+    event AdminSet(address indexed oldAdmin, address indexed newAdmin);
 
     constructor() {
         _disableInitializers();
@@ -72,6 +74,14 @@ contract OracleRegistry is ICloneableV2, Initializable {
     modifier onlyAdmin() {
         if (msg.sender != admin) revert OnlyAdmin();
         _;
+    }
+
+    /// @notice Update the admin address. Admin only.
+    /// @param newAdmin The new admin address.
+    function setAdmin(address newAdmin) external onlyAdmin {
+        if (newAdmin == address(0)) revert ZeroAdmin();
+        emit AdminSet(admin, newAdmin);
+        admin = newAdmin;
     }
 
     /// @notice Set or update the oracle for a vault. Admin only.

--- a/src/concrete/registry/OracleRegistry.sol
+++ b/src/concrete/registry/OracleRegistry.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain.factory/interface/ICloneableV2.sol";
+import {Initializable} from "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
+import {AggregatorV3Interface} from "src/interface/IAggregatorV3.sol";
+
+/// @dev Error raised when the caller is not the admin.
+error OnlyAdmin();
+
+/// @dev Error raised when a zero address is provided for the admin.
+error ZeroAdmin();
+
+/// @dev Error raised when a zero address is provided for the vault.
+error ZeroVault();
+
+/// @dev Error raised when a zero address is provided for the oracle.
+error ZeroOracle();
+
+/// @dev Error raised when array lengths do not match in bulk operations.
+error ArrayLengthMismatch();
+
+/// @title OracleRegistryConfig
+/// @notice Configuration for OracleRegistry initialization.
+/// @param admin The admin address.
+struct OracleRegistryConfig {
+    address admin;
+}
+
+/// @title OracleRegistry
+/// @notice Centralizes vault -> oracle adapter mappings. Protocol adapters
+/// look up their oracle from the registry at runtime instead of storing a
+/// direct reference. A single registry update propagates to all protocol
+/// adapters for that vault automatically.
+contract OracleRegistry is ICloneableV2, Initializable {
+    /// @dev Admin address for governance actions.
+    address public admin;
+    /// @dev Mapping from vault address to oracle adapter.
+    mapping(address vault => AggregatorV3Interface oracle) internal _oracles;
+
+    /// @dev Emitted when the registry is initialized.
+    event OracleRegistryInitialized(address indexed sender, OracleRegistryConfig config);
+    /// @dev Emitted when an oracle is set for a vault.
+    event OracleSet(address indexed vault, address indexed oldOracle, address indexed newOracle);
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// As per ICloneableV2, this overload MUST always revert. Documents the
+    /// signature of the initialize function.
+    /// @param config The initialization configuration.
+    function initialize(OracleRegistryConfig memory config) external pure returns (bytes32) {
+        (config);
+        revert InitializeSignatureFn();
+    }
+
+    /// @inheritdoc ICloneableV2
+    function initialize(bytes calldata data) external initializer returns (bytes32) {
+        OracleRegistryConfig memory config = abi.decode(data, (OracleRegistryConfig));
+
+        if (config.admin == address(0)) revert ZeroAdmin();
+
+        admin = config.admin;
+
+        emit OracleRegistryInitialized(msg.sender, config);
+
+        return ICLONEABLE_V2_SUCCESS;
+    }
+
+    modifier onlyAdmin() {
+        if (msg.sender != admin) revert OnlyAdmin();
+        _;
+    }
+
+    /// @notice Set or update the oracle for a vault. Admin only.
+    /// @param vault The vault address.
+    /// @param oracle The oracle adapter address.
+    function setOracle(address vault, AggregatorV3Interface oracle) external onlyAdmin {
+        if (vault == address(0)) revert ZeroVault();
+        if (address(oracle) == address(0)) revert ZeroOracle();
+
+        address oldOracle = address(_oracles[vault]);
+        _oracles[vault] = oracle;
+
+        emit OracleSet(vault, oldOracle, address(oracle));
+    }
+
+    /// @notice Bulk set or update oracles for multiple vaults. Admin only.
+    /// @param vaults The vault addresses.
+    /// @param oracles The oracle adapter addresses.
+    function setOracleBulk(address[] calldata vaults, AggregatorV3Interface[] calldata oracles) external onlyAdmin {
+        if (vaults.length != oracles.length) revert ArrayLengthMismatch();
+
+        for (uint256 i = 0; i < vaults.length; i++) {
+            if (vaults[i] == address(0)) revert ZeroVault();
+            if (address(oracles[i]) == address(0)) revert ZeroOracle();
+
+            address oldOracle = address(_oracles[vaults[i]]);
+            _oracles[vaults[i]] = oracles[i];
+
+            emit OracleSet(vaults[i], oldOracle, address(oracles[i]));
+        }
+    }
+
+    /// @notice Get the oracle for a vault.
+    /// @param vault The vault address.
+    /// @return The oracle adapter, or address(0) if not registered.
+    function getOracle(address vault) external view returns (AggregatorV3Interface) {
+        return _oracles[vault];
+    }
+}

--- a/src/lib/LibProdDeploy.sol
+++ b/src/lib/LibProdDeploy.sol
@@ -20,4 +20,10 @@ library LibProdDeploy {
 
     /// TODO: Set after initial deployment to Base.
     address constant ORACLE_UNIFIED_DEPLOYER = address(0);
+
+    /// TODO: Set after initial deployment to Base.
+    address constant ORACLE_REGISTRY_BEACON_SET_DEPLOYER = address(0);
+
+    /// TODO: Set after initial deployment to Base.
+    address constant ORACLE_REGISTRY = address(0);
 }

--- a/test/abstract/OracleRegistryTest.sol
+++ b/test/abstract/OracleRegistryTest.sol
@@ -17,8 +17,7 @@ contract OracleRegistryTest is Test {
         I_IMPLEMENTATION = new OracleRegistry();
         I_DEPLOYER = new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: address(this),
-                initialOracleRegistryImplementation: address(I_IMPLEMENTATION)
+                initialOwner: address(this), initialOracleRegistryImplementation: address(I_IMPLEMENTATION)
             })
         );
     }

--- a/test/abstract/OracleRegistryTest.sol
+++ b/test/abstract/OracleRegistryTest.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {OracleRegistry, OracleRegistryConfig} from "src/concrete/registry/OracleRegistry.sol";
+import {
+    OracleRegistryBeaconSetDeployer,
+    OracleRegistryBeaconSetDeployerConfig
+} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
+
+contract OracleRegistryTest is Test {
+    OracleRegistry internal immutable I_IMPLEMENTATION;
+    OracleRegistryBeaconSetDeployer internal immutable I_DEPLOYER;
+
+    constructor() {
+        I_IMPLEMENTATION = new OracleRegistry();
+        I_DEPLOYER = new OracleRegistryBeaconSetDeployer(
+            OracleRegistryBeaconSetDeployerConfig({
+                initialOwner: address(this),
+                initialOracleRegistryImplementation: address(I_IMPLEMENTATION)
+            })
+        );
+    }
+
+    function createRegistry(address admin) internal returns (OracleRegistry) {
+        return I_DEPLOYER.newOracleRegistry(OracleRegistryConfig({admin: admin}));
+    }
+}

--- a/test/abstract/OracleRegistryTest.sol
+++ b/test/abstract/OracleRegistryTest.sol
@@ -17,7 +17,8 @@ contract OracleRegistryTest is Test {
         I_IMPLEMENTATION = new OracleRegistry();
         I_DEPLOYER = new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: address(this), initialOracleRegistryImplementation: address(I_IMPLEMENTATION)
+                initialOwner: address(this),
+                initialOracleRegistryImplementation: address(I_IMPLEMENTATION)
             })
         );
     }

--- a/test/abstract/PythOracleAdapterTest.sol
+++ b/test/abstract/PythOracleAdapterTest.sol
@@ -17,8 +17,7 @@ contract PythOracleAdapterTest is Test {
         I_IMPLEMENTATION = new PythOracleAdapter();
         I_DEPLOYER = new PythOracleAdapterBeaconSetDeployer(
             PythOracleAdapterBeaconSetDeployerConfig({
-                initialOwner: address(this),
-                initialPythOracleAdapterImplementation: address(I_IMPLEMENTATION)
+                initialOwner: address(this), initialPythOracleAdapterImplementation: address(I_IMPLEMENTATION)
             })
         );
     }

--- a/test/abstract/PythOracleAdapterTest.sol
+++ b/test/abstract/PythOracleAdapterTest.sol
@@ -17,7 +17,8 @@ contract PythOracleAdapterTest is Test {
         I_IMPLEMENTATION = new PythOracleAdapter();
         I_DEPLOYER = new PythOracleAdapterBeaconSetDeployer(
             PythOracleAdapterBeaconSetDeployerConfig({
-                initialOwner: address(this), initialPythOracleAdapterImplementation: address(I_IMPLEMENTATION)
+                initialOwner: address(this),
+                initialPythOracleAdapterImplementation: address(I_IMPLEMENTATION)
             })
         );
     }

--- a/test/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.construct.t.sol
@@ -17,15 +17,14 @@ contract MorphoProtocolAdapterBeaconSetDeployerConstructTest is Test {
         vm.expectRevert(abi.encodeWithSelector(ZeroImplementation.selector));
         new MorphoProtocolAdapterBeaconSetDeployer(
             MorphoProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner,
-                initialMorphoProtocolAdapterImplementation: address(0)
+                initialOwner: initialOwner, initialMorphoProtocolAdapterImplementation: address(0)
             })
         );
     }
 
-    function testMorphoProtocolAdapterBeaconSetDeployerConstructZeroBeaconOwner(
-        address initialMorphoProtocolAdapterImplementation
-    ) external {
+    function testMorphoProtocolAdapterBeaconSetDeployerConstructZeroBeaconOwner(address initialMorphoProtocolAdapterImplementation)
+        external
+    {
         vm.assume(initialMorphoProtocolAdapterImplementation != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroBeaconOwner.selector));
         new MorphoProtocolAdapterBeaconSetDeployer(
@@ -42,8 +41,7 @@ contract MorphoProtocolAdapterBeaconSetDeployerConstructTest is Test {
 
         MorphoProtocolAdapterBeaconSetDeployer deployer = new MorphoProtocolAdapterBeaconSetDeployer(
             MorphoProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner,
-                initialMorphoProtocolAdapterImplementation: address(implementation)
+                initialOwner: initialOwner, initialMorphoProtocolAdapterImplementation: address(implementation)
             })
         );
 

--- a/test/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.construct.t.sol
@@ -22,9 +22,9 @@ contract MorphoProtocolAdapterBeaconSetDeployerConstructTest is Test {
         );
     }
 
-    function testMorphoProtocolAdapterBeaconSetDeployerConstructZeroBeaconOwner(
-        address initialMorphoProtocolAdapterImplementation
-    ) external {
+    function testMorphoProtocolAdapterBeaconSetDeployerConstructZeroBeaconOwner(address initialMorphoProtocolAdapterImplementation)
+        external
+    {
         vm.assume(initialMorphoProtocolAdapterImplementation != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroBeaconOwner.selector));
         new MorphoProtocolAdapterBeaconSetDeployer(

--- a/test/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.construct.t.sol
@@ -17,8 +17,7 @@ contract MorphoProtocolAdapterBeaconSetDeployerConstructTest is Test {
         vm.expectRevert(abi.encodeWithSelector(ZeroImplementation.selector));
         new MorphoProtocolAdapterBeaconSetDeployer(
             MorphoProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner,
-                initialMorphoProtocolAdapterImplementation: address(0)
+                initialOwner: initialOwner, initialMorphoProtocolAdapterImplementation: address(0)
             })
         );
     }
@@ -42,8 +41,7 @@ contract MorphoProtocolAdapterBeaconSetDeployerConstructTest is Test {
 
         MorphoProtocolAdapterBeaconSetDeployer deployer = new MorphoProtocolAdapterBeaconSetDeployer(
             MorphoProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner,
-                initialMorphoProtocolAdapterImplementation: address(implementation)
+                initialOwner: initialOwner, initialMorphoProtocolAdapterImplementation: address(implementation)
             })
         );
 

--- a/test/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.construct.t.sol
@@ -17,14 +17,15 @@ contract MorphoProtocolAdapterBeaconSetDeployerConstructTest is Test {
         vm.expectRevert(abi.encodeWithSelector(ZeroImplementation.selector));
         new MorphoProtocolAdapterBeaconSetDeployer(
             MorphoProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner, initialMorphoProtocolAdapterImplementation: address(0)
+                initialOwner: initialOwner,
+                initialMorphoProtocolAdapterImplementation: address(0)
             })
         );
     }
 
-    function testMorphoProtocolAdapterBeaconSetDeployerConstructZeroBeaconOwner(address initialMorphoProtocolAdapterImplementation)
-        external
-    {
+    function testMorphoProtocolAdapterBeaconSetDeployerConstructZeroBeaconOwner(
+        address initialMorphoProtocolAdapterImplementation
+    ) external {
         vm.assume(initialMorphoProtocolAdapterImplementation != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroBeaconOwner.selector));
         new MorphoProtocolAdapterBeaconSetDeployer(
@@ -41,7 +42,8 @@ contract MorphoProtocolAdapterBeaconSetDeployerConstructTest is Test {
 
         MorphoProtocolAdapterBeaconSetDeployer deployer = new MorphoProtocolAdapterBeaconSetDeployer(
             MorphoProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner, initialMorphoProtocolAdapterImplementation: address(implementation)
+                initialOwner: initialOwner,
+                initialMorphoProtocolAdapterImplementation: address(implementation)
             })
         );
 

--- a/test/src/concrete/deploy/OracleRegistryBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/OracleRegistryBeaconSetDeployer.construct.t.sol
@@ -18,8 +18,7 @@ contract OracleRegistryBeaconSetDeployerConstructTest is Test {
         vm.expectRevert(abi.encodeWithSelector(ZeroImplementation.selector));
         new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: initialOwner,
-                initialOracleRegistryImplementation: address(0)
+                initialOwner: initialOwner, initialOracleRegistryImplementation: address(0)
             })
         );
     }
@@ -30,8 +29,7 @@ contract OracleRegistryBeaconSetDeployerConstructTest is Test {
         vm.expectRevert(abi.encodeWithSelector(ZeroBeaconOwner.selector));
         new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: address(0),
-                initialOracleRegistryImplementation: implementation
+                initialOwner: address(0), initialOracleRegistryImplementation: implementation
             })
         );
     }
@@ -44,8 +42,7 @@ contract OracleRegistryBeaconSetDeployerConstructTest is Test {
 
         OracleRegistryBeaconSetDeployer deployer = new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: initialOwner,
-                initialOracleRegistryImplementation: address(implementation)
+                initialOwner: initialOwner, initialOracleRegistryImplementation: address(implementation)
             })
         );
 

--- a/test/src/concrete/deploy/OracleRegistryBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/OracleRegistryBeaconSetDeployer.construct.t.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+import {
+    OracleRegistryBeaconSetDeployer,
+    OracleRegistryBeaconSetDeployerConfig,
+    ZeroImplementation,
+    ZeroBeaconOwner
+} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
+
+contract OracleRegistryBeaconSetDeployerConstructTest is Test {
+    /// Test that zero implementation address reverts.
+    function testConstructZeroImplementation(address initialOwner) external {
+        vm.assume(initialOwner != address(0));
+        vm.expectRevert(abi.encodeWithSelector(ZeroImplementation.selector));
+        new OracleRegistryBeaconSetDeployer(
+            OracleRegistryBeaconSetDeployerConfig({
+                initialOwner: initialOwner,
+                initialOracleRegistryImplementation: address(0)
+            })
+        );
+    }
+
+    /// Test that zero beacon owner address reverts.
+    function testConstructZeroBeaconOwner(address implementation) external {
+        vm.assume(implementation != address(0));
+        vm.expectRevert(abi.encodeWithSelector(ZeroBeaconOwner.selector));
+        new OracleRegistryBeaconSetDeployer(
+            OracleRegistryBeaconSetDeployerConfig({
+                initialOwner: address(0),
+                initialOracleRegistryImplementation: implementation
+            })
+        );
+    }
+
+    /// Test successful construction creates beacon.
+    function testConstructSuccess(address initialOwner) external {
+        vm.assume(initialOwner != address(0));
+
+        OracleRegistry implementation = new OracleRegistry();
+
+        OracleRegistryBeaconSetDeployer deployer = new OracleRegistryBeaconSetDeployer(
+            OracleRegistryBeaconSetDeployerConfig({
+                initialOwner: initialOwner,
+                initialOracleRegistryImplementation: address(implementation)
+            })
+        );
+
+        assertTrue(address(deployer.I_ORACLE_REGISTRY_BEACON()) != address(0));
+    }
+}

--- a/test/src/concrete/deploy/OracleRegistryBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/OracleRegistryBeaconSetDeployer.construct.t.sol
@@ -18,7 +18,8 @@ contract OracleRegistryBeaconSetDeployerConstructTest is Test {
         vm.expectRevert(abi.encodeWithSelector(ZeroImplementation.selector));
         new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: initialOwner, initialOracleRegistryImplementation: address(0)
+                initialOwner: initialOwner,
+                initialOracleRegistryImplementation: address(0)
             })
         );
     }
@@ -29,7 +30,8 @@ contract OracleRegistryBeaconSetDeployerConstructTest is Test {
         vm.expectRevert(abi.encodeWithSelector(ZeroBeaconOwner.selector));
         new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: address(0), initialOracleRegistryImplementation: implementation
+                initialOwner: address(0),
+                initialOracleRegistryImplementation: implementation
             })
         );
     }
@@ -42,7 +44,8 @@ contract OracleRegistryBeaconSetDeployerConstructTest is Test {
 
         OracleRegistryBeaconSetDeployer deployer = new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: initialOwner, initialOracleRegistryImplementation: address(implementation)
+                initialOwner: initialOwner,
+                initialOracleRegistryImplementation: address(implementation)
             })
         );
 

--- a/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
+++ b/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
@@ -6,8 +6,9 @@ import {Test} from "forge-std/Test.sol";
 import {OracleUnifiedDeployer} from "src/concrete/deploy/OracleUnifiedDeployer.sol";
 import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
 import {PythOracleAdapterBeaconSetDeployer} from "src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
-import {PassthroughProtocolAdapterBeaconSetDeployer} from
-    "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
+import {
+    PassthroughProtocolAdapterBeaconSetDeployer
+} from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
 import {MorphoProtocolAdapterBeaconSetDeployer} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
 import {PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
 import {OracleRegistry, OracleRegistryConfig} from "src/concrete/registry/OracleRegistry.sol";
@@ -24,8 +25,7 @@ contract OracleUnifiedDeployerTest is Test {
         I_REGISTRY_IMPLEMENTATION = new OracleRegistry();
         I_REGISTRY_DEPLOYER = new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: address(this),
-                initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
+                initialOwner: address(this), initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
             })
         );
     }

--- a/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
+++ b/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
@@ -10,22 +10,46 @@ import {PassthroughProtocolAdapterBeaconSetDeployer} from
     "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
 import {MorphoProtocolAdapterBeaconSetDeployer} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
 import {PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
-import {AggregatorV3Interface} from "src/interface/IAggregatorV3.sol";
+import {OracleRegistry, OracleRegistryConfig} from "src/concrete/registry/OracleRegistry.sol";
+import {
+    OracleRegistryBeaconSetDeployer,
+    OracleRegistryBeaconSetDeployerConfig
+} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
 
 contract OracleUnifiedDeployerTest is Test {
+    OracleRegistry internal immutable I_REGISTRY_IMPLEMENTATION;
+    OracleRegistryBeaconSetDeployer internal immutable I_REGISTRY_DEPLOYER;
+
+    constructor() {
+        I_REGISTRY_IMPLEMENTATION = new OracleRegistry();
+        I_REGISTRY_DEPLOYER = new OracleRegistryBeaconSetDeployer(
+            OracleRegistryBeaconSetDeployerConfig({
+                initialOwner: address(this),
+                initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
+            })
+        );
+    }
+
+    function _createRegistry(address admin) internal returns (OracleRegistry) {
+        return I_REGISTRY_DEPLOYER.newOracleRegistry(OracleRegistryConfig({admin: admin}));
+    }
+
     function testOracleUnifiedDeployer(
         address vault,
         bytes32 priceId,
         uint256 maxAge,
         address oracleAdapter,
         address morphoAdapter,
-        address passthroughAdapter
+        address passthroughAdapter,
+        address registryAdmin
     ) external {
         vm.assume(oracleAdapter.code.length == 0);
         vm.assume(morphoAdapter.code.length == 0);
         vm.assume(passthroughAdapter.code.length == 0);
+        vm.assume(registryAdmin != address(0));
 
         OracleUnifiedDeployer unifiedDeployer = new OracleUnifiedDeployer();
+        OracleRegistry registry = _createRegistry(registryAdmin);
 
         // Mock the PythOracleAdapterBeaconSetDeployer at the prod address.
         vm.etch(LibProdDeploy.PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER, vm.getCode("PythOracleAdapterBeaconSetDeployer"));
@@ -46,9 +70,7 @@ contract OracleUnifiedDeployerTest is Test {
         vm.mockCall(
             LibProdDeploy.MORPHO_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER,
             abi.encodeWithSelector(
-                MorphoProtocolAdapterBeaconSetDeployer.newMorphoProtocolAdapter.selector,
-                AggregatorV3Interface(oracleAdapter),
-                address(this)
+                MorphoProtocolAdapterBeaconSetDeployer.newMorphoProtocolAdapter.selector, registry, vault, address(this)
             ),
             abi.encode(morphoAdapter)
         );
@@ -62,7 +84,8 @@ contract OracleUnifiedDeployerTest is Test {
             LibProdDeploy.PASSTHROUGH_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER,
             abi.encodeWithSelector(
                 PassthroughProtocolAdapterBeaconSetDeployer.newPassthroughProtocolAdapter.selector,
-                AggregatorV3Interface(oracleAdapter),
+                registry,
+                vault,
                 address(this)
             ),
             abi.encode(passthroughAdapter)
@@ -70,6 +93,6 @@ contract OracleUnifiedDeployerTest is Test {
 
         vm.expectEmit();
         emit OracleUnifiedDeployer.Deployment(address(this), oracleAdapter, morphoAdapter, passthroughAdapter);
-        unifiedDeployer.newOracleAndProtocolAdapters(vault, priceId, maxAge);
+        unifiedDeployer.newOracleAndProtocolAdapters(vault, priceId, maxAge, registry);
     }
 }

--- a/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
+++ b/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
@@ -6,9 +6,8 @@ import {Test} from "forge-std/Test.sol";
 import {OracleUnifiedDeployer} from "src/concrete/deploy/OracleUnifiedDeployer.sol";
 import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
 import {PythOracleAdapterBeaconSetDeployer} from "src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
-import {
-    PassthroughProtocolAdapterBeaconSetDeployer
-} from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
+import {PassthroughProtocolAdapterBeaconSetDeployer} from
+    "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
 import {MorphoProtocolAdapterBeaconSetDeployer} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
 import {PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
 import {OracleRegistry, OracleRegistryConfig} from "src/concrete/registry/OracleRegistry.sol";
@@ -25,7 +24,8 @@ contract OracleUnifiedDeployerTest is Test {
         I_REGISTRY_IMPLEMENTATION = new OracleRegistry();
         I_REGISTRY_DEPLOYER = new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: address(this), initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
+                initialOwner: address(this),
+                initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
             })
         );
     }

--- a/test/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.construct.t.sol
@@ -12,22 +12,19 @@ import {
 import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
 
 contract PassthroughProtocolAdapterBeaconSetDeployerConstructTest is Test {
-    function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroImplementation(address initialOwner)
-        external
-    {
+    function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroImplementation(address initialOwner) external {
         vm.assume(initialOwner != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroImplementation.selector));
         new PassthroughProtocolAdapterBeaconSetDeployer(
             PassthroughProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner,
-                initialPassthroughProtocolAdapterImplementation: address(0)
+                initialOwner: initialOwner, initialPassthroughProtocolAdapterImplementation: address(0)
             })
         );
     }
 
-    function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroBeaconOwner(
-        address initialPassthroughProtocolAdapterImplementation
-    ) external {
+    function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroBeaconOwner(address initialPassthroughProtocolAdapterImplementation)
+        external
+    {
         vm.assume(initialPassthroughProtocolAdapterImplementation != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroBeaconOwner.selector));
         new PassthroughProtocolAdapterBeaconSetDeployer(
@@ -44,8 +41,7 @@ contract PassthroughProtocolAdapterBeaconSetDeployerConstructTest is Test {
 
         PassthroughProtocolAdapterBeaconSetDeployer deployer = new PassthroughProtocolAdapterBeaconSetDeployer(
             PassthroughProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner,
-                initialPassthroughProtocolAdapterImplementation: address(implementation)
+                initialOwner: initialOwner, initialPassthroughProtocolAdapterImplementation: address(implementation)
             })
         );
 

--- a/test/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.construct.t.sol
@@ -12,19 +12,22 @@ import {
 import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
 
 contract PassthroughProtocolAdapterBeaconSetDeployerConstructTest is Test {
-    function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroImplementation(address initialOwner) external {
+    function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroImplementation(address initialOwner)
+        external
+    {
         vm.assume(initialOwner != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroImplementation.selector));
         new PassthroughProtocolAdapterBeaconSetDeployer(
             PassthroughProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner, initialPassthroughProtocolAdapterImplementation: address(0)
+                initialOwner: initialOwner,
+                initialPassthroughProtocolAdapterImplementation: address(0)
             })
         );
     }
 
-    function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroBeaconOwner(address initialPassthroughProtocolAdapterImplementation)
-        external
-    {
+    function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroBeaconOwner(
+        address initialPassthroughProtocolAdapterImplementation
+    ) external {
         vm.assume(initialPassthroughProtocolAdapterImplementation != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroBeaconOwner.selector));
         new PassthroughProtocolAdapterBeaconSetDeployer(
@@ -41,7 +44,8 @@ contract PassthroughProtocolAdapterBeaconSetDeployerConstructTest is Test {
 
         PassthroughProtocolAdapterBeaconSetDeployer deployer = new PassthroughProtocolAdapterBeaconSetDeployer(
             PassthroughProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner, initialPassthroughProtocolAdapterImplementation: address(implementation)
+                initialOwner: initialOwner,
+                initialPassthroughProtocolAdapterImplementation: address(implementation)
             })
         );
 

--- a/test/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.construct.t.sol
@@ -22,9 +22,9 @@ contract PassthroughProtocolAdapterBeaconSetDeployerConstructTest is Test {
         );
     }
 
-    function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroBeaconOwner(
-        address initialPassthroughProtocolAdapterImplementation
-    ) external {
+    function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroBeaconOwner(address initialPassthroughProtocolAdapterImplementation)
+        external
+    {
         vm.assume(initialPassthroughProtocolAdapterImplementation != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroBeaconOwner.selector));
         new PassthroughProtocolAdapterBeaconSetDeployer(

--- a/test/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.construct.t.sol
@@ -12,15 +12,12 @@ import {
 import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
 
 contract PassthroughProtocolAdapterBeaconSetDeployerConstructTest is Test {
-    function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroImplementation(address initialOwner)
-        external
-    {
+    function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroImplementation(address initialOwner) external {
         vm.assume(initialOwner != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroImplementation.selector));
         new PassthroughProtocolAdapterBeaconSetDeployer(
             PassthroughProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner,
-                initialPassthroughProtocolAdapterImplementation: address(0)
+                initialOwner: initialOwner, initialPassthroughProtocolAdapterImplementation: address(0)
             })
         );
     }
@@ -44,8 +41,7 @@ contract PassthroughProtocolAdapterBeaconSetDeployerConstructTest is Test {
 
         PassthroughProtocolAdapterBeaconSetDeployer deployer = new PassthroughProtocolAdapterBeaconSetDeployer(
             PassthroughProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner,
-                initialPassthroughProtocolAdapterImplementation: address(implementation)
+                initialOwner: initialOwner, initialPassthroughProtocolAdapterImplementation: address(implementation)
             })
         );
 

--- a/test/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.construct.t.sol
@@ -17,21 +17,19 @@ contract PythOracleAdapterBeaconSetDeployerConstructTest is Test {
         vm.expectRevert(abi.encodeWithSelector(ZeroImplementation.selector));
         new PythOracleAdapterBeaconSetDeployer(
             PythOracleAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner,
-                initialPythOracleAdapterImplementation: address(0)
+                initialOwner: initialOwner, initialPythOracleAdapterImplementation: address(0)
             })
         );
     }
 
-    function testPythOracleAdapterBeaconSetDeployerConstructZeroBeaconOwner(
-        address initialPythOracleAdapterImplementation
-    ) external {
+    function testPythOracleAdapterBeaconSetDeployerConstructZeroBeaconOwner(address initialPythOracleAdapterImplementation)
+        external
+    {
         vm.assume(initialPythOracleAdapterImplementation != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroBeaconOwner.selector));
         new PythOracleAdapterBeaconSetDeployer(
             PythOracleAdapterBeaconSetDeployerConfig({
-                initialOwner: address(0),
-                initialPythOracleAdapterImplementation: initialPythOracleAdapterImplementation
+                initialOwner: address(0), initialPythOracleAdapterImplementation: initialPythOracleAdapterImplementation
             })
         );
     }
@@ -42,8 +40,7 @@ contract PythOracleAdapterBeaconSetDeployerConstructTest is Test {
 
         PythOracleAdapterBeaconSetDeployer deployer = new PythOracleAdapterBeaconSetDeployer(
             PythOracleAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner,
-                initialPythOracleAdapterImplementation: address(implementation)
+                initialOwner: initialOwner, initialPythOracleAdapterImplementation: address(implementation)
             })
         );
 

--- a/test/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.construct.t.sol
@@ -17,19 +17,21 @@ contract PythOracleAdapterBeaconSetDeployerConstructTest is Test {
         vm.expectRevert(abi.encodeWithSelector(ZeroImplementation.selector));
         new PythOracleAdapterBeaconSetDeployer(
             PythOracleAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner, initialPythOracleAdapterImplementation: address(0)
+                initialOwner: initialOwner,
+                initialPythOracleAdapterImplementation: address(0)
             })
         );
     }
 
-    function testPythOracleAdapterBeaconSetDeployerConstructZeroBeaconOwner(address initialPythOracleAdapterImplementation)
-        external
-    {
+    function testPythOracleAdapterBeaconSetDeployerConstructZeroBeaconOwner(
+        address initialPythOracleAdapterImplementation
+    ) external {
         vm.assume(initialPythOracleAdapterImplementation != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroBeaconOwner.selector));
         new PythOracleAdapterBeaconSetDeployer(
             PythOracleAdapterBeaconSetDeployerConfig({
-                initialOwner: address(0), initialPythOracleAdapterImplementation: initialPythOracleAdapterImplementation
+                initialOwner: address(0),
+                initialPythOracleAdapterImplementation: initialPythOracleAdapterImplementation
             })
         );
     }
@@ -40,7 +42,8 @@ contract PythOracleAdapterBeaconSetDeployerConstructTest is Test {
 
         PythOracleAdapterBeaconSetDeployer deployer = new PythOracleAdapterBeaconSetDeployer(
             PythOracleAdapterBeaconSetDeployerConfig({
-                initialOwner: initialOwner, initialPythOracleAdapterImplementation: address(implementation)
+                initialOwner: initialOwner,
+                initialPythOracleAdapterImplementation: address(implementation)
             })
         );
 

--- a/test/src/concrete/oracle/PythOracleAdapter.latestAnswer.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.latestAnswer.t.sol
@@ -27,8 +27,7 @@ contract PythOracleAdapterLatestAnswerTest is Test {
         PythOracleAdapter implementation = new PythOracleAdapter();
         I_DEPLOYER = new PythOracleAdapterBeaconSetDeployer(
             PythOracleAdapterBeaconSetDeployerConfig({
-                initialOwner: address(this),
-                initialPythOracleAdapterImplementation: address(implementation)
+                initialOwner: address(this), initialPythOracleAdapterImplementation: address(implementation)
             })
         );
     }
@@ -51,10 +50,7 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault,
-                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
-                maxAge: 3600,
-                admin: address(this)
+                vault: mockVault, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
             })
         );
 
@@ -74,10 +70,7 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle2x = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault2x,
-                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
-                maxAge: 3600,
-                admin: address(this)
+                vault: mockVault2x, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
             })
         );
 
@@ -86,10 +79,7 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle1x = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault1x,
-                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
-                maxAge: 3600,
-                admin: address(this)
+                vault: mockVault1x, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
             })
         );
 
@@ -107,10 +97,7 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault,
-                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
-                maxAge: 3600,
-                admin: address(this)
+                vault: mockVault, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
             })
         );
 
@@ -125,10 +112,7 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault,
-                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
-                maxAge: 3600,
-                admin: address(this)
+                vault: mockVault, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
             })
         );
 
@@ -151,10 +135,7 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault,
-                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
-                maxAge: 3600,
-                admin: address(this)
+                vault: mockVault, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
             })
         );
 
@@ -169,10 +150,7 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracleDiv = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVaultDiv,
-                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
-                maxAge: 3600,
-                admin: address(this)
+                vault: mockVaultDiv, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
             })
         );
 
@@ -181,10 +159,7 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle1x = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault1x,
-                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
-                maxAge: 3600,
-                admin: address(this)
+                vault: mockVault1x, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
             })
         );
 

--- a/test/src/concrete/oracle/PythOracleAdapter.latestAnswer.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.latestAnswer.t.sol
@@ -27,7 +27,8 @@ contract PythOracleAdapterLatestAnswerTest is Test {
         PythOracleAdapter implementation = new PythOracleAdapter();
         I_DEPLOYER = new PythOracleAdapterBeaconSetDeployer(
             PythOracleAdapterBeaconSetDeployerConfig({
-                initialOwner: address(this), initialPythOracleAdapterImplementation: address(implementation)
+                initialOwner: address(this),
+                initialPythOracleAdapterImplementation: address(implementation)
             })
         );
     }
@@ -50,7 +51,10 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this)
             })
         );
 
@@ -70,7 +74,10 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle2x = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault2x, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault2x,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this)
             })
         );
 
@@ -79,7 +86,10 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle1x = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault1x, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault1x,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this)
             })
         );
 
@@ -97,7 +107,10 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this)
             })
         );
 
@@ -112,7 +125,10 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this)
             })
         );
 
@@ -135,7 +151,10 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this)
             })
         );
 
@@ -150,7 +169,10 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracleDiv = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVaultDiv, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVaultDiv,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this)
             })
         );
 
@@ -159,7 +181,10 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle1x = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault1x, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault1x,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this)
             })
         );
 

--- a/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
@@ -33,15 +33,13 @@ contract MorphoProtocolAdapterTest is Test {
         I_IMPLEMENTATION = new MorphoProtocolAdapter();
         I_DEPLOYER = new MorphoProtocolAdapterBeaconSetDeployer(
             MorphoProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: address(this),
-                initialMorphoProtocolAdapterImplementation: address(I_IMPLEMENTATION)
+                initialOwner: address(this), initialMorphoProtocolAdapterImplementation: address(I_IMPLEMENTATION)
             })
         );
         I_REGISTRY_IMPLEMENTATION = new OracleRegistry();
         I_REGISTRY_DEPLOYER = new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: address(this),
-                initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
+                initialOwner: address(this), initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
             })
         );
     }

--- a/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
@@ -34,13 +34,15 @@ contract MorphoProtocolAdapterTest is Test {
         I_IMPLEMENTATION = new MorphoProtocolAdapter();
         I_DEPLOYER = new MorphoProtocolAdapterBeaconSetDeployer(
             MorphoProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: address(this), initialMorphoProtocolAdapterImplementation: address(I_IMPLEMENTATION)
+                initialOwner: address(this),
+                initialMorphoProtocolAdapterImplementation: address(I_IMPLEMENTATION)
             })
         );
         I_REGISTRY_IMPLEMENTATION = new OracleRegistry();
         I_REGISTRY_DEPLOYER = new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: address(this), initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
+                initialOwner: address(this),
+                initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
             })
         );
     }
@@ -262,5 +264,52 @@ contract MorphoProtocolAdapterTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(NonPositivePrice.selector));
         adapter.price();
+    }
+
+    /// Test setAdmin by admin.
+    function testSetAdmin(address registryAdmin, address vault, address admin, address newAdmin) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
+        vm.assume(admin != address(0));
+        vm.assume(newAdmin != address(0));
+
+        OracleRegistry registry = _createRegistry(registryAdmin);
+        MorphoProtocolAdapter adapter = I_DEPLOYER.newMorphoProtocolAdapter(registry, vault, admin);
+
+        vm.expectEmit(true, true, true, true);
+        emit MorphoProtocolAdapter.AdminSet(admin, newAdmin);
+        vm.prank(admin);
+        adapter.setAdmin(newAdmin);
+
+        assertEq(adapter.admin(), newAdmin);
+    }
+
+    /// Test setAdmin reverts for non-admin.
+    function testSetAdminOnlyAdmin(address registryAdmin, address vault, address admin, address nonAdmin) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
+        vm.assume(admin != address(0));
+        vm.assume(nonAdmin != admin);
+
+        OracleRegistry registry = _createRegistry(registryAdmin);
+        MorphoProtocolAdapter adapter = I_DEPLOYER.newMorphoProtocolAdapter(registry, vault, admin);
+
+        vm.prank(nonAdmin);
+        vm.expectRevert(abi.encodeWithSelector(OnlyAdmin.selector));
+        adapter.setAdmin(address(1));
+    }
+
+    /// Test setAdmin with zero address reverts.
+    function testSetAdminZeroAddress(address registryAdmin, address vault, address admin) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
+        vm.assume(admin != address(0));
+
+        OracleRegistry registry = _createRegistry(registryAdmin);
+        MorphoProtocolAdapter adapter = I_DEPLOYER.newMorphoProtocolAdapter(registry, vault, admin);
+
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(ZeroAdmin.selector));
+        adapter.setAdmin(address(0));
     }
 }

--- a/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
@@ -7,6 +7,7 @@ import {
     MorphoProtocolAdapter,
     MorphoProtocolAdapterConfig,
     OnlyAdmin,
+    ZeroAdmin,
     ZeroRegistry,
     ZeroVault,
     OracleNotFound,
@@ -63,10 +64,20 @@ contract MorphoProtocolAdapterTest is Test {
         I_DEPLOYER.newMorphoProtocolAdapter(registry, address(0), admin);
     }
 
+    /// Test that initialization with zero admin reverts.
+    function testInitializeZeroAdmin(address registryAdmin, address vault) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
+        OracleRegistry registry = _createRegistry(registryAdmin);
+        vm.expectRevert(abi.encodeWithSelector(ZeroAdmin.selector));
+        I_DEPLOYER.newMorphoProtocolAdapter(registry, vault, address(0));
+    }
+
     /// Test successful initialization.
     function testInitializeSuccess(address registryAdmin, address vault, address admin) external {
         vm.assume(registryAdmin != address(0));
         vm.assume(vault != address(0));
+        vm.assume(admin != address(0));
 
         OracleRegistry registry = _createRegistry(registryAdmin);
         MorphoProtocolAdapter adapter = I_DEPLOYER.newMorphoProtocolAdapter(registry, vault, admin);
@@ -80,6 +91,7 @@ contract MorphoProtocolAdapterTest is Test {
     function testInitializeEvent(address registryAdmin, address vault, address admin) external {
         vm.assume(registryAdmin != address(0));
         vm.assume(vault != address(0));
+        vm.assume(admin != address(0));
 
         OracleRegistry registry = _createRegistry(registryAdmin);
 

--- a/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
@@ -34,15 +34,13 @@ contract MorphoProtocolAdapterTest is Test {
         I_IMPLEMENTATION = new MorphoProtocolAdapter();
         I_DEPLOYER = new MorphoProtocolAdapterBeaconSetDeployer(
             MorphoProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: address(this),
-                initialMorphoProtocolAdapterImplementation: address(I_IMPLEMENTATION)
+                initialOwner: address(this), initialMorphoProtocolAdapterImplementation: address(I_IMPLEMENTATION)
             })
         );
         I_REGISTRY_IMPLEMENTATION = new OracleRegistry();
         I_REGISTRY_DEPLOYER = new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: address(this),
-                initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
+                initialOwner: address(this), initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
             })
         );
     }

--- a/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
@@ -7,17 +7,26 @@ import {
     PassthroughProtocolAdapter,
     PassthroughProtocolAdapterConfig,
     OnlyAdmin,
-    ZeroOracle
+    ZeroRegistry,
+    ZeroVault,
+    OracleNotFound
 } from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
 import {
     PassthroughProtocolAdapterBeaconSetDeployer,
     PassthroughProtocolAdapterBeaconSetDeployerConfig
 } from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
+import {OracleRegistry, OracleRegistryConfig} from "src/concrete/registry/OracleRegistry.sol";
+import {
+    OracleRegistryBeaconSetDeployer,
+    OracleRegistryBeaconSetDeployerConfig
+} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
 import {AggregatorV3Interface} from "src/interface/IAggregatorV3.sol";
 
 contract PassthroughProtocolAdapterTest is Test {
     PassthroughProtocolAdapter internal immutable I_IMPLEMENTATION;
     PassthroughProtocolAdapterBeaconSetDeployer internal immutable I_DEPLOYER;
+    OracleRegistry internal immutable I_REGISTRY_IMPLEMENTATION;
+    OracleRegistryBeaconSetDeployer internal immutable I_REGISTRY_DEPLOYER;
 
     constructor() {
         I_IMPLEMENTATION = new PassthroughProtocolAdapter();
@@ -27,36 +36,64 @@ contract PassthroughProtocolAdapterTest is Test {
                 initialPassthroughProtocolAdapterImplementation: address(I_IMPLEMENTATION)
             })
         );
+        I_REGISTRY_IMPLEMENTATION = new OracleRegistry();
+        I_REGISTRY_DEPLOYER = new OracleRegistryBeaconSetDeployer(
+            OracleRegistryBeaconSetDeployerConfig({
+                initialOwner: address(this),
+                initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
+            })
+        );
     }
 
-    /// Test that initialization with zero oracle reverts.
-    function testInitializeZeroOracle(address admin) external {
-        vm.expectRevert(abi.encodeWithSelector(ZeroOracle.selector));
-        I_DEPLOYER.newPassthroughProtocolAdapter(AggregatorV3Interface(address(0)), admin);
+    function _createRegistry(address admin) internal returns (OracleRegistry) {
+        return I_REGISTRY_DEPLOYER.newOracleRegistry(OracleRegistryConfig({admin: admin}));
+    }
+
+    /// Test that initialization with zero registry reverts.
+    function testInitializeZeroRegistry(address vault, address admin) external {
+        vm.assume(vault != address(0));
+        vm.expectRevert(abi.encodeWithSelector(ZeroRegistry.selector));
+        I_DEPLOYER.newPassthroughProtocolAdapter(OracleRegistry(address(0)), vault, admin);
+    }
+
+    /// Test that initialization with zero vault reverts.
+    function testInitializeZeroVault(address registryAdmin, address admin) external {
+        vm.assume(registryAdmin != address(0));
+        OracleRegistry registry = _createRegistry(registryAdmin);
+        vm.expectRevert(abi.encodeWithSelector(ZeroVault.selector));
+        I_DEPLOYER.newPassthroughProtocolAdapter(registry, address(0), admin);
     }
 
     /// Test successful initialization.
-    function testInitializeSuccess(address oracleAddr, address admin) external {
-        vm.assume(oracleAddr != address(0));
+    function testInitializeSuccess(address registryAdmin, address vault, address admin) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
 
-        PassthroughProtocolAdapter adapter =
-            I_DEPLOYER.newPassthroughProtocolAdapter(AggregatorV3Interface(oracleAddr), admin);
+        OracleRegistry registry = _createRegistry(registryAdmin);
+        PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
 
-        assertEq(address(adapter.oracle()), oracleAddr);
+        assertEq(address(adapter.registry()), address(registry));
+        assertEq(adapter.vault(), vault);
         assertEq(adapter.admin(), admin);
     }
 
     /// Test that initialization emits event.
-    function testInitializeEvent(address oracleAddr, address admin) external {
-        vm.assume(oracleAddr != address(0));
+    function testInitializeEvent(address registryAdmin, address vault, address admin) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
+
+        OracleRegistry registry = _createRegistry(registryAdmin);
 
         vm.recordLogs();
-        I_DEPLOYER.newPassthroughProtocolAdapter(AggregatorV3Interface(oracleAddr), admin);
+        I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
         bool eventFound = false;
         for (uint256 i = 0; i < logs.length; i++) {
-            if (logs[i].topics[0] == keccak256("PassthroughProtocolAdapterInitialized(address,(address,address))")) {
+            if (
+                logs[i].topics[0]
+                    == keccak256("PassthroughProtocolAdapterInitialized(address,(address,address,address))")
+            ) {
                 eventFound = true;
                 break;
             }
@@ -64,59 +101,91 @@ contract PassthroughProtocolAdapterTest is Test {
         assertTrue(eventFound, "PassthroughProtocolAdapterInitialized event not found");
     }
 
-    /// Test setOracle by admin.
-    function testSetOracle(address oracleAddr, address newOracleAddr, address admin) external {
-        vm.assume(oracleAddr != address(0));
-        vm.assume(newOracleAddr != address(0));
+    /// Test setRegistry by admin.
+    function testSetRegistry(address registryAdmin, address vault, address admin) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
         vm.assume(admin != address(0));
 
-        PassthroughProtocolAdapter adapter =
-            I_DEPLOYER.newPassthroughProtocolAdapter(AggregatorV3Interface(oracleAddr), admin);
+        OracleRegistry registry1 = _createRegistry(registryAdmin);
+        OracleRegistry registry2 = _createRegistry(registryAdmin);
+
+        PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry1, vault, admin);
 
         vm.expectEmit();
-        emit PassthroughProtocolAdapter.OracleSet(oracleAddr, newOracleAddr);
+        emit PassthroughProtocolAdapter.RegistrySet(address(registry1), address(registry2));
         vm.prank(admin);
-        adapter.setOracle(AggregatorV3Interface(newOracleAddr));
+        adapter.setRegistry(registry2);
 
-        assertEq(address(adapter.oracle()), newOracleAddr);
+        assertEq(address(adapter.registry()), address(registry2));
     }
 
-    /// Test setOracle reverts for non-admin.
-    function testSetOracleOnlyAdmin(address oracleAddr, address admin, address nonAdmin) external {
-        vm.assume(oracleAddr != address(0));
+    /// Test setRegistry reverts for non-admin.
+    function testSetRegistryOnlyAdmin(address registryAdmin, address vault, address admin, address nonAdmin) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
         vm.assume(admin != address(0));
         vm.assume(nonAdmin != admin);
 
-        PassthroughProtocolAdapter adapter =
-            I_DEPLOYER.newPassthroughProtocolAdapter(AggregatorV3Interface(oracleAddr), admin);
+        OracleRegistry registry = _createRegistry(registryAdmin);
+        PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
 
         vm.prank(nonAdmin);
         vm.expectRevert(abi.encodeWithSelector(OnlyAdmin.selector));
-        adapter.setOracle(AggregatorV3Interface(oracleAddr));
+        adapter.setRegistry(registry);
     }
 
-    /// Test setOracle with zero address reverts.
-    function testSetOracleZeroAddress(address oracleAddr, address admin) external {
-        vm.assume(oracleAddr != address(0));
+    /// Test setRegistry with zero address reverts.
+    function testSetRegistryZeroAddress(address registryAdmin, address vault, address admin) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
         vm.assume(admin != address(0));
 
-        PassthroughProtocolAdapter adapter =
-            I_DEPLOYER.newPassthroughProtocolAdapter(AggregatorV3Interface(oracleAddr), admin);
+        OracleRegistry registry = _createRegistry(registryAdmin);
+        PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
 
         vm.prank(admin);
-        vm.expectRevert(abi.encodeWithSelector(ZeroOracle.selector));
-        adapter.setOracle(AggregatorV3Interface(address(0)));
+        vm.expectRevert(abi.encodeWithSelector(ZeroRegistry.selector));
+        adapter.setRegistry(OracleRegistry(address(0)));
+    }
+
+    /// Test passthrough functions revert when oracle not found.
+    function testOracleNotFound(address registryAdmin, address vault, address admin) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
+        vm.assume(admin != address(0));
+
+        OracleRegistry registry = _createRegistry(registryAdmin);
+        PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
+
+        vm.expectRevert(abi.encodeWithSelector(OracleNotFound.selector));
+        adapter.decimals();
+
+        vm.expectRevert(abi.encodeWithSelector(OracleNotFound.selector));
+        adapter.description();
+
+        vm.expectRevert(abi.encodeWithSelector(OracleNotFound.selector));
+        adapter.latestAnswer();
+
+        vm.expectRevert(abi.encodeWithSelector(OracleNotFound.selector));
+        adapter.latestRoundData();
     }
 
     /// Test passthrough of decimals.
     function testPassthroughDecimals(address admin) external {
         vm.assume(admin != address(0));
 
+        address vault = address(uint160(uint256(keccak256("vault"))));
         address mockOracle = address(uint160(uint256(keccak256("mock.oracle"))));
+
+        // Create registry and register oracle
+        OracleRegistry registry = _createRegistry(admin);
+        vm.prank(admin);
+        registry.setOracle(vault, AggregatorV3Interface(mockOracle));
+
         vm.mockCall(mockOracle, abi.encodeWithSelector(AggregatorV3Interface.decimals.selector), abi.encode(uint8(8)));
 
-        PassthroughProtocolAdapter adapter =
-            I_DEPLOYER.newPassthroughProtocolAdapter(AggregatorV3Interface(mockOracle), admin);
+        PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
 
         assertEq(adapter.decimals(), 8);
     }
@@ -125,13 +194,19 @@ contract PassthroughProtocolAdapterTest is Test {
     function testPassthroughLatestAnswer(address admin, int256 mockPrice) external {
         vm.assume(admin != address(0));
 
+        address vault = address(uint160(uint256(keccak256("vault"))));
         address mockOracle = address(uint160(uint256(keccak256("mock.oracle"))));
+
+        // Create registry and register oracle
+        OracleRegistry registry = _createRegistry(admin);
+        vm.prank(admin);
+        registry.setOracle(vault, AggregatorV3Interface(mockOracle));
+
         vm.mockCall(
             mockOracle, abi.encodeWithSelector(AggregatorV3Interface.latestAnswer.selector), abi.encode(mockPrice)
         );
 
-        PassthroughProtocolAdapter adapter =
-            I_DEPLOYER.newPassthroughProtocolAdapter(AggregatorV3Interface(mockOracle), admin);
+        PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
 
         assertEq(adapter.latestAnswer(), mockPrice);
     }
@@ -140,15 +215,21 @@ contract PassthroughProtocolAdapterTest is Test {
     function testPassthroughLatestRoundData(address admin) external {
         vm.assume(admin != address(0));
 
+        address vault = address(uint160(uint256(keccak256("vault"))));
         address mockOracle = address(uint160(uint256(keccak256("mock.oracle"))));
+
+        // Create registry and register oracle
+        OracleRegistry registry = _createRegistry(admin);
+        vm.prank(admin);
+        registry.setOracle(vault, AggregatorV3Interface(mockOracle));
+
         vm.mockCall(
             mockOracle,
             abi.encodeWithSelector(AggregatorV3Interface.latestRoundData.selector),
             abi.encode(uint80(1), int256(10000e8), uint256(1000), uint256(1000), uint80(1))
         );
 
-        PassthroughProtocolAdapter adapter =
-            I_DEPLOYER.newPassthroughProtocolAdapter(AggregatorV3Interface(mockOracle), admin);
+        PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
 
         (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
             adapter.latestRoundData();
@@ -164,11 +245,17 @@ contract PassthroughProtocolAdapterTest is Test {
     function testPassthroughDescription(address admin) external {
         vm.assume(admin != address(0));
 
+        address vault = address(uint160(uint256(keccak256("vault"))));
         address mockOracle = address(uint160(uint256(keccak256("mock.oracle"))));
+
+        // Create registry and register oracle
+        OracleRegistry registry = _createRegistry(admin);
+        vm.prank(admin);
+        registry.setOracle(vault, AggregatorV3Interface(mockOracle));
+
         vm.mockCall(mockOracle, abi.encodeWithSelector(AggregatorV3Interface.description.selector), abi.encode(""));
 
-        PassthroughProtocolAdapter adapter =
-            I_DEPLOYER.newPassthroughProtocolAdapter(AggregatorV3Interface(mockOracle), admin);
+        PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
 
         assertEq(adapter.description(), "");
     }

--- a/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
@@ -32,15 +32,13 @@ contract PassthroughProtocolAdapterTest is Test {
         I_IMPLEMENTATION = new PassthroughProtocolAdapter();
         I_DEPLOYER = new PassthroughProtocolAdapterBeaconSetDeployer(
             PassthroughProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: address(this),
-                initialPassthroughProtocolAdapterImplementation: address(I_IMPLEMENTATION)
+                initialOwner: address(this), initialPassthroughProtocolAdapterImplementation: address(I_IMPLEMENTATION)
             })
         );
         I_REGISTRY_IMPLEMENTATION = new OracleRegistry();
         I_REGISTRY_DEPLOYER = new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: address(this),
-                initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
+                initialOwner: address(this), initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
             })
         );
     }

--- a/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
@@ -33,13 +33,15 @@ contract PassthroughProtocolAdapterTest is Test {
         I_IMPLEMENTATION = new PassthroughProtocolAdapter();
         I_DEPLOYER = new PassthroughProtocolAdapterBeaconSetDeployer(
             PassthroughProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: address(this), initialPassthroughProtocolAdapterImplementation: address(I_IMPLEMENTATION)
+                initialOwner: address(this),
+                initialPassthroughProtocolAdapterImplementation: address(I_IMPLEMENTATION)
             })
         );
         I_REGISTRY_IMPLEMENTATION = new OracleRegistry();
         I_REGISTRY_DEPLOYER = new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: address(this), initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
+                initialOwner: address(this),
+                initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
             })
         );
     }
@@ -160,6 +162,53 @@ contract PassthroughProtocolAdapterTest is Test {
         adapter.setRegistry(OracleRegistry(address(0)));
     }
 
+    /// Test setAdmin by admin.
+    function testSetAdmin(address registryAdmin, address vault, address admin, address newAdmin) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
+        vm.assume(admin != address(0));
+        vm.assume(newAdmin != address(0));
+
+        OracleRegistry registry = _createRegistry(registryAdmin);
+        PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
+
+        vm.expectEmit(true, true, true, true);
+        emit PassthroughProtocolAdapter.AdminSet(admin, newAdmin);
+        vm.prank(admin);
+        adapter.setAdmin(newAdmin);
+
+        assertEq(adapter.admin(), newAdmin);
+    }
+
+    /// Test setAdmin reverts for non-admin.
+    function testSetAdminOnlyAdmin(address registryAdmin, address vault, address admin, address nonAdmin) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
+        vm.assume(admin != address(0));
+        vm.assume(nonAdmin != admin);
+
+        OracleRegistry registry = _createRegistry(registryAdmin);
+        PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
+
+        vm.prank(nonAdmin);
+        vm.expectRevert(abi.encodeWithSelector(OnlyAdmin.selector));
+        adapter.setAdmin(address(1));
+    }
+
+    /// Test setAdmin with zero address reverts.
+    function testSetAdminZeroAddress(address registryAdmin, address vault, address admin) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
+        vm.assume(admin != address(0));
+
+        OracleRegistry registry = _createRegistry(registryAdmin);
+        PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
+
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(ZeroAdmin.selector));
+        adapter.setAdmin(address(0));
+    }
+
     /// Test passthrough functions revert when oracle not found.
     function testOracleNotFound(address registryAdmin, address vault, address admin) external {
         vm.assume(registryAdmin != address(0));
@@ -174,6 +223,9 @@ contract PassthroughProtocolAdapterTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(OracleNotFound.selector));
         adapter.description();
+
+        vm.expectRevert(abi.encodeWithSelector(OracleNotFound.selector));
+        adapter.version();
 
         vm.expectRevert(abi.encodeWithSelector(OracleNotFound.selector));
         adapter.latestAnswer();
@@ -269,5 +321,24 @@ contract PassthroughProtocolAdapterTest is Test {
         PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
 
         assertEq(adapter.description(), "");
+    }
+
+    /// Test passthrough of version.
+    function testPassthroughVersion(address admin) external {
+        vm.assume(admin != address(0));
+
+        address vault = address(uint160(uint256(keccak256("vault"))));
+        address mockOracle = address(uint160(uint256(keccak256("mock.oracle"))));
+
+        // Create registry and register oracle
+        OracleRegistry registry = _createRegistry(admin);
+        vm.prank(admin);
+        registry.setOracle(vault, AggregatorV3Interface(mockOracle));
+
+        vm.mockCall(mockOracle, abi.encodeWithSelector(AggregatorV3Interface.version.selector), abi.encode(uint256(1)));
+
+        PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
+
+        assertEq(adapter.version(), 1);
     }
 }

--- a/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
@@ -7,6 +7,7 @@ import {
     PassthroughProtocolAdapter,
     PassthroughProtocolAdapterConfig,
     OnlyAdmin,
+    ZeroAdmin,
     ZeroRegistry,
     ZeroVault,
     OracleNotFound
@@ -57,15 +58,26 @@ contract PassthroughProtocolAdapterTest is Test {
     /// Test that initialization with zero vault reverts.
     function testInitializeZeroVault(address registryAdmin, address admin) external {
         vm.assume(registryAdmin != address(0));
+        vm.assume(admin != address(0));
         OracleRegistry registry = _createRegistry(registryAdmin);
         vm.expectRevert(abi.encodeWithSelector(ZeroVault.selector));
         I_DEPLOYER.newPassthroughProtocolAdapter(registry, address(0), admin);
+    }
+
+    /// Test that initialization with zero admin reverts.
+    function testInitializeZeroAdmin(address registryAdmin, address vault) external {
+        vm.assume(registryAdmin != address(0));
+        vm.assume(vault != address(0));
+        OracleRegistry registry = _createRegistry(registryAdmin);
+        vm.expectRevert(abi.encodeWithSelector(ZeroAdmin.selector));
+        I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, address(0));
     }
 
     /// Test successful initialization.
     function testInitializeSuccess(address registryAdmin, address vault, address admin) external {
         vm.assume(registryAdmin != address(0));
         vm.assume(vault != address(0));
+        vm.assume(admin != address(0));
 
         OracleRegistry registry = _createRegistry(registryAdmin);
         PassthroughProtocolAdapter adapter = I_DEPLOYER.newPassthroughProtocolAdapter(registry, vault, admin);
@@ -79,6 +91,7 @@ contract PassthroughProtocolAdapterTest is Test {
     function testInitializeEvent(address registryAdmin, address vault, address admin) external {
         vm.assume(registryAdmin != address(0));
         vm.assume(vault != address(0));
+        vm.assume(admin != address(0));
 
         OracleRegistry registry = _createRegistry(registryAdmin);
 

--- a/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
@@ -33,15 +33,13 @@ contract PassthroughProtocolAdapterTest is Test {
         I_IMPLEMENTATION = new PassthroughProtocolAdapter();
         I_DEPLOYER = new PassthroughProtocolAdapterBeaconSetDeployer(
             PassthroughProtocolAdapterBeaconSetDeployerConfig({
-                initialOwner: address(this),
-                initialPassthroughProtocolAdapterImplementation: address(I_IMPLEMENTATION)
+                initialOwner: address(this), initialPassthroughProtocolAdapterImplementation: address(I_IMPLEMENTATION)
             })
         );
         I_REGISTRY_IMPLEMENTATION = new OracleRegistry();
         I_REGISTRY_DEPLOYER = new OracleRegistryBeaconSetDeployer(
             OracleRegistryBeaconSetDeployerConfig({
-                initialOwner: address(this),
-                initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
+                initialOwner: address(this), initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
             })
         );
     }

--- a/test/src/concrete/registry/OracleRegistry.t.sol
+++ b/test/src/concrete/registry/OracleRegistry.t.sol
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {OracleRegistryTest} from "test/abstract/OracleRegistryTest.sol";
+import {
+    OracleRegistry,
+    OracleRegistryConfig,
+    OnlyAdmin,
+    ZeroAdmin,
+    ZeroVault,
+    ZeroOracle,
+    ArrayLengthMismatch
+} from "src/concrete/registry/OracleRegistry.sol";
+import {AggregatorV3Interface} from "src/interface/IAggregatorV3.sol";
+import {Vm} from "forge-std/Test.sol";
+
+contract OracleRegistryInitializeTest is OracleRegistryTest {
+    /// Test that zero admin address reverts.
+    function testInitializeZeroAdmin() external {
+        vm.expectRevert(abi.encodeWithSelector(ZeroAdmin.selector));
+        I_DEPLOYER.newOracleRegistry(OracleRegistryConfig({admin: address(0)}));
+    }
+
+    /// Test successful initialization sets admin correctly.
+    function testInitializeSuccess(address admin) external {
+        vm.assume(admin != address(0));
+
+        OracleRegistry registry = createRegistry(admin);
+
+        assertEq(registry.admin(), admin);
+    }
+
+    /// Test that OracleRegistryInitialized event is emitted.
+    function testInitializeEvent(address admin) external {
+        vm.assume(admin != address(0));
+
+        vm.recordLogs();
+        OracleRegistry registry = createRegistry(admin);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bool eventFound = false;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == keccak256("OracleRegistryInitialized(address,(address))")) {
+                address sender = address(uint160(uint256(logs[i].topics[1])));
+                OracleRegistryConfig memory config = abi.decode(logs[i].data, (OracleRegistryConfig));
+                assertEq(sender, address(I_DEPLOYER));
+                assertEq(config.admin, admin);
+                eventFound = true;
+                break;
+            }
+        }
+        assertTrue(eventFound, "OracleRegistryInitialized event not found");
+        assertTrue(address(registry) != address(0));
+    }
+}
+
+contract OracleRegistrySetOracleTest is OracleRegistryTest {
+    /// Test that only admin can call setOracle.
+    function testSetOracleOnlyAdmin(address admin, address notAdmin, address vault, address oracle) external {
+        vm.assume(admin != address(0));
+        vm.assume(notAdmin != admin);
+        vm.assume(vault != address(0));
+        vm.assume(oracle != address(0));
+
+        OracleRegistry registry = createRegistry(admin);
+
+        vm.prank(notAdmin);
+        vm.expectRevert(abi.encodeWithSelector(OnlyAdmin.selector));
+        registry.setOracle(vault, AggregatorV3Interface(oracle));
+    }
+
+    /// Test that zero vault address reverts.
+    function testSetOracleZeroVault(address admin, address oracle) external {
+        vm.assume(admin != address(0));
+        vm.assume(oracle != address(0));
+
+        OracleRegistry registry = createRegistry(admin);
+
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(ZeroVault.selector));
+        registry.setOracle(address(0), AggregatorV3Interface(oracle));
+    }
+
+    /// Test that zero oracle address reverts.
+    function testSetOracleZeroOracle(address admin, address vault) external {
+        vm.assume(admin != address(0));
+        vm.assume(vault != address(0));
+
+        OracleRegistry registry = createRegistry(admin);
+
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(ZeroOracle.selector));
+        registry.setOracle(vault, AggregatorV3Interface(address(0)));
+    }
+
+    /// Test successful new registration (oldOracle is address(0)).
+    function testSetOracleNewRegistration(address admin, address vault, address oracle) external {
+        vm.assume(admin != address(0));
+        vm.assume(vault != address(0));
+        vm.assume(oracle != address(0));
+
+        OracleRegistry registry = createRegistry(admin);
+
+        vm.prank(admin);
+        vm.expectEmit(true, true, true, true);
+        emit OracleSet(vault, address(0), oracle);
+        registry.setOracle(vault, AggregatorV3Interface(oracle));
+
+        assertEq(address(registry.getOracle(vault)), oracle);
+    }
+
+    /// Test successful update of existing registration.
+    function testSetOracleUpdate(address admin, address vault, address oracle1, address oracle2) external {
+        vm.assume(admin != address(0));
+        vm.assume(vault != address(0));
+        vm.assume(oracle1 != address(0));
+        vm.assume(oracle2 != address(0));
+        vm.assume(oracle1 != oracle2);
+
+        OracleRegistry registry = createRegistry(admin);
+
+        vm.prank(admin);
+        registry.setOracle(vault, AggregatorV3Interface(oracle1));
+
+        vm.prank(admin);
+        vm.expectEmit(true, true, true, true);
+        emit OracleSet(vault, oracle1, oracle2);
+        registry.setOracle(vault, AggregatorV3Interface(oracle2));
+
+        assertEq(address(registry.getOracle(vault)), oracle2);
+    }
+
+    event OracleSet(address indexed vault, address indexed oldOracle, address indexed newOracle);
+}
+
+contract OracleRegistrySetOracleBulkTest is OracleRegistryTest {
+    /// Test that only admin can call setOracleBulk.
+    function testSetOracleBulkOnlyAdmin(address admin, address notAdmin) external {
+        vm.assume(admin != address(0));
+        vm.assume(notAdmin != admin);
+
+        OracleRegistry registry = createRegistry(admin);
+
+        address[] memory vaults = new address[](1);
+        vaults[0] = address(1);
+        AggregatorV3Interface[] memory oracles = new AggregatorV3Interface[](1);
+        oracles[0] = AggregatorV3Interface(address(2));
+
+        vm.prank(notAdmin);
+        vm.expectRevert(abi.encodeWithSelector(OnlyAdmin.selector));
+        registry.setOracleBulk(vaults, oracles);
+    }
+
+    /// Test that array length mismatch reverts.
+    function testSetOracleBulkArrayLengthMismatch(address admin) external {
+        vm.assume(admin != address(0));
+
+        OracleRegistry registry = createRegistry(admin);
+
+        address[] memory vaults = new address[](2);
+        vaults[0] = address(1);
+        vaults[1] = address(2);
+        AggregatorV3Interface[] memory oracles = new AggregatorV3Interface[](1);
+        oracles[0] = AggregatorV3Interface(address(3));
+
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(ArrayLengthMismatch.selector));
+        registry.setOracleBulk(vaults, oracles);
+    }
+
+    /// Test that zero vault in bulk reverts.
+    function testSetOracleBulkZeroVault(address admin) external {
+        vm.assume(admin != address(0));
+
+        OracleRegistry registry = createRegistry(admin);
+
+        address[] memory vaults = new address[](2);
+        vaults[0] = address(1);
+        vaults[1] = address(0);
+        AggregatorV3Interface[] memory oracles = new AggregatorV3Interface[](2);
+        oracles[0] = AggregatorV3Interface(address(2));
+        oracles[1] = AggregatorV3Interface(address(3));
+
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(ZeroVault.selector));
+        registry.setOracleBulk(vaults, oracles);
+    }
+
+    /// Test that zero oracle in bulk reverts.
+    function testSetOracleBulkZeroOracle(address admin) external {
+        vm.assume(admin != address(0));
+
+        OracleRegistry registry = createRegistry(admin);
+
+        address[] memory vaults = new address[](2);
+        vaults[0] = address(1);
+        vaults[1] = address(2);
+        AggregatorV3Interface[] memory oracles = new AggregatorV3Interface[](2);
+        oracles[0] = AggregatorV3Interface(address(3));
+        oracles[1] = AggregatorV3Interface(address(0));
+
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(ZeroOracle.selector));
+        registry.setOracleBulk(vaults, oracles);
+    }
+
+    /// Test successful bulk registration.
+    function testSetOracleBulkSuccess(address admin) external {
+        vm.assume(admin != address(0));
+
+        OracleRegistry registry = createRegistry(admin);
+
+        address[] memory vaults = new address[](3);
+        vaults[0] = address(1);
+        vaults[1] = address(2);
+        vaults[2] = address(3);
+        AggregatorV3Interface[] memory oracles = new AggregatorV3Interface[](3);
+        oracles[0] = AggregatorV3Interface(address(4));
+        oracles[1] = AggregatorV3Interface(address(5));
+        oracles[2] = AggregatorV3Interface(address(6));
+
+        vm.prank(admin);
+        registry.setOracleBulk(vaults, oracles);
+
+        assertEq(address(registry.getOracle(vaults[0])), address(oracles[0]));
+        assertEq(address(registry.getOracle(vaults[1])), address(oracles[1]));
+        assertEq(address(registry.getOracle(vaults[2])), address(oracles[2]));
+    }
+}
+
+contract OracleRegistryGetOracleTest is OracleRegistryTest {
+    /// Test that getOracle returns address(0) for unregistered vault.
+    function testGetOracleUnregistered(address admin, address vault) external {
+        vm.assume(admin != address(0));
+        vm.assume(vault != address(0));
+
+        OracleRegistry registry = createRegistry(admin);
+
+        assertEq(address(registry.getOracle(vault)), address(0));
+    }
+
+    /// Test that getOracle returns correct oracle for registered vault.
+    function testGetOracleRegistered(address admin, address vault, address oracle) external {
+        vm.assume(admin != address(0));
+        vm.assume(vault != address(0));
+        vm.assume(oracle != address(0));
+
+        OracleRegistry registry = createRegistry(admin);
+
+        vm.prank(admin);
+        registry.setOracle(vault, AggregatorV3Interface(oracle));
+
+        assertEq(address(registry.getOracle(vault)), oracle);
+    }
+}

--- a/test/src/concrete/registry/OracleRegistry.t.sol
+++ b/test/src/concrete/registry/OracleRegistry.t.sol
@@ -222,12 +222,20 @@ contract OracleRegistrySetOracleBulkTest is OracleRegistryTest {
         oracles[2] = AggregatorV3Interface(address(6));
 
         vm.prank(admin);
+        vm.expectEmit(true, true, true, true);
+        emit OracleSet(vaults[0], address(0), address(oracles[0]));
+        vm.expectEmit(true, true, true, true);
+        emit OracleSet(vaults[1], address(0), address(oracles[1]));
+        vm.expectEmit(true, true, true, true);
+        emit OracleSet(vaults[2], address(0), address(oracles[2]));
         registry.setOracleBulk(vaults, oracles);
 
         assertEq(address(registry.getOracle(vaults[0])), address(oracles[0]));
         assertEq(address(registry.getOracle(vaults[1])), address(oracles[1]));
         assertEq(address(registry.getOracle(vaults[2])), address(oracles[2]));
     }
+
+    event OracleSet(address indexed vault, address indexed oldOracle, address indexed newOracle);
 }
 
 contract OracleRegistryGetOracleTest is OracleRegistryTest {


### PR DESCRIPTION
## Motivation

Protocol adapters currently store direct oracle references. When swapping oracles (e.g., Pyth dies, switch to Chainlink), we need to call `setOracle()` on every protocol adapter individually — N vaults × M protocols = N×M calls.

## Solution

Add an `OracleRegistry` contract that centralizes the `vault → oracle adapter` mapping. Protocol adapters now store `registry + vault` and look up their oracle via `registry.getOracle(vault)` at runtime.

**Key changes:**
- New `OracleRegistry` with `setOracle()`, `setOracleBulk()`, `getOracle()`
- Protocol adapters replace `setOracle()` with `setRegistry()` (opt-out = point to different registry)
- `OracleUnifiedDeployer` takes registry parameter; admin calls `registry.setOracle()` separately
- Single registry update now propagates to all protocol adapters for that vault

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to a front-end or a dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized Oracle Registry for vault→oracle mappings with single-call and bulk updates; adapters can point to a registry
  * Deployment tooling to create registry beacons and registry-aware adapters

* **Behavior Changes / Error Handling**
  * Protocol adapters resolve oracles at runtime via the registry and revert with OracleNotFound for unregistered vaults
  * Adapters and oracles support admin rotation (AdminSet) and registry reassignment

* **Tests**
  * Comprehensive registry-focused unit and integration tests added

* **Documentation & Tooling**
  * Architecture and deployment docs updated; CI/static-analysis config and licenses added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->