### PR TITLE
feat: add manual Goldsky deploy workflow for subgraph

### DIFF
--- a/.github/workflows/deploy-subgraph.yaml
+++ b/.github/workflows/deploy-subgraph.yaml
@@ -49,7 +49,9 @@ jobs:
         run: nix develop -c bash -c "cd subgraph && npx graph build --network ${{ inputs.network }}"
 
       - name: Login to Goldsky
-        run: nix develop -c goldsky login --token ${{ secrets.CI_GOLDSKY_TOKEN }}
+        env:
+          GOLDSKY_TOKEN: ${{ secrets.CI_GOLDSKY_TOKEN }}
+        run: nix develop -c goldsky login --token "$GOLDSKY_TOKEN"
 
       - name: Check repo is clean
         run: git diff --exit-code -- . ':(exclude)subgraph/subgraph.yaml'

--- a/.github/workflows/deploy-subgraph.yaml
+++ b/.github/workflows/deploy-subgraph.yaml
@@ -1,0 +1,61 @@
+name: Deploy subgraph
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to deploy to"
+        required: true
+        type: choice
+        options:
+          - base
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+
+      - run: nix develop -c rainix-sol-prelude
+
+      - name: Install subgraph dependencies
+        run: nix develop -c bash -c "cd subgraph && npm install"
+
+      - name: Codegen
+        run: nix develop -c bash -c "cd subgraph && npx graph codegen"
+
+      - name: Build
+        run: nix develop -c bash -c "cd subgraph && npx graph build --network ${{ inputs.network }}"
+
+      - name: Login to Goldsky
+        run: nix develop -c goldsky login --token ${{ secrets.CI_GOLDSKY_TOKEN }}
+
+      - name: Check repo is clean
+        run: git diff --exit-code -- . ':(exclude)subgraph/subgraph.yaml'
+
+      - name: Deploy to Goldsky
+        run: >
+          nix develop -c goldsky subgraph deploy
+          "st0x-oracle-${{ inputs.network }}/$(date -Idate)-$(openssl rand -hex 2)"
+        working-directory: subgraph


### PR DESCRIPTION
Manual dispatch workflow for deploying the subgraph to Goldsky.

### Usage
1. Go to Actions → Deploy subgraph → Run workflow
2. Select network (base)
3. Click Run

### What it does
1. Checkout + nix setup + sol prelude (builds ABIs)
2. `npm install` + `graph codegen` + `graph build --network {network}`
3. `goldsky login` + `goldsky subgraph deploy st0x-oracle-{network}/{date}-{hex}`

### Required secret
- `CI_GOLDSKY_TOKEN` — Goldsky API token

Follows the same pattern as rain.orderbook's deploy-subgraph workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new manual deployment workflow for the subgraph, letting maintainers trigger deployments to a chosen network.
  * Ensures consistent, repeatable builds and faster runs via caching and reproducible build steps.
  * Verifies a clean repository state before deploying and publishes deployments with unique, timestamped identifiers for traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->