### PR TITLE
feat: scaffold subgraph with OracleRegistry schema and matchstick tests

### DIFF
--- a/.github/workflows/subgraph-test.yaml
+++ b/.github/workflows/subgraph-test.yaml
@@ -1,0 +1,35 @@
+name: Subgraph Tests
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+
+      - run: nix develop -c rainix-sol-prelude
+
+      - name: Install subgraph dependencies
+        run: nix develop -c bash -c "cd subgraph && npm install"
+
+      - name: Codegen
+        run: nix develop -c bash -c "cd subgraph && npx graph codegen"
+
+      - name: Run matchstick tests
+        run: nix develop -c bash -c "cd subgraph && npx graph test -d"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -15,7 +15,8 @@ path = [
     "AGENTS.md",
     "CLAUDE.md",
     "SPEC.md",
-    "slither.config.json"
+    "slither.config.json",
+    "subgraph/**"
 ]
 SPDX-FileCopyrightText = "Copyright (c) 2020 Rain Open Source Software Ltd"
 SPDX-License-Identifier = "LicenseRef-DCL-1.0"

--- a/subgraph/.gitignore
+++ b/subgraph/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+generated/
+build/
+package-lock.json

--- a/subgraph/docker-compose.yml
+++ b/subgraph/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  matchstick:
+    image: rainprotocol/matchstick:main
+    volumes:
+      - ..:/matchstick

--- a/subgraph/networks.json
+++ b/subgraph/networks.json
@@ -1,0 +1,8 @@
+{
+    "base": {
+        "OracleRegistry": {
+            "address": "0x36a14d00a8597731fb6dB1e0e7EeA0BB81ffD156",
+            "startBlock": 26843790
+        }
+    }
+}

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "st0x-oracle-subgraph",
+    "description": "Subgraph for st0x oracle registry and adapters",
+    "version": "1.0.0",
+    "license": "LicenseRef-DCL-1.0",
+    "author": "ST0x Technology",
+    "scripts": {
+        "test": "graph test -d"
+    },
+    "dependencies": {
+        "@graphprotocol/graph-cli": "^0.63.0",
+        "@graphprotocol/graph-ts": "=0.32.0",
+        "matchstick-as": "^0.6.0",
+        "source-map-support": "^0.5.21"
+    }
+}

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,0 +1,62 @@
+"The OracleRegistry contract instance"
+type OracleRegistry @entity {
+  id: Bytes!
+  "Current admin address"
+  admin: Bytes!
+  "All vault-to-oracle mappings"
+  oracleMappings: [OracleMapping!]! @derivedFrom(field: "registry")
+  "Admin change history"
+  adminChanges: [AdminChange!]! @derivedFrom(field: "registry")
+}
+
+"A mapping from a vault to its oracle in the registry"
+type OracleMapping @entity {
+  id: Bytes!
+  "The registry this mapping belongs to"
+  registry: OracleRegistry!
+  "The vault address"
+  vault: Bytes!
+  "The current oracle address"
+  oracle: Bytes!
+  "History of oracle changes for this vault"
+  changes: [OracleChange!]! @derivedFrom(field: "mapping")
+}
+
+"An event recording an oracle change for a vault"
+type OracleChange @entity(immutable: true) {
+  id: Bytes!
+  "The oracle mapping that changed"
+  mapping: OracleMapping!
+  "The vault address"
+  vault: Bytes!
+  "The previous oracle address"
+  oldOracle: Bytes!
+  "The new oracle address"
+  newOracle: Bytes!
+  "Block timestamp"
+  timestamp: BigInt!
+  "The transaction"
+  transaction: Transaction!
+}
+
+"An admin change event"
+type AdminChange @entity(immutable: true) {
+  id: Bytes!
+  "The registry this change belongs to"
+  registry: OracleRegistry!
+  "The previous admin"
+  oldAdmin: Bytes!
+  "The new admin"
+  newAdmin: Bytes!
+  "Block timestamp"
+  timestamp: BigInt!
+  "The transaction"
+  transaction: Transaction!
+}
+
+type Transaction @entity(immutable: true) {
+  id: Bytes!
+  timestamp: BigInt!
+  blockNumber: BigInt!
+  from: Bytes!
+}

