### PR TITLE
refactor: newOracleRegistry uses msg.sender as admin

### DIFF
--- a/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
+++ b/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
@@ -50,13 +50,14 @@ contract OracleRegistryBeaconSetDeployer {
     }
 
     /// @notice Deploys and initializes a new OracleRegistry proxy.
-    /// @param config The initialization configuration.
+    /// The caller (msg.sender) becomes the registry admin, consistent with
+    /// OracleUnifiedDeployer which sets msg.sender as admin for all adapters.
     /// @return registry The deployed OracleRegistry proxy.
     // slither-disable-next-line reentrancy-events
-    function newOracleRegistry(OracleRegistryConfig memory config) external returns (OracleRegistry) {
+    function newOracleRegistry() external returns (OracleRegistry) {
         OracleRegistry registry = OracleRegistry(address(new BeaconProxy(address(I_ORACLE_REGISTRY_BEACON), "")));
 
-        if (registry.initialize(abi.encode(config)) != ICLONEABLE_V2_SUCCESS) {
+        if (registry.initialize(abi.encode(OracleRegistryConfig({admin: msg.sender}))) != ICLONEABLE_V2_SUCCESS) {
             revert InitializeRegistryFailed();
         }
 

--- a/src/lib/LibProdDeploy.sol
+++ b/src/lib/LibProdDeploy.sol
@@ -21,8 +21,8 @@ library LibProdDeploy {
     /// Deployed to Base 2026-02-13. Run: 21982788744.
     address constant ORACLE_UNIFIED_DEPLOYER = 0x377c9657D1827b6bcd1e4B6d0a714815D5F2C615;
 
-    /// Deployed to Base 2026-02-13. Run: 21983445812.
-    address constant ORACLE_REGISTRY_BEACON_SET_DEPLOYER = 0x7467d1BE9E1181Fa368D4d9B3fc684A7dc0d06e3;
+    /// TODO: Redeploy after newOracleRegistry signature change.
+    address constant ORACLE_REGISTRY_BEACON_SET_DEPLOYER = address(0);
 
     /// TODO: Set after initial deployment to Base.
     address constant ORACLE_REGISTRY = address(0);

--- a/test/abstract/OracleRegistryTest.sol
+++ b/test/abstract/OracleRegistryTest.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test, Vm} from "forge-std/Test.sol";
-import {OracleRegistry, OracleRegistryConfig} from "src/concrete/registry/OracleRegistry.sol";
+import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig
@@ -23,6 +23,7 @@ contract OracleRegistryTest is Test {
     }
 
     function createRegistry(address admin) internal returns (OracleRegistry) {
-        return I_DEPLOYER.newOracleRegistry(OracleRegistryConfig({admin: admin}));
+        vm.prank(admin);
+        return I_DEPLOYER.newOracleRegistry();
     }
 }

--- a/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
+++ b/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
@@ -11,7 +11,7 @@ import {
 } from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
 import {MorphoProtocolAdapterBeaconSetDeployer} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
 import {PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
-import {OracleRegistry, OracleRegistryConfig} from "src/concrete/registry/OracleRegistry.sol";
+import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig
@@ -31,7 +31,8 @@ contract OracleUnifiedDeployerTest is Test {
     }
 
     function _createRegistry(address admin) internal returns (OracleRegistry) {
-        return I_REGISTRY_DEPLOYER.newOracleRegistry(OracleRegistryConfig({admin: admin}));
+        vm.prank(admin);
+        return I_REGISTRY_DEPLOYER.newOracleRegistry();
     }
 
     function testOracleUnifiedDeployer(

--- a/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
@@ -17,7 +17,7 @@ import {
     MorphoProtocolAdapterBeaconSetDeployer,
     MorphoProtocolAdapterBeaconSetDeployerConfig
 } from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
-import {OracleRegistry, OracleRegistryConfig} from "src/concrete/registry/OracleRegistry.sol";
+import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig
@@ -46,7 +46,8 @@ contract MorphoProtocolAdapterTest is Test {
     }
 
     function _createRegistry(address admin) internal returns (OracleRegistry) {
-        return I_REGISTRY_DEPLOYER.newOracleRegistry(OracleRegistryConfig({admin: admin}));
+        vm.prank(admin);
+        return I_REGISTRY_DEPLOYER.newOracleRegistry();
     }
 
     /// Test that initialization with zero registry reverts.

--- a/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
@@ -16,7 +16,7 @@ import {
     PassthroughProtocolAdapterBeaconSetDeployer,
     PassthroughProtocolAdapterBeaconSetDeployerConfig
 } from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
-import {OracleRegistry, OracleRegistryConfig} from "src/concrete/registry/OracleRegistry.sol";
+import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig
@@ -45,7 +45,8 @@ contract PassthroughProtocolAdapterTest is Test {
     }
 
     function _createRegistry(address admin) internal returns (OracleRegistry) {
-        return I_REGISTRY_DEPLOYER.newOracleRegistry(OracleRegistryConfig({admin: admin}));
+        vm.prank(admin);
+        return I_REGISTRY_DEPLOYER.newOracleRegistry();
     }
 
     /// Test that initialization with zero registry reverts.

--- a/test/src/concrete/registry/OracleRegistry.t.sol
+++ b/test/src/concrete/registry/OracleRegistry.t.sol
@@ -17,10 +17,14 @@ import {AggregatorV3Interface} from "src/interface/IAggregatorV3.sol";
 import {Vm} from "forge-std/Test.sol";
 
 contract OracleRegistryInitializeTest is OracleRegistryTest {
-    /// Test that zero admin address reverts.
-    function testInitializeZeroAdmin() external {
-        vm.expectRevert(abi.encodeWithSelector(ZeroAdmin.selector));
-        I_DEPLOYER.newOracleRegistry(OracleRegistryConfig({admin: address(0)}));
+    /// Test that deployer sets msg.sender as admin.
+    /// Note: zero admin is no longer possible through the deployer since
+    /// msg.sender cannot be address(0).
+    function testInitializeAdminIsMsgSender(address admin) external {
+        vm.assume(admin != address(0));
+        vm.prank(admin);
+        OracleRegistry registry = I_DEPLOYER.newOracleRegistry();
+        assertEq(registry.admin(), admin);
     }
 
     /// Test successful initialization sets admin correctly.


### PR DESCRIPTION
Makes registry deployment consistent with the unified deployer — `msg.sender` becomes the admin automatically, no need to pass your own address.

**Changes:**
- `newOracleRegistry()` takes no params, uses `msg.sender` as admin
- All test call sites updated to `vm.prank(admin)` before calling
- `ORACLE_REGISTRY_BEACON_SET_DEPLOYER` reset to `address(0)` — needs redeploy after merge

**After merge:**
1. Redeploy `oracle-registry-beacon-set` suite
2. PR new deployer address
3. `cast send` calls (now step 1 is just `newOracleRegistry()` with no args)