### PR TITLE
feat: prod fork tests for wtCOIN oracle + set beacon owner

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -26,6 +26,15 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - run: |
+          network=${{ inputs.network }}
+
+          echo "etherscan_api_key_secret_name=CI_DEPLOY_${network^^}_ETHERSCAN_API_KEY" >> $GITHUB_ENV
+          echo "rpc_secret_name=CI_DEPLOY_${network^^}_RPC_URL" >> $GITHUB_ENV
+          echo "verify_secret_name=CI_DEPLOY_${network^^}_VERIFY" >> $GITHUB_ENV
+          echo "verifier_secret_name=CI_DEPLOY_${network^^}_VERIFIER" >> $GITHUB_ENV
+          echo "verifier_url_secret_name=CI_DEPLOY_${network^^}_VERIFIER_URL" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -53,9 +62,9 @@ jobs:
         env:
           DEPLOYMENT_SUITE: ${{ inputs.suite }}
           DEPLOY_BROADCAST: '1'
-          DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
-          ETH_RPC_URL: ${{ secrets.RPC_URL_BASE }}
-          ETHERSCAN_API_KEY: ${{ secrets.BASESCAN_API_KEY }}
-          DEPLOY_VERIFY: '1'
-          DEPLOY_VERIFIER: 'etherscan'
-          DEPLOY_VERIFIER_URL: 'https://api.etherscan.io/v2/api?chainid=8453'
+          DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
+          ETH_RPC_URL: ${{ secrets[env.rpc_secret_name] || vars[env.rpc_secret_name] || '' }}
+          ETHERSCAN_API_KEY: ${{ secrets[env.etherscan_api_key_secret_name] || vars[env.etherscan_api_key_secret_name] || ''}}
+          DEPLOY_VERIFY: ${{ secrets[env.verify_secret_name] || vars[env.verify_secret_name] || '' }}
+          DEPLOY_VERIFIER: ${{ secrets[env.verifier_secret_name] || vars[env.verifier_secret_name] || '' }}
+          DEPLOY_VERIFIER_URL: ${{ secrets[env.verifier_url_secret_name] || vars[env.verifier_url_secret_name] || '' }}

--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -26,15 +26,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          network=${{ inputs.network }}
-
-          echo "etherscan_api_key_secret_name=CI_DEPLOY_${network^^}_ETHERSCAN_API_KEY" >> $GITHUB_ENV
-          echo "rpc_secret_name=CI_DEPLOY_${network^^}_RPC_URL" >> $GITHUB_ENV
-          echo "verify_secret_name=CI_DEPLOY_${network^^}_VERIFY" >> $GITHUB_ENV
-          echo "verifier_secret_name=CI_DEPLOY_${network^^}_VERIFIER" >> $GITHUB_ENV
-          echo "verifier_url_secret_name=CI_DEPLOY_${network^^}_VERIFIER_URL" >> $GITHUB_ENV
-
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -62,9 +53,9 @@ jobs:
         env:
           DEPLOYMENT_SUITE: ${{ inputs.suite }}
           DEPLOY_BROADCAST: '1'
-          DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
-          ETH_RPC_URL: ${{ secrets[env.rpc_secret_name] || vars[env.rpc_secret_name] || '' }}
-          ETHERSCAN_API_KEY: ${{ secrets[env.etherscan_api_key_secret_name] || vars[env.etherscan_api_key_secret_name] || ''}}
-          DEPLOY_VERIFY: ${{ secrets[env.verify_secret_name] || vars[env.verify_secret_name] || '' }}
-          DEPLOY_VERIFIER: ${{ secrets[env.verifier_secret_name] || vars[env.verifier_secret_name] || '' }}
-          DEPLOY_VERIFIER_URL: ${{ secrets[env.verifier_url_secret_name] || vars[env.verifier_url_secret_name] || '' }}
+          DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
+          ETH_RPC_URL: ${{ secrets.RPC_URL_BASE }}
+          ETHERSCAN_API_KEY: ${{ secrets.BASESCAN_API_KEY }}
+          DEPLOY_VERIFY: '1'
+          DEPLOY_VERIFIER: 'etherscan'
+          DEPLOY_VERIFIER_URL: 'https://api.basescan.org/api'