--- a/subgraph/src/handlers.ts
+++ b/subgraph/src/handlers.ts
@@ -1,0 +1,80 @@
+import { Bytes } from "@graphprotocol/graph-ts";
+import {
+  OracleRegistryInitialized,
+  OracleSet,
+  AdminSet,
+} from "../generated/OracleRegistry/OracleRegistry";
+import {
+  OracleRegistry,
+  OracleMapping,
+  OracleChange,
+  AdminChange,
+} from "../generated/schema";
+import { createTransactionEntity } from "./transaction";
+
+function eventId(event: OracleSet): Bytes {
+  return event.transaction.hash.concatI32(event.logIndex.toI32());
+}
+
+function adminEventId(event: AdminSet): Bytes {
+  return event.transaction.hash.concatI32(event.logIndex.toI32());
+}
+
+function initEventId(event: OracleRegistryInitialized): Bytes {
+  return event.transaction.hash.concatI32(event.logIndex.toI32());
+}
+
+function oracleMappingId(registry: Bytes, vault: Bytes): Bytes {
+  return registry.concat(vault);
+}
+
+export function handleOracleRegistryInitialized(
+  event: OracleRegistryInitialized
+): void {
+  createTransactionEntity(event);
+
+  let registry = new OracleRegistry(event.address);
+  registry.admin = event.params.sender;
+  registry.save();
+}
+
+export function handleOracleSet(event: OracleSet): void {
+  createTransactionEntity(event);
+
+  let mappingId = oracleMappingId(event.address, event.params.vault);
+  let mapping = OracleMapping.load(mappingId);
+  if (mapping == null) {
+    mapping = new OracleMapping(mappingId);
+    mapping.registry = event.address;
+    mapping.vault = event.params.vault;
+  }
+  mapping.oracle = event.params.newOracle;
+  mapping.save();
+
+  let change = new OracleChange(eventId(event));
+  change.mapping = mappingId;
+  change.vault = event.params.vault;
+  change.oldOracle = event.params.oldOracle;
+  change.newOracle = event.params.newOracle;
+  change.timestamp = event.block.timestamp;
+  change.transaction = event.transaction.hash;
+  change.save();
+}
+
+export function handleAdminSet(event: AdminSet): void {
+  createTransactionEntity(event);
+
+  let registry = OracleRegistry.load(event.address);
+  if (registry != null) {
+    registry.admin = event.params.newAdmin;
+    registry.save();
+  }
+
+  let change = new AdminChange(adminEventId(event));
+  change.registry = event.address;
+  change.oldAdmin = event.params.oldAdmin;
+  change.newAdmin = event.params.newAdmin;
+  change.timestamp = event.block.timestamp;
+  change.transaction = event.transaction.hash;
+  change.save();
+}

--- a/subgraph/src/transaction.ts
+++ b/subgraph/src/transaction.ts
@@ -1,0 +1,14 @@
+import { ethereum } from "@graphprotocol/graph-ts";
+import { Transaction } from "../generated/schema";
+
+export function createTransactionEntity(event: ethereum.Event): Transaction {
+  let tx = Transaction.load(event.transaction.hash);
+  if (tx == null) {
+    tx = new Transaction(event.transaction.hash);
+    tx.timestamp = event.block.timestamp;
+    tx.blockNumber = event.block.number;
+    tx.from = event.transaction.from;
+    tx.save();
+  }
+  return tx;
+}

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -1,0 +1,32 @@
+specVersion: "0.0.4"
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: OracleRegistry
+    network: base
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: OracleRegistry
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - OracleRegistry
+        - OracleMapping
+        - OracleChange
+        - AdminChange
+        - Transaction
+      abis:
+        - name: OracleRegistry
+          file: ../out/OracleRegistry.sol/OracleRegistry.json
+      eventHandlers:
+        - event: OracleRegistryInitialized(indexed address,(address))
+          handler: handleOracleRegistryInitialized
+        - event: OracleSet(indexed address,indexed address,indexed address)
+          handler: handleOracleSet
+        - event: AdminSet(indexed address,indexed address)
+          handler: handleAdminSet
+      file: ./src/handlers.ts

