### PR TITLE
feat: add wtCOIN oracle addresses + fix COIN price feed ID

### DIFF
--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -40,4 +40,5 @@ jobs:
           ETH_RPC_URL: ${{ secrets.CI_DEPLOY_RPC_URL }}
           ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY }}
           RPC_URL_BASE_FORK: ${{ vars.CI_DEPLOY_BASE_RPC_URL }}
+          FORK_BLOCK_BASE: ${{ vars.FORK_BLOCK_BASE }}
         run: nix develop -c ${{ matrix.task }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,92 @@
+# AGENTS.md — st0x.oracle
+
+## Build System
+
+This repo uses **nix flakes** for all tooling. Do not use globally installed `forge` or `solc`.
+
+```bash
+# Enter the nix dev shell
+nix develop
+
+# Or run a single command
+nix develop -c forge build
+```
+
+All commands below assume you are inside `nix develop`.
+
+## Before Pushing
+
+Run the full CI prelude locally before every push:
+
+```bash
+nix develop -c rainix-sol-prelude
+```
+
+This runs formatting, linting, and compilation — the same checks CI runs. If it fails locally, it will fail on CI.
+
+At minimum:
+1. `forge fmt` — auto-format all Solidity files
+2. `forge build` — compile everything
+3. `forge test` — run unit + fuzz tests
+
+For fork tests (ProdFork.t.sol):
+```bash
+RPC_URL_BASE_FORK=https://mainnet.base.org forge test --match-contract ProdForkTest
+```
+
+## Address Checksums
+
+Solidity requires EIP-55 checksummed addresses. When adding deployed addresses, use `cast to-check-sum-address` to get the correct casing:
+
+```bash
+cast to-check-sum-address 0xabcdef...
+```
+
+Do not use lowercase addresses from transaction receipts directly.
+
+## Testing
+
+- **Every feature needs tests.** No exceptions.
+- **Use fuzz tests** wherever appropriate — especially for functions that take arbitrary inputs.
+- **Prod fork tests** (`test/src/concrete/ProdFork.t.sol`) run against live Base mainnet state. They use skip modifiers (`onlyIfOracleDeployed`, etc.) so they pass vacuously before deployment and run against real contracts after.
+- Fork tests can be merged before deployment — the skip modifiers handle this.
+
+## Deployment
+
+Deployments happen via GitHub Actions (`manual-sol-artifacts.yaml`), not locally.
+
+1. Run the workflow with `network=base` and the appropriate `suite`
+2. Parse deployed addresses from the workflow logs
+3. PR the addresses into `src/lib/LibProdDeploy.sol` (for deployer addresses) or `test/src/concrete/ProdFork.t.sol` `LibProdOracles` (for oracle/adapter addresses)
+4. Use `cast send` with `--interactive` for any onchain calls that need a private key
+
+### Deployment Suites
+
+- `pyth-oracle-adapter-beacon-set` — PythOracleAdapter beacon + impl
+- `morpho-protocol-adapter-beacon-set` — MorphoProtocolAdapter beacon + impl
+- `passthrough-protocol-adapter-beacon-set` — PassthroughProtocolAdapter beacon + impl
+- `oracle-unified-deployer` — OracleUnifiedDeployer (stateless, calls beacon set deployers)
+- `oracle-registry-beacon-set` — OracleRegistry beacon + impl
+
+### Secret Naming Convention
+
+Workflow secrets follow the `CI_DEPLOY_<NETWORK>_<SUFFIX>` pattern:
+- `CI_DEPLOY_BASE_RPC_URL`
+- `CI_DEPLOY_BASE_DEPLOYER_PRIVATE_KEY`
+- `CI_DEPLOY_BASE_ETHERSCAN_API_KEY`
+- `CI_DEPLOY_BASE_VERIFIER_URL` (use `https://api.etherscan.io/v2/api?chainid=8453`)
+
+## Architecture
+
+- **PythOracleAdapter** — wraps Pyth price feeds into AggregatorV3Interface (8 decimals)
+- **MorphoProtocolAdapter** — scales oracle price to 36 decimals for Morpho
+- **PassthroughProtocolAdapter** — passes oracle price through unchanged (AggregatorV3Interface)
+- **OracleRegistry** — maps vault → oracle adapter. Protocol adapters look up their oracle from the registry at runtime.
+- **OracleUnifiedDeployer** — deploys all three adapters for a vault in one call. Takes registry address as parameter.
+- **Beacon pattern** — all contracts use UpgradeableBeacon proxies. `BEACON_INITIAL_OWNER` is `rainlang.eth` (`0x8E4bdeec7CEB9570D440676345dA1dCe10329f5b`).
+
+## Key Constants
+
+- `BEACON_INITIAL_OWNER`: `0x8E4bdeec7CEB9570D440676345dA1dCe10329f5b` (rainlang.eth)
+- All deployer addresses are in `src/lib/LibProdDeploy.sol`
+- All oracle instance addresses are in `test/src/concrete/ProdFork.t.sol` `LibProdOracles`

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -12,6 +12,7 @@ path = [
     "foundry.toml",
     "REUSE.toml",
     "foundry.lock",
+    "AGENTS.md",
     "CLAUDE.md",
     "SPEC.md",
     "slither.config.json"

--- a/test/src/concrete/ProdFork.t.sol
+++ b/test/src/concrete/ProdFork.t.sol
@@ -26,6 +26,10 @@ library LibProdOracles {
     /// Deployed to Base 2026-02-13.
     address constant WTCOIN_PASSTHROUGH = 0x2e73ef522e9369576bd5fc8f25bf2f0e4cc6b57e;
 
+    /// OracleRegistry instance.
+    /// Deployed to Base 2026-02-13.
+    address constant ORACLE_REGISTRY = 0x36a14d00a8597731fb6db1e0e7eea0bb81ffd156;
+
     /// wtCOIN ERC-4626 vault.
     address constant WTCOIN_VAULT = 0x5cDa0E1CA4ce2af96315f7F8963C85399c172204;
 
@@ -63,6 +67,14 @@ contract ProdForkTest is Test {
     /// @dev Skip modifier for Passthrough adapter tests.
     modifier onlyIfPassthroughDeployed() {
         if (LibProdOracles.WTCOIN_PASSTHROUGH == address(0)) {
+            return;
+        }
+        _;
+    }
+
+    /// @dev Skip modifier for registry tests.
+    modifier onlyIfRegistryDeployed() {
+        if (LibProdOracles.ORACLE_REGISTRY == address(0)) {
             return;
         }
         _;
@@ -255,6 +267,198 @@ contract ProdForkTest is Test {
         // All three should be consistent
         assertEq(passthroughPrice, oraclePrice, "Passthrough != Oracle");
         assertEq(morphoPrice, uint256(oraclePrice) * 1e28, "Morpho != Oracle * 1e28");
+    }
+
+    // =========================================================================
+    // OracleRegistry tests
+    // =========================================================================
+
+    /// @notice Registry has wtCOIN oracle registered.
+    function testProdRegistryHasWtcoinOracle() external onlyIfRegistryDeployed onlyIfOracleDeployed {
+        _forkBase();
+
+        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        AggregatorV3Interface oracle = registry.getOracle(LibProdOracles.WTCOIN_VAULT);
+        assertEq(address(oracle), LibProdOracles.WTCOIN_ORACLE, "Registry should map wtCOIN vault to oracle");
+    }
+
+    /// @notice Registry admin can update an oracle.
+    function testProdRegistrySetOracle() external onlyIfRegistryDeployed {
+        _forkBase();
+
+        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        address registryAdmin = registry.admin();
+
+        // Set a dummy oracle for a dummy vault
+        address dummyVault = address(0x1111111111111111111111111111111111111111);
+        address dummyOracle = address(0x2222222222222222222222222222222222222222);
+
+        vm.prank(registryAdmin);
+        registry.setOracle(dummyVault, AggregatorV3Interface(dummyOracle));
+
+        assertEq(address(registry.getOracle(dummyVault)), dummyOracle, "Oracle should be set");
+    }
+
+    /// @notice Registry admin can set oracles in bulk.
+    function testProdRegistrySetOracleBulk() external onlyIfRegistryDeployed {
+        _forkBase();
+
+        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        address registryAdmin = registry.admin();
+
+        address[] memory vaults = new address[](3);
+        vaults[0] = address(0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA);
+        vaults[1] = address(0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB);
+        vaults[2] = address(0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC);
+
+        AggregatorV3Interface[] memory oracles = new AggregatorV3Interface[](3);
+        oracles[0] = AggregatorV3Interface(address(0x1111111111111111111111111111111111111111));
+        oracles[1] = AggregatorV3Interface(address(0x2222222222222222222222222222222222222222));
+        oracles[2] = AggregatorV3Interface(address(0x3333333333333333333333333333333333333333));
+
+        vm.prank(registryAdmin);
+        registry.setOracleBulk(vaults, oracles);
+
+        for (uint256 i = 0; i < vaults.length; i++) {
+            assertEq(address(registry.getOracle(vaults[i])), address(oracles[i]), "Bulk oracle mismatch");
+        }
+    }
+
+    /// @notice Non-admin cannot set oracles on the registry.
+    function testProdRegistryOnlyAdminCanSetOracle() external onlyIfRegistryDeployed {
+        _forkBase();
+
+        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+
+        vm.prank(address(0xdead));
+        vm.expectRevert();
+        registry.setOracle(
+            address(0x1111111111111111111111111111111111111111),
+            AggregatorV3Interface(address(0x2222222222222222222222222222222222222222))
+        );
+    }
+
+    /// @notice Non-admin cannot bulk set oracles.
+    function testProdRegistryOnlyAdminCanSetOracleBulk() external onlyIfRegistryDeployed {
+        _forkBase();
+
+        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+
+        address[] memory vaults = new address[](1);
+        vaults[0] = address(0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA);
+        AggregatorV3Interface[] memory oracles = new AggregatorV3Interface[](1);
+        oracles[0] = AggregatorV3Interface(address(0x1111111111111111111111111111111111111111));
+
+        vm.prank(address(0xdead));
+        vm.expectRevert();
+        registry.setOracleBulk(vaults, oracles);
+    }
+
+    /// @notice Bulk set with mismatched array lengths reverts.
+    function testProdRegistryBulkMismatchedLengthsReverts() external onlyIfRegistryDeployed {
+        _forkBase();
+
+        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        address registryAdmin = registry.admin();
+
+        address[] memory vaults = new address[](2);
+        vaults[0] = address(0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA);
+        vaults[1] = address(0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB);
+        AggregatorV3Interface[] memory oracles = new AggregatorV3Interface[](1);
+        oracles[0] = AggregatorV3Interface(address(0x1111111111111111111111111111111111111111));
+
+        vm.prank(registryAdmin);
+        vm.expectRevert();
+        registry.setOracleBulk(vaults, oracles);
+    }
+
+    /// @notice Setting zero vault reverts.
+    function testProdRegistrySetOracleZeroVaultReverts() external onlyIfRegistryDeployed {
+        _forkBase();
+
+        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        address registryAdmin = registry.admin();
+
+        vm.prank(registryAdmin);
+        vm.expectRevert();
+        registry.setOracle(address(0), AggregatorV3Interface(address(0x1111111111111111111111111111111111111111)));
+    }
+
+    /// @notice Setting zero oracle reverts.
+    function testProdRegistrySetOracleZeroOracleReverts() external onlyIfRegistryDeployed {
+        _forkBase();
+
+        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        address registryAdmin = registry.admin();
+
+        vm.prank(registryAdmin);
+        vm.expectRevert();
+        registry.setOracle(address(0x1111111111111111111111111111111111111111), AggregatorV3Interface(address(0)));
+    }
+
+    /// @notice Admin can transfer admin role.
+    function testProdRegistrySetAdmin() external onlyIfRegistryDeployed {
+        _forkBase();
+
+        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        address registryAdmin = registry.admin();
+        address newAdmin = address(0x4444444444444444444444444444444444444444);
+
+        vm.prank(registryAdmin);
+        registry.setAdmin(newAdmin);
+        assertEq(registry.admin(), newAdmin, "Admin should be updated");
+
+        // New admin can act
+        vm.prank(newAdmin);
+        registry.setOracle(
+            address(0x5555555555555555555555555555555555555555),
+            AggregatorV3Interface(address(0x6666666666666666666666666666666666666666))
+        );
+
+        // Old admin cannot
+        vm.prank(registryAdmin);
+        vm.expectRevert();
+        registry.setOracle(
+            address(0x7777777777777777777777777777777777777777),
+            AggregatorV3Interface(address(0x8888888888888888888888888888888888888888))
+        );
+    }
+
+    /// @notice Registry oracle update propagates to protocol adapters.
+    function testProdRegistryUpdatePropagates() external onlyIfRegistryDeployed onlyIfAllDeployed {
+        _forkBase();
+
+        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        MorphoProtocolAdapter morpho = MorphoProtocolAdapter(LibProdOracles.WTCOIN_MORPHO);
+        PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
+
+        // Get current price
+        uint256 morphoPriceBefore = morpho.price();
+        int256 ptPriceBefore = passthrough.latestAnswer();
+        assertGt(morphoPriceBefore, 0);
+        assertGt(ptPriceBefore, 0);
+
+        // Swap the oracle in registry to a dummy — adapters should revert or return different data
+        address registryAdmin = registry.admin();
+        address dummyOracle = address(0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef);
+
+        vm.prank(registryAdmin);
+        registry.setOracle(LibProdOracles.WTCOIN_VAULT, AggregatorV3Interface(dummyOracle));
+
+        // Adapters now point to dummy — calls should revert
+        vm.expectRevert();
+        morpho.price();
+
+        vm.expectRevert();
+        passthrough.latestAnswer();
+
+        // Restore original oracle
+        vm.prank(registryAdmin);
+        registry.setOracle(LibProdOracles.WTCOIN_VAULT, AggregatorV3Interface(LibProdOracles.WTCOIN_ORACLE));
+
+        // Should work again
+        uint256 morphoPriceAfter = morpho.price();
+        assertEq(morphoPriceAfter, morphoPriceBefore, "Price should be same after restore");
     }
 
     // =========================================================================

--- a/test/src/concrete/ProdFork.t.sol
+++ b/test/src/concrete/ProdFork.t.sol
@@ -16,19 +16,19 @@ import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
 library LibProdOracles {
     /// wtCOIN oracle adapter (PythOracleAdapter proxy).
     /// Deployed to Base 2026-02-13.
-    address constant WTCOIN_ORACLE = 0x9f0fc96fef8e62bffd35bdb76e7287a3e4aa57b0;
+    address constant WTCOIN_ORACLE = 0x9f0fc96FeF8e62bfFD35bDb76e7287A3E4aa57B0;
 
     /// wtCOIN Morpho protocol adapter.
     /// Deployed to Base 2026-02-13.
-    address constant WTCOIN_MORPHO = 0xbe4fe57576e54595400195e6bc00002cb4ed232e;
+    address constant WTCOIN_MORPHO = 0xbe4fE57576e54595400195e6bc00002CB4ed232E;
 
     /// wtCOIN passthrough protocol adapter (Aave/Compound).
     /// Deployed to Base 2026-02-13.
-    address constant WTCOIN_PASSTHROUGH = 0x2e73ef522e9369576bd5fc8f25bf2f0e4cc6b57e;
+    address constant WTCOIN_PASSTHROUGH = 0x2e73ef522E9369576bD5fC8f25Bf2f0E4cC6b57E;
 
     /// OracleRegistry instance.
     /// Deployed to Base 2026-02-13.
-    address constant ORACLE_REGISTRY = 0x36a14d00a8597731fb6db1e0e7eea0bb81ffd156;
+    address constant ORACLE_REGISTRY = 0x36a14d00a8597731fb6dB1e0e7EeA0BB81ffD156;
 
     /// wtCOIN ERC-4626 vault.
     address constant WTCOIN_VAULT = 0x5cDa0E1CA4ce2af96315f7F8963C85399c172204;

--- a/test/src/concrete/ProdFork.t.sol
+++ b/test/src/concrete/ProdFork.t.sol
@@ -307,9 +307,9 @@ contract ProdForkTest is Test {
         address registryAdmin = registry.admin();
 
         address[] memory vaults = new address[](3);
-        vaults[0] = address(0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA);
-        vaults[1] = address(0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB);
-        vaults[2] = address(0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC);
+        vaults[0] = address(0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa);
+        vaults[1] = address(0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB);
+        vaults[2] = address(0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC);
 
         AggregatorV3Interface[] memory oracles = new AggregatorV3Interface[](3);
         oracles[0] = AggregatorV3Interface(address(0x1111111111111111111111111111111111111111));
@@ -345,7 +345,7 @@ contract ProdForkTest is Test {
         OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
 
         address[] memory vaults = new address[](1);
-        vaults[0] = address(0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA);
+        vaults[0] = address(0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa);
         AggregatorV3Interface[] memory oracles = new AggregatorV3Interface[](1);
         oracles[0] = AggregatorV3Interface(address(0x1111111111111111111111111111111111111111));
 
@@ -362,8 +362,8 @@ contract ProdForkTest is Test {
         address registryAdmin = registry.admin();
 
         address[] memory vaults = new address[](2);
-        vaults[0] = address(0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA);
-        vaults[1] = address(0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB);
+        vaults[0] = address(0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa);
+        vaults[1] = address(0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB);
         AggregatorV3Interface[] memory oracles = new AggregatorV3Interface[](1);
         oracles[0] = AggregatorV3Interface(address(0x1111111111111111111111111111111111111111));
 
@@ -440,7 +440,7 @@ contract ProdForkTest is Test {
 
         // Swap the oracle in registry to a dummy — adapters should revert or return different data
         address registryAdmin = registry.admin();
-        address dummyOracle = address(0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef);
+        address dummyOracle = address(0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF);
 
         vm.prank(registryAdmin);
         registry.setOracle(LibProdOracles.WTCOIN_VAULT, AggregatorV3Interface(dummyOracle));

--- a/test/src/concrete/ProdFork.t.sol
+++ b/test/src/concrete/ProdFork.t.sol
@@ -9,8 +9,6 @@ import {MorphoProtocolAdapter} from "src/concrete/protocol/MorphoProtocolAdapter
 import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
 import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
-import {IPyth} from "pyth-sdk/IPyth.sol";
-import {PythStructs} from "pyth-sdk/PythStructs.sol";
 
 /// @title LibProdOracles
 /// @notice Hardcoded production oracle addresses deployed via
@@ -93,24 +91,12 @@ contract ProdForkTest is Test {
         _;
     }
 
+    /// @dev Fork Base at a specific block. Use FORK_BLOCK_BASE env var to pin
+    /// to a block during NYSE market hours (required for COIN/USD Pyth feed).
     function _forkBase() internal {
-        vm.createSelectFork(vm.envString("RPC_URL_BASE_FORK"));
-        _warpToFreshPrice();
-    }
-
-    /// @dev Warp block.timestamp to the oracle's last publishTime so that
-    /// maxAge checks pass regardless of when CI runs. Equity feeds like
-    /// COIN/USD are only updated during NYSE market hours.
-    /// Calls Pyth's getPriceUnsafe (no staleness check) to read publishTime,
-    /// then warps to that timestamp.
-    function _warpToFreshPrice() internal {
-        if (LibProdOracles.WTCOIN_ORACLE == address(0)) return;
-        // Base mainnet Pyth contract
-        IPyth pyth = IPyth(0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a);
-        PythStructs.Price memory price = pyth.getPriceUnsafe(LibProdOracles.COIN_PRICE_ID);
-        if (price.publishTime > 0) {
-            vm.warp(uint256(uint64(price.publishTime)));
-        }
+        string memory rpc = vm.envString("RPC_URL_BASE_FORK");
+        uint256 blockNumber = vm.envUint("FORK_BLOCK_BASE");
+        vm.createSelectFork(rpc, blockNumber);
     }
 
     // =========================================================================

--- a/test/src/concrete/ProdFork.t.sol
+++ b/test/src/concrete/ProdFork.t.sol
@@ -15,23 +15,23 @@ import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
 /// OracleUnifiedDeployer. Update these after each deployment.
 library LibProdOracles {
     /// wtCOIN oracle adapter (PythOracleAdapter proxy).
-    /// TODO: Set after deployment.
-    address constant WTCOIN_ORACLE = address(0);
+    /// Deployed to Base 2026-02-13.
+    address constant WTCOIN_ORACLE = 0x9f0fc96fef8e62bffd35bdb76e7287a3e4aa57b0;
 
     /// wtCOIN Morpho protocol adapter.
-    /// TODO: Set after deployment.
-    address constant WTCOIN_MORPHO = address(0);
+    /// Deployed to Base 2026-02-13.
+    address constant WTCOIN_MORPHO = 0xbe4fe57576e54595400195e6bc00002cb4ed232e;
 
     /// wtCOIN passthrough protocol adapter (Aave/Compound).
-    /// TODO: Set after deployment.
-    address constant WTCOIN_PASSTHROUGH = address(0);
+    /// Deployed to Base 2026-02-13.
+    address constant WTCOIN_PASSTHROUGH = 0x2e73ef522e9369576bd5fc8f25bf2f0e4cc6b57e;
 
     /// wtCOIN ERC-4626 vault.
     address constant WTCOIN_VAULT = 0x5cDa0E1CA4ce2af96315f7F8963C85399c172204;
 
     /// COIN/USD Pyth price feed ID.
     /// https://www.pyth.network/developers/price-feed-ids
-    bytes32 constant COIN_PRICE_ID = 0xe65ff435be2e5170520bca5af8e56241d18a8abe0e12face633cee71a685e08d;
+    bytes32 constant COIN_PRICE_ID = 0xfee33f2a978bf32dd6b662b65ba8083c6773b494f8401194ec1870c640860245;
 }
 
 /// @title ProdForkTest

--- a/test/src/concrete/ProdFork.t.sol
+++ b/test/src/concrete/ProdFork.t.sol
@@ -9,6 +9,8 @@ import {MorphoProtocolAdapter} from "src/concrete/protocol/MorphoProtocolAdapter
 import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
 import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
+import {IPyth} from "pyth-sdk/IPyth.sol";
+import {PythStructs} from "pyth-sdk/PythStructs.sol";
 
 /// @title LibProdOracles
 /// @notice Hardcoded production oracle addresses deployed via
@@ -93,6 +95,22 @@ contract ProdForkTest is Test {
 
     function _forkBase() internal {
         vm.createSelectFork(vm.envString("RPC_URL_BASE_FORK"));
+        _warpToFreshPrice();
+    }
+
+    /// @dev Warp block.timestamp to the oracle's last publishTime so that
+    /// maxAge checks pass regardless of when CI runs. Equity feeds like
+    /// COIN/USD are only updated during NYSE market hours.
+    /// Calls Pyth's getPriceUnsafe (no staleness check) to read publishTime,
+    /// then warps to that timestamp.
+    function _warpToFreshPrice() internal {
+        if (LibProdOracles.WTCOIN_ORACLE == address(0)) return;
+        // Base mainnet Pyth contract
+        IPyth pyth = IPyth(0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a);
+        PythStructs.Price memory price = pyth.getPriceUnsafe(LibProdOracles.COIN_PRICE_ID);
+        if (price.publishTime > 0) {
+            vm.warp(uint256(uint64(price.publishTime)));
+        }
     }
 
     // =========================================================================


### PR DESCRIPTION
All wtCOIN oracle infrastructure now deployed and registered on Base.

| Contract | Address |
|----------|---------|
| OracleRegistry | `0x36a14d00a8597731fb6db1e0e7eea0bb81ffd156` |
| PythOracleAdapter | `0x9f0fc96fef8e62bffd35bdb76e7287a3e4aa57b0` |
| MorphoProtocolAdapter | `0xbe4fe57576e54595400195e6bc00002cb4ed232e` |
| PassthroughProtocolAdapter | `0x2e73ef522e9369576bd5fc8f25bf2f0e4cc6b57e` |

Also fixes `COIN_PRICE_ID` — was using an incorrect feed ID, now points to the real `Equity.US.COIN/USD` feed from Pyth Hermes API.

Prod fork tests should now run against live contracts (during US market hours when Pyth has fresh COIN prices).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated production oracle constants and added an oracle registry constant to reflect current deployments; updated a price identifier.

* **Tests**
  * Added integration tests for the oracle registry covering registration, single/bulk updates, admin controls, zero-value checks, propagation to adapters, and restoration scenarios.

* **Documentation**
  * Added repository documentation covering build, testing, deployment workflows, and operational conventions; tooling annotation updated to include the new docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->