--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -58,4 +58,4 @@ jobs:
           ETHERSCAN_API_KEY: ${{ secrets.BASESCAN_API_KEY }}
           DEPLOY_VERIFY: '1'
           DEPLOY_VERIFIER: 'etherscan'
-          DEPLOY_VERIFIER_URL: 'https://api.basescan.org/api'
+          DEPLOY_VERIFIER_URL: 'https://api.etherscan.io/v2/api?chainid=8453'

--- a/src/lib/LibProdDeploy.sol
+++ b/src/lib/LibProdDeploy.sol
@@ -6,8 +6,8 @@ pragma solidity ^0.8.25;
 /// @notice Hardcoded production deployment addresses. Provides an audit trail
 /// in git of any address modifications.
 library LibProdDeploy {
-    /// TODO: Set to the founder multisig address.
-    address constant BEACON_INITIAL_OWNER = address(0);
+    /// rainlang.eth founder multisig.
+    address constant BEACON_INITIAL_OWNER = 0x8E4bdeec7CEB9570D440676345dA1dCe10329f5b;
 
     /// TODO: Set after initial deployment to Base.
     address constant PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER = address(0);

--- a/test/src/concrete/ProdFork.t.sol
+++ b/test/src/concrete/ProdFork.t.sol
@@ -38,15 +38,41 @@ library LibProdOracles {
 /// These tests run against real deployed contracts on a Base fork to verify
 /// correct behavior with live Pyth prices and vault state.
 ///
-/// To run: forge test --match-contract ProdForkTest --fork-url $RPC_URL_BASE
+/// To run: forge test --match-contract ProdForkTest --fork-url $RPC_URL_BASE_FORK
 ///
 /// NOTE: Tests will be skipped (pass vacuously) until oracle addresses are
 /// set in LibProdOracles. This allows the PR to merge before deployment.
 contract ProdForkTest is Test {
-    /// @dev Skip modifier for tests that require deployed oracles.
-    /// Remove once addresses are populated.
-    modifier onlyIfDeployed() {
+    /// @dev Skip modifier for oracle-only tests.
+    modifier onlyIfOracleDeployed() {
         if (LibProdOracles.WTCOIN_ORACLE == address(0)) {
+            return;
+        }
+        _;
+    }
+
+    /// @dev Skip modifier for Morpho adapter tests.
+    modifier onlyIfMorphoDeployed() {
+        if (LibProdOracles.WTCOIN_MORPHO == address(0)) {
+            return;
+        }
+        _;
+    }
+
+    /// @dev Skip modifier for Passthrough adapter tests.
+    modifier onlyIfPassthroughDeployed() {
+        if (LibProdOracles.WTCOIN_PASSTHROUGH == address(0)) {
+            return;
+        }
+        _;
+    }
+
+    /// @dev Skip modifier for tests that require all three deployed.
+    modifier onlyIfAllDeployed() {
+        if (
+            LibProdOracles.WTCOIN_ORACLE == address(0) || LibProdOracles.WTCOIN_MORPHO == address(0)
+                || LibProdOracles.WTCOIN_PASSTHROUGH == address(0)
+        ) {
             return;
         }
         _;
@@ -61,7 +87,7 @@ contract ProdForkTest is Test {
     // =========================================================================
 
     /// @notice Oracle returns a positive price for wtCOIN.
-    function testProdWtcoinOracleLatestAnswer() external onlyIfDeployed {
+    function testProdWtcoinOracleLatestAnswer() external onlyIfOracleDeployed {
         _forkBase();
 
         PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
@@ -74,7 +100,7 @@ contract ProdForkTest is Test {
     }
 
     /// @notice Oracle returns valid latestRoundData.
-    function testProdWtcoinOracleLatestRoundData() external onlyIfDeployed {
+    function testProdWtcoinOracleLatestRoundData() external onlyIfOracleDeployed {
         _forkBase();
 
         PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
@@ -91,7 +117,7 @@ contract ProdForkTest is Test {
     }
 
     /// @notice Oracle reports 8 decimals.
-    function testProdWtcoinOracleDecimals() external onlyIfDeployed {
+    function testProdWtcoinOracleDecimals() external onlyIfOracleDeployed {
         _forkBase();
 
         PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
@@ -99,7 +125,7 @@ contract ProdForkTest is Test {
     }
 
     /// @notice Oracle config matches expected values.
-    function testProdWtcoinOracleConfig() external onlyIfDeployed {
+    function testProdWtcoinOracleConfig() external onlyIfOracleDeployed {
         _forkBase();
 
         PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
@@ -110,7 +136,7 @@ contract ProdForkTest is Test {
     }
 
     /// @notice Oracle reverts when paused.
-    function testProdWtcoinOracleRevertsWhenPaused() external onlyIfDeployed {
+    function testProdWtcoinOracleRevertsWhenPaused() external onlyIfOracleDeployed {
         _forkBase();
 
         PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
@@ -131,7 +157,7 @@ contract ProdForkTest is Test {
     }
 
     /// @notice Only admin can pause.
-    function testProdWtcoinOracleOnlyAdminCanPause() external onlyIfDeployed {
+    function testProdWtcoinOracleOnlyAdminCanPause() external onlyIfOracleDeployed {
         _forkBase();
 
         PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
@@ -146,7 +172,7 @@ contract ProdForkTest is Test {
     // =========================================================================
 
     /// @notice Morpho adapter returns price scaled to 36 decimals.
-    function testProdWtcoinMorphoPrice() external onlyIfDeployed {
+    function testProdWtcoinMorphoPrice() external onlyIfMorphoDeployed {
         _forkBase();
 
         PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
@@ -160,7 +186,7 @@ contract ProdForkTest is Test {
     }
 
     /// @notice Morpho adapter points to the correct oracle.
-    function testProdWtcoinMorphoOracleRef() external onlyIfDeployed {
+    function testProdWtcoinMorphoOracleRef() external onlyIfMorphoDeployed {
         _forkBase();
 
         MorphoProtocolAdapter morpho = MorphoProtocolAdapter(LibProdOracles.WTCOIN_MORPHO);
@@ -174,7 +200,7 @@ contract ProdForkTest is Test {
     // =========================================================================
 
     /// @notice Passthrough adapter returns same answer as oracle.
-    function testProdWtcoinPassthroughAnswer() external onlyIfDeployed {
+    function testProdWtcoinPassthroughAnswer() external onlyIfPassthroughDeployed {
         _forkBase();
 
         PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
@@ -187,7 +213,7 @@ contract ProdForkTest is Test {
     }
 
     /// @notice Passthrough adapter returns same roundData as oracle.
-    function testProdWtcoinPassthroughRoundData() external onlyIfDeployed {
+    function testProdWtcoinPassthroughRoundData() external onlyIfPassthroughDeployed {
         _forkBase();
 
         PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
@@ -201,7 +227,7 @@ contract ProdForkTest is Test {
     }
 
     /// @notice Passthrough adapter reports 8 decimals.
-    function testProdWtcoinPassthroughDecimals() external onlyIfDeployed {
+    function testProdWtcoinPassthroughDecimals() external onlyIfPassthroughDeployed {
         _forkBase();
 
         PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
@@ -209,7 +235,7 @@ contract ProdForkTest is Test {
     }
 
     /// @notice Passthrough adapter points to the correct oracle.
-    function testProdWtcoinPassthroughOracleRef() external onlyIfDeployed {
+    function testProdWtcoinPassthroughOracleRef() external onlyIfPassthroughDeployed {
         _forkBase();
 
         PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
@@ -225,7 +251,7 @@ contract ProdForkTest is Test {
     // =========================================================================
 
     /// @notice All three contracts return consistent prices.
-    function testProdWtcoinPriceConsistency() external onlyIfDeployed {
+    function testProdWtcoinPriceConsistency() external onlyIfAllDeployed {
         _forkBase();
 
         PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
@@ -246,7 +272,7 @@ contract ProdForkTest is Test {
     // =========================================================================
 
     /// @notice Protocol adapters can swap oracle reference.
-    function testProdWtcoinSetOracle() external onlyIfDeployed {
+    function testProdWtcoinSetOracle() external onlyIfPassthroughDeployed {
         _forkBase();
 
         PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);

--- a/test/src/concrete/ProdFork.t.sol
+++ b/test/src/concrete/ProdFork.t.sol
@@ -26,7 +26,7 @@ library LibProdOracles {
     address constant WTCOIN_PASSTHROUGH = address(0);
 
     /// wtCOIN ERC-4626 vault.
-    address constant WTCOIN_VAULT = 0x5cDa0E1CA4ce2af96315F7F8963C85399c172204;
+    address constant WTCOIN_VAULT = 0x5cDa0E1CA4ce2af96315f7F8963C85399c172204;
 
     /// COIN/USD Pyth price feed ID.
     /// https://www.pyth.network/developers/price-feed-ids

--- a/test/src/concrete/ProdFork.t.sol
+++ b/test/src/concrete/ProdFork.t.sol
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {AggregatorV3Interface} from "src/interface/IAggregatorV3.sol";
+import {PythOracleAdapter} from "src/concrete/oracle/PythOracleAdapter.sol";
+import {MorphoProtocolAdapter} from "src/concrete/protocol/MorphoProtocolAdapter.sol";
+import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
+import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
+
+/// @title LibProdOracles
+/// @notice Hardcoded production oracle addresses deployed via
+/// OracleUnifiedDeployer. Update these after each deployment.
+library LibProdOracles {
+    /// wtCOIN oracle adapter (PythOracleAdapter proxy).
+    /// TODO: Set after deployment.
+    address constant WTCOIN_ORACLE = address(0);
+
+    /// wtCOIN Morpho protocol adapter.
+    /// TODO: Set after deployment.
+    address constant WTCOIN_MORPHO = address(0);
+
+    /// wtCOIN passthrough protocol adapter (Aave/Compound).
+    /// TODO: Set after deployment.
+    address constant WTCOIN_PASSTHROUGH = address(0);
+
+    /// wtCOIN ERC-4626 vault.
+    address constant WTCOIN_VAULT = 0x5cDa0E1CA4ce2af96315F7F8963C85399c172204;
+
+    /// COIN/USD Pyth price feed ID.
+    /// https://www.pyth.network/developers/price-feed-ids
+    bytes32 constant COIN_PRICE_ID = 0xe65ff435be2e5170520bca5af8e56241d18a8abe0e12face633cee71a685e08d;
+}
+
+/// @title ProdForkTest
+/// @notice Production fork tests for deployed st0x.oracle contracts on Base.
+/// These tests run against real deployed contracts on a Base fork to verify
+/// correct behavior with live Pyth prices and vault state.
+///
+/// To run: forge test --match-contract ProdForkTest --fork-url $RPC_URL_BASE
+///
+/// NOTE: Tests will be skipped (pass vacuously) until oracle addresses are
+/// set in LibProdOracles. This allows the PR to merge before deployment.
+contract ProdForkTest is Test {
+    /// @dev Skip modifier for tests that require deployed oracles.
+    /// Remove once addresses are populated.
+    modifier onlyIfDeployed() {
+        if (LibProdOracles.WTCOIN_ORACLE == address(0)) {
+            return;
+        }
+        _;
+    }
+
+    function _forkBase() internal {
+        vm.createSelectFork(vm.envString("RPC_URL_BASE_FORK"));
+    }
+
+    // =========================================================================
+    // PythOracleAdapter tests
+    // =========================================================================
+
+    /// @notice Oracle returns a positive price for wtCOIN.
+    function testProdWtcoinOracleLatestAnswer() external onlyIfDeployed {
+        _forkBase();
+
+        PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
+        int256 answer = oracle.latestAnswer();
+
+        // COIN trades roughly $50-$500. At 8 decimals that's 5e9 to 5e10.
+        // Use wide bounds to be resilient to price moves.
+        assertGt(answer, 1e9, "Price too low (< $10)");
+        assertLt(answer, 1e12, "Price too high (> $10,000)");
+    }
+
+    /// @notice Oracle returns valid latestRoundData.
+    function testProdWtcoinOracleLatestRoundData() external onlyIfDeployed {
+        _forkBase();
+
+        PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
+            oracle.latestRoundData();
+
+        assertEq(roundId, 1);
+        assertEq(answeredInRound, 1);
+        assertGt(answer, 0, "Answer must be positive");
+        assertGt(updatedAt, 0, "updatedAt must be set");
+        // Price should not be older than maxAge (300s) + some fork tolerance
+        assertGt(updatedAt, block.timestamp - 600, "Price too stale");
+        assertEq(startedAt, updatedAt, "startedAt should equal updatedAt");
+    }
+
+    /// @notice Oracle reports 8 decimals.
+    function testProdWtcoinOracleDecimals() external onlyIfDeployed {
+        _forkBase();
+
+        PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
+        assertEq(oracle.decimals(), 8);
+    }
+
+    /// @notice Oracle config matches expected values.
+    function testProdWtcoinOracleConfig() external onlyIfDeployed {
+        _forkBase();
+
+        PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
+        assertEq(oracle.vault(), LibProdOracles.WTCOIN_VAULT, "Wrong vault");
+        assertEq(oracle.priceId(), LibProdOracles.COIN_PRICE_ID, "Wrong priceId");
+        assertEq(oracle.maxAge(), 300, "Expected 5 min maxAge");
+        assertFalse(oracle.paused(), "Should not be paused");
+    }
+
+    /// @notice Oracle reverts when paused.
+    function testProdWtcoinOracleRevertsWhenPaused() external onlyIfDeployed {
+        _forkBase();
+
+        PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
+        address oracleAdmin = oracle.admin();
+
+        vm.prank(oracleAdmin);
+        oracle.setPaused(true);
+
+        vm.expectRevert();
+        oracle.latestAnswer();
+
+        // Unpause and verify it works again
+        vm.prank(oracleAdmin);
+        oracle.setPaused(false);
+
+        int256 answer = oracle.latestAnswer();
+        assertGt(answer, 0);
+    }
+
+    /// @notice Only admin can pause.
+    function testProdWtcoinOracleOnlyAdminCanPause() external onlyIfDeployed {
+        _forkBase();
+
+        PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
+
+        vm.prank(address(0xdead));
+        vm.expectRevert();
+        oracle.setPaused(true);
+    }
+
+    // =========================================================================
+    // MorphoProtocolAdapter tests
+    // =========================================================================
+
+    /// @notice Morpho adapter returns price scaled to 36 decimals.
+    function testProdWtcoinMorphoPrice() external onlyIfDeployed {
+        _forkBase();
+
+        PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
+        MorphoProtocolAdapter morpho = MorphoProtocolAdapter(LibProdOracles.WTCOIN_MORPHO);
+
+        int256 oracleAnswer = oracle.latestAnswer();
+        uint256 morphoPrice = morpho.price();
+
+        // Morpho scales 8 -> 36 decimals (multiply by 1e28)
+        assertEq(morphoPrice, uint256(oracleAnswer) * 1e28, "Morpho price should be oracle * 1e28");
+    }
+
+    /// @notice Morpho adapter points to the correct oracle.
+    function testProdWtcoinMorphoOracleRef() external onlyIfDeployed {
+        _forkBase();
+
+        MorphoProtocolAdapter morpho = MorphoProtocolAdapter(LibProdOracles.WTCOIN_MORPHO);
+        assertEq(
+            address(morpho.oracle()), LibProdOracles.WTCOIN_ORACLE, "Morpho should reference the wtCOIN oracle"
+        );
+    }
+
+    // =========================================================================
+    // PassthroughProtocolAdapter tests
+    // =========================================================================
+
+    /// @notice Passthrough adapter returns same answer as oracle.
+    function testProdWtcoinPassthroughAnswer() external onlyIfDeployed {
+        _forkBase();
+
+        PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
+        PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
+
+        int256 oracleAnswer = oracle.latestAnswer();
+        int256 passthroughAnswer = passthrough.latestAnswer();
+
+        assertEq(passthroughAnswer, oracleAnswer, "Passthrough should match oracle exactly");
+    }
+
+    /// @notice Passthrough adapter returns same roundData as oracle.
+    function testProdWtcoinPassthroughRoundData() external onlyIfDeployed {
+        _forkBase();
+
+        PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
+        PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
+
+        (, int256 oracleAnswer,, uint256 oracleUpdatedAt,) = oracle.latestRoundData();
+        (, int256 ptAnswer,, uint256 ptUpdatedAt,) = passthrough.latestRoundData();
+
+        assertEq(ptAnswer, oracleAnswer, "Answers must match");
+        assertEq(ptUpdatedAt, oracleUpdatedAt, "Timestamps must match");
+    }
+
+    /// @notice Passthrough adapter reports 8 decimals.
+    function testProdWtcoinPassthroughDecimals() external onlyIfDeployed {
+        _forkBase();
+
+        PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
+        assertEq(passthrough.decimals(), 8);
+    }
+
+    /// @notice Passthrough adapter points to the correct oracle.
+    function testProdWtcoinPassthroughOracleRef() external onlyIfDeployed {
+        _forkBase();
+
+        PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
+        assertEq(
+            address(passthrough.oracle()),
+            LibProdOracles.WTCOIN_ORACLE,
+            "Passthrough should reference the wtCOIN oracle"
+        );
+    }
+
+    // =========================================================================
+    // Cross-layer consistency
+    // =========================================================================
+
+    /// @notice All three contracts return consistent prices.
+    function testProdWtcoinPriceConsistency() external onlyIfDeployed {
+        _forkBase();
+
+        PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
+        MorphoProtocolAdapter morpho = MorphoProtocolAdapter(LibProdOracles.WTCOIN_MORPHO);
+        PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
+
+        int256 oraclePrice = oracle.latestAnswer();
+        int256 passthroughPrice = passthrough.latestAnswer();
+        uint256 morphoPrice = morpho.price();
+
+        // All three should be consistent
+        assertEq(passthroughPrice, oraclePrice, "Passthrough != Oracle");
+        assertEq(morphoPrice, uint256(oraclePrice) * 1e28, "Morpho != Oracle * 1e28");
+    }
+
+    // =========================================================================
+    // Protocol adapter setOracle (oracle swap scenario)
+    // =========================================================================
+
+    /// @notice Protocol adapters can swap oracle reference.
+    function testProdWtcoinSetOracle() external onlyIfDeployed {
+        _forkBase();
+
+        PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
+        address ptAdmin = passthrough.admin();
+
+        // Create a mock oracle that returns a known value
+        address mockOracle = address(new MockAggregator(42e8));
+
+        vm.prank(ptAdmin);
+        passthrough.setOracle(AggregatorV3Interface(mockOracle));
+
+        assertEq(passthrough.latestAnswer(), 42e8, "Should use new oracle");
+
+        // Swap back
+        vm.prank(ptAdmin);
+        passthrough.setOracle(AggregatorV3Interface(LibProdOracles.WTCOIN_ORACLE));
+    }
+}
+
+/// @dev Minimal mock for testing setOracle.
+contract MockAggregator is AggregatorV3Interface {
+    int256 private immutable _answer;
+
+    constructor(int256 answer) {
+        _answer = answer;
+    }
+
+    function decimals() external pure override returns (uint8) {
+        return 8;
+    }
+
+    function description() external pure override returns (string memory) {
+        return "Mock";
+    }
+
+    function version() external pure override returns (uint256) {
+        return 1;
+    }
+
+    function latestAnswer() external view override returns (int256) {
+        return _answer;
+    }
+
+    function latestRoundData()
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        return (1, _answer, block.timestamp, block.timestamp, 1);
+    }
+}

--- a/test/src/concrete/ProdFork.t.sol
+++ b/test/src/concrete/ProdFork.t.sol
@@ -7,6 +7,7 @@ import {AggregatorV3Interface} from "src/interface/IAggregatorV3.sol";
 import {PythOracleAdapter} from "src/concrete/oracle/PythOracleAdapter.sol";
 import {MorphoProtocolAdapter} from "src/concrete/protocol/MorphoProtocolAdapter.sol";
 import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
+import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
 
 /// @title LibProdOracles
@@ -175,24 +176,21 @@ contract ProdForkTest is Test {
     function testProdWtcoinMorphoPrice() external onlyIfMorphoDeployed {
         _forkBase();
 
-        PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
         MorphoProtocolAdapter morpho = MorphoProtocolAdapter(LibProdOracles.WTCOIN_MORPHO);
-
-        int256 oracleAnswer = oracle.latestAnswer();
         uint256 morphoPrice = morpho.price();
 
-        // Morpho scales 8 -> 36 decimals (multiply by 1e28)
-        assertEq(morphoPrice, uint256(oracleAnswer) * 1e28, "Morpho price should be oracle * 1e28");
+        // Morpho scales 8 -> 36 decimals. COIN ~$50-$500 → 5e9 to 5e10 at 8 dec → 5e37 to 5e38 at 36 dec.
+        assertGt(morphoPrice, 1e37, "Morpho price too low");
+        assertLt(morphoPrice, 1e40, "Morpho price too high");
     }
 
-    /// @notice Morpho adapter points to the correct oracle.
-    function testProdWtcoinMorphoOracleRef() external onlyIfMorphoDeployed {
+    /// @notice Morpho adapter points to a valid registry and vault.
+    function testProdWtcoinMorphoConfig() external onlyIfMorphoDeployed {
         _forkBase();
 
         MorphoProtocolAdapter morpho = MorphoProtocolAdapter(LibProdOracles.WTCOIN_MORPHO);
-        assertEq(
-            address(morpho.oracle()), LibProdOracles.WTCOIN_ORACLE, "Morpho should reference the wtCOIN oracle"
-        );
+        assertEq(morpho.vault(), LibProdOracles.WTCOIN_VAULT, "Morpho should reference the wtCOIN vault");
+        assertTrue(address(morpho.registry()) != address(0), "Registry should be set");
     }
 
     // =========================================================================
@@ -203,27 +201,22 @@ contract ProdForkTest is Test {
     function testProdWtcoinPassthroughAnswer() external onlyIfPassthroughDeployed {
         _forkBase();
 
-        PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
         PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
-
-        int256 oracleAnswer = oracle.latestAnswer();
         int256 passthroughAnswer = passthrough.latestAnswer();
 
-        assertEq(passthroughAnswer, oracleAnswer, "Passthrough should match oracle exactly");
+        assertGt(passthroughAnswer, 1e9, "Price too low");
+        assertLt(passthroughAnswer, 1e12, "Price too high");
     }
 
-    /// @notice Passthrough adapter returns same roundData as oracle.
+    /// @notice Passthrough adapter returns valid roundData.
     function testProdWtcoinPassthroughRoundData() external onlyIfPassthroughDeployed {
         _forkBase();
 
-        PythOracleAdapter oracle = PythOracleAdapter(LibProdOracles.WTCOIN_ORACLE);
         PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
-
-        (, int256 oracleAnswer,, uint256 oracleUpdatedAt,) = oracle.latestRoundData();
         (, int256 ptAnswer,, uint256 ptUpdatedAt,) = passthrough.latestRoundData();
 
-        assertEq(ptAnswer, oracleAnswer, "Answers must match");
-        assertEq(ptUpdatedAt, oracleUpdatedAt, "Timestamps must match");
+        assertGt(ptAnswer, 0, "Answer must be positive");
+        assertGt(ptUpdatedAt, 0, "updatedAt must be set");
     }
 
     /// @notice Passthrough adapter reports 8 decimals.
@@ -234,16 +227,13 @@ contract ProdForkTest is Test {
         assertEq(passthrough.decimals(), 8);
     }
 
-    /// @notice Passthrough adapter points to the correct oracle.
-    function testProdWtcoinPassthroughOracleRef() external onlyIfPassthroughDeployed {
+    /// @notice Passthrough adapter points to a valid registry and vault.
+    function testProdWtcoinPassthroughConfig() external onlyIfPassthroughDeployed {
         _forkBase();
 
         PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
-        assertEq(
-            address(passthrough.oracle()),
-            LibProdOracles.WTCOIN_ORACLE,
-            "Passthrough should reference the wtCOIN oracle"
-        );
+        assertEq(passthrough.vault(), LibProdOracles.WTCOIN_VAULT, "Passthrough should reference the wtCOIN vault");
+        assertTrue(address(passthrough.registry()) != address(0), "Registry should be set");
     }
 
     // =========================================================================
@@ -268,60 +258,32 @@ contract ProdForkTest is Test {
     }
 
     // =========================================================================
-    // Protocol adapter setOracle (oracle swap scenario)
+    // Registry swap scenario
     // =========================================================================
 
-    /// @notice Protocol adapters can swap oracle reference.
-    function testProdWtcoinSetOracle() external onlyIfPassthroughDeployed {
+    /// @notice Protocol adapters can swap registry reference.
+    function testProdWtcoinSetRegistry() external onlyIfPassthroughDeployed {
         _forkBase();
 
         PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
         address ptAdmin = passthrough.admin();
+        OracleRegistry currentRegistry = passthrough.registry();
 
-        // Create a mock oracle that returns a known value
-        address mockOracle = address(new MockAggregator(42e8));
+        // Verify current registry works
+        int256 answer = passthrough.latestAnswer();
+        assertGt(answer, 0);
 
+        // Only admin can set registry
+        vm.prank(address(0xdead));
+        vm.expectRevert();
+        passthrough.setRegistry(currentRegistry);
+
+        // Admin can set registry (set to same one, just testing the call works)
         vm.prank(ptAdmin);
-        passthrough.setOracle(AggregatorV3Interface(mockOracle));
+        passthrough.setRegistry(currentRegistry);
 
-        assertEq(passthrough.latestAnswer(), 42e8, "Should use new oracle");
-
-        // Swap back
-        vm.prank(ptAdmin);
-        passthrough.setOracle(AggregatorV3Interface(LibProdOracles.WTCOIN_ORACLE));
-    }
-}
-
-/// @dev Minimal mock for testing setOracle.
-contract MockAggregator is AggregatorV3Interface {
-    int256 private immutable _answer;
-
-    constructor(int256 answer) {
-        _answer = answer;
-    }
-
-    function decimals() external pure override returns (uint8) {
-        return 8;
-    }
-
-    function description() external pure override returns (string memory) {
-        return "Mock";
-    }
-
-    function version() external pure override returns (uint256) {
-        return 1;
-    }
-
-    function latestAnswer() external view override returns (int256) {
-        return _answer;
-    }
-
-    function latestRoundData()
-        external
-        view
-        override
-        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
-    {
-        return (1, _answer, block.timestamp, block.timestamp, 1);
+        // Still works after re-setting
+        int256 answerAfter = passthrough.latestAnswer();
+        assertEq(answerAfter, answer);
     }
 }


### PR DESCRIPTION
## Changes

### LibProdDeploy.sol
- Set `BEACON_INITIAL_OWNER` to `rainlang.eth` (`0x8E4bdeec7CEB9570D440676345dA1dCe10329f5b`)

### ProdFork.t.sol (new)
Production fork tests that run against deployed contracts on a Base fork. Tests cover:

**PythOracleAdapter:**
- `latestAnswer()` returns sane price ($10-$10,000 range for COIN)
- `latestRoundData()` returns valid round data with fresh timestamp
- Reports 8 decimals
- Config matches expected vault, priceId, maxAge (300s)
- Reverts when paused, works again after unpause
- Only admin can pause

**MorphoProtocolAdapter:**
- Price correctly scaled from 8 to 36 decimals (`oracle * 1e28`)
- Points to correct oracle

**PassthroughProtocolAdapter:**
- Returns identical answer to oracle
- Returns identical roundData to oracle
- Reports 8 decimals
- Points to correct oracle
- `setOracle()` swap works (oracle migration scenario)

**Cross-layer:**
- All three contracts return consistent prices in single block

### Deployment workflow
Tests use `onlyIfDeployed` modifier — they pass vacuously until oracle addresses are populated in `LibProdOracles`. After deploying wtCOIN oracle via the manual workflow, fill in the addresses and tests go live.

### Deploy order
1. `pyth-oracle-adapter-beacon-set` → record address
2. `morpho-protocol-adapter-beacon-set` → record address  
3. `passthrough-protocol-adapter-beacon-set` → record address
4. Update `LibProdDeploy.sol` with 3 deployer addresses, push
5. `oracle-unified-deployer` → record address, update LibProdDeploy
6. Call `newOracleAndProtocolAdapters(wtCOIN_vault, COIN_priceId, 300)`
7. Fill `LibProdOracles` addresses in ProdFork.t.sol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Updated the initial owner address for beacon deployments from placeholder to the founder multisig address on Base network.

* **Tests**
  * Added production fork test suite validating oracle adapters and price feed functionality across multiple protocol integrations, including pause/recovery mechanisms, cross-adapter price consistency, and oracle configuration changes on the Base network.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->