--- a/subgraph/tests/event-mocks.test.ts
+++ b/subgraph/tests/event-mocks.test.ts
@@ -1,0 +1,65 @@
+import { newMockEvent } from "matchstick-as";
+import { ethereum, Address, Bytes } from "@graphprotocol/graph-ts";
+import {
+  OracleSet,
+  AdminSet,
+} from "../generated/OracleRegistry/OracleRegistry";
+import { createTransactionEntity } from "../src/transaction";
+
+export function createOracleSetEvent(
+  vault: Address,
+  oldOracle: Address,
+  newOracle: Address
+): OracleSet {
+  let mockEvent = newMockEvent();
+  let event = new OracleSet(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null
+  );
+  event.parameters = new Array();
+  event.parameters.push(
+    new ethereum.EventParam("vault", ethereum.Value.fromAddress(vault))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("oldOracle", ethereum.Value.fromAddress(oldOracle))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("newOracle", ethereum.Value.fromAddress(newOracle))
+  );
+
+  createTransactionEntity(event);
+  return event;
+}
+
+export function createAdminSetEvent(
+  oldAdmin: Address,
+  newAdmin: Address
+): AdminSet {
+  let mockEvent = newMockEvent();
+  let event = new AdminSet(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null
+  );
+  event.parameters = new Array();
+  event.parameters.push(
+    new ethereum.EventParam("oldAdmin", ethereum.Value.fromAddress(oldAdmin))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("newAdmin", ethereum.Value.fromAddress(newAdmin))
+  );
+
+  createTransactionEntity(event);
+  return event;
+}

--- a/subgraph/tests/handlers/handle-oracle-set.test.ts
+++ b/subgraph/tests/handlers/handle-oracle-set.test.ts
@@ -1,0 +1,58 @@
+import {
+  test,
+  assert,
+  clearStore,
+  describe,
+  afterEach,
+} from "matchstick-as";
+import { Address } from "@graphprotocol/graph-ts";
+import { createOracleSetEvent } from "../event-mocks.test";
+import { handleOracleSet } from "../../src/handlers";
+import { OracleMapping } from "../../generated/schema";
+
+let VAULT = Address.fromString(
+  "0x5cDa0E1CA4ce2af96315f7F8963C85399c172204"
+);
+let OLD_ORACLE = Address.fromString(
+  "0x0000000000000000000000000000000000000000"
+);
+let NEW_ORACLE = Address.fromString(
+  "0x1C63889a9FAd36C6a4422B3dAFCD57b11deC73d8"
+);
+
+describe("Handle OracleSet", () => {
+  afterEach(() => {
+    clearStore();
+  });
+
+  test("handleOracleSet() creates mapping and change", () => {
+    let event = createOracleSetEvent(VAULT, OLD_ORACLE, NEW_ORACLE);
+    handleOracleSet(event);
+
+    // Should create an OracleMapping
+    assert.entityCount("OracleMapping", 1);
+
+    // Should create an OracleChange
+    assert.entityCount("OracleChange", 1);
+
+    // Should create a Transaction
+    assert.entityCount("Transaction", 1);
+  });
+
+  test("handleOracleSet() updates existing mapping", () => {
+    let event1 = createOracleSetEvent(VAULT, OLD_ORACLE, NEW_ORACLE);
+    handleOracleSet(event1);
+
+    let NEWER_ORACLE = Address.fromString(
+      "0x9e775f2ab11e49e18924379a31502a8b593bbec7"
+    );
+    let event2 = createOracleSetEvent(VAULT, NEW_ORACLE, NEWER_ORACLE);
+    handleOracleSet(event2);
+
+    // Still one mapping (updated in place)
+    assert.entityCount("OracleMapping", 1);
+
+    // But two changes
+    assert.entityCount("OracleChange", 2);
+  });
+});


### PR DESCRIPTION
## What

Scaffolds a subgraph for the st0x oracle system, following the same pattern as rain.orderbook.

### Schema
- **OracleRegistry** — tracks the registry instance and current admin
- **OracleMapping** — vault-to-oracle mappings (current state)
- **OracleChange** — immutable history of oracle changes per vault
- **AdminChange** — immutable history of admin changes
- **Transaction** — block/timestamp metadata

### Handlers
Indexes three OracleRegistry events:
- `OracleRegistryInitialized` — creates the registry entity
- `OracleSet` — creates/updates oracle mappings, records change history
- `AdminSet` — updates registry admin, records change history

### Tests
One matchstick test file with two cases:
1. Creates mapping and change entities on OracleSet
2. Updates existing mapping on subsequent OracleSet calls

### CI
New `subgraph-test.yaml` workflow runs on push:
1. Nix setup + sol prelude (for ABIs)
2. npm install + graph codegen
3. graph test -d (matchstick via docker)

### Next Steps
- Add deployer + adapter event indexing
- Deploy workflow (Goldsky or similar)
- Expand test coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a subgraph exposing Oracle Registry entities for querying oracle mappings, oracle change history, admin changes, and transaction metadata.

* **Chores**
  * Added automated workflow for subgraph testing and code generation.
  * Added local development tooling and configuration for running subgraph tests and matchstick.

* **Tests**
  * Added unit tests and event mocks validating OracleSet and AdminSet handling and change recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->