### PR TITLE
feat: add OracleRegistryBeaconSetDeployer address (Base mainnet)

### DIFF
--- a/src/lib/LibProdDeploy.sol
+++ b/src/lib/LibProdDeploy.sol
@@ -21,8 +21,8 @@ library LibProdDeploy {
     /// Deployed to Base 2026-02-13. Run: 21982788744.
     address constant ORACLE_UNIFIED_DEPLOYER = 0x377c9657D1827b6bcd1e4B6d0a714815D5F2C615;
 
-    /// TODO: Set after initial deployment to Base.
-    address constant ORACLE_REGISTRY_BEACON_SET_DEPLOYER = address(0);
+    /// Deployed to Base 2026-02-13. Run: 21983445812.
+    address constant ORACLE_REGISTRY_BEACON_SET_DEPLOYER = 0x7467d1BE9E1181Fa368D4d9B3fc684A7dc0d06e3;
 
     /// TODO: Set after initial deployment to Base.
     address constant ORACLE_REGISTRY = address(0);


### PR DESCRIPTION
Adds the OracleRegistryBeaconSetDeployer address from today's deployment.

`0x7467d1BE9E1181Fa368D4d9B3fc684A7dc0d06e3` — run 21983445812

**All infrastructure is now deployed on Base:**
| Contract | Address |
|----------|---------|
| PythOracleAdapterBeaconSetDeployer | `0x29295438119dA1E773f6A103cC935c89BfdEbc4A` |
| MorphoProtocolAdapterBeaconSetDeployer | `0x5022bb2ecB539Ad54E49871389E134fb2c9fE9a5` |
| PassthroughProtocolAdapterBeaconSetDeployer | `0x62bb7076075a78dEc0e888668C44482235B93CD0` |
| OracleUnifiedDeployer | `0x377c9657D1827b6bcd1e4B6d0a714815D5F2C615` |
| OracleRegistryBeaconSetDeployer | `0x7467d1BE9E1181Fa368D4d9B3fc684A7dc0d06e3` |

**Next steps after merge:**
1. `cast send` to create a registry instance via `newOracleRegistry()`
2. `cast send` to create wtCOIN oracle+adapters via `newOracleAndProtocolAdapters()`
3. PR oracle addresses into `LibProdOracles` for prod fork tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration address for contract registry infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->