### PR TITLE
Deploy multi-adapter beacons + update constants

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -23,6 +23,7 @@ on:
           - oracle-unified-deployer
           - oracle-registry-beacon-set
           - multi-pyth-oracle-adapter-beacon-set
+          - multi-oracle-unified-deployer
 
 jobs:
   deploy:

--- a/src/lib/LibProdDeploy.sol
+++ b/src/lib/LibProdDeploy.sol
@@ -24,9 +24,12 @@ library LibProdDeploy {
     /// Deployed to Base 2026-02-13. Run: 21984615902.
     address constant ORACLE_REGISTRY_BEACON_SET_DEPLOYER = 0x3B8E2056Dce6E6847e853c3FEdda379802cD07d3;
 
-    /// TODO: Set after initial deployment to Base.
+    /// TODO: Set after deployment to Base.
     address constant MULTI_PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER = address(0);
 
-    /// TODO: Set after initial deployment to Base.
-    address constant ORACLE_REGISTRY = address(0);
+    /// TODO: Set after deployment to Base.
+    address constant MULTI_ORACLE_UNIFIED_DEPLOYER = address(0);
+
+    /// Deployed to Base 2026-02-13.
+    address constant ORACLE_REGISTRY = 0x36a14d00a8597731fb6dB1e0e7EeA0BB81ffD156;
 }


### PR DESCRIPTION
## What

Prep for deploying MultiPythOracleAdapter infrastructure to Base.

### Changes
- Fix `ORACLE_REGISTRY` in LibProdDeploy (was `address(0)`, already deployed at `0x36a1...` on 2026-02-13)
- Add `MULTI_ORACLE_UNIFIED_DEPLOYER` constant placeholder
- Add `multi-oracle-unified-deployer` to manual deploy workflow options

### Deploy order
1. **Manual action**: `multi-pyth-oracle-adapter-beacon-set` → Base
2. **Manual action**: `multi-oracle-unified-deployer` → Base
3. Update `LibProdDeploy.sol` constants with deployed addresses
4. Update `ProdFork.t.sol` `LibProdOracles` with proxy addresses (after first wtCOIN multi-feed oracle is created via unified deployer)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-oracle unified deployer in deployment workflows.

* **Chores**
  * Finalized oracle registry deployment configuration.
  * Introduced multi-oracle unified deployer constant for future configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->