### PR TITLE
refactor: use rain.math.float throughout vault share price calculation

### DIFF
--- a/src/abstract/BasePythOracleAdapter.sol
+++ b/src/abstract/BasePythOracleAdapter.sol
@@ -155,9 +155,9 @@ abstract contract BasePythOracleAdapter is AggregatorV3Interface {
         Float supplyFloat = LibDecimalFloat.fromFixedDecimalLosslessPacked(totalSupply, 0);
         Float vaultSharePriceFloat = LibDecimalFloat.div(LibDecimalFloat.mul(priceFloat, assetsFloat), supplyFloat);
 
-        // slither-disable-next-line unused-return
         // The second return (bool lossy) is intentionally ignored — lossy
         // conversion is expected and acceptable when scaling to 8 decimals.
+        // slither-disable-next-line unused-return
         (uint256 price8,) = LibDecimalFloat.toFixedDecimalLossy(vaultSharePriceFloat, 8);
 
         if (price8 == 0) revert ZeroVaultSharePrice();

--- a/src/abstract/BasePythOracleAdapter.sol
+++ b/src/abstract/BasePythOracleAdapter.sol
@@ -72,7 +72,7 @@ abstract contract BasePythOracleAdapter is AggregatorV3Interface {
     // slither-disable-next-line pyth-unchecked-confidence
     function latestAnswer() external view override returns (int256) {
         _validateNotPaused();
-        // Confidence is checked in _vaultSharePrice -> _conservativeScaledPrice
+        // Confidence is checked in _vaultSharePrice -> _conservativePriceFloat
         PythStructs.Price memory priceData = _getPriceData();
         return _vaultSharePrice(priceData);
     }
@@ -86,7 +86,7 @@ abstract contract BasePythOracleAdapter is AggregatorV3Interface {
         returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
         _validateNotPaused();
-        // Confidence is checked in _vaultSharePrice -> _conservativeScaledPrice
+        // Confidence is checked in _vaultSharePrice -> _conservativePriceFloat
         PythStructs.Price memory priceData = _getPriceData();
         int256 scaledPrice = _vaultSharePrice(priceData);
 
@@ -117,31 +117,29 @@ abstract contract BasePythOracleAdapter is AggregatorV3Interface {
         if (paused) revert OraclePaused();
     }
 
-    /// @dev Computes conservative price (price - confidence) and scales to 8
-    /// decimals using LibDecimalFloat. Reverts if the conservative price is not
-    /// positive.
+    /// @dev Computes conservative price (price - confidence) as a Rain Float.
+    /// Reverts if the conservative price is not positive.
     /// @param priceData The Pyth price data.
-    /// @return The conservative price scaled to 8 decimals.
-    function _conservativeScaledPrice(PythStructs.Price memory priceData) internal pure returns (int256) {
+    /// @return The conservative price as a Rain Float.
+    function _conservativePriceFloat(PythStructs.Price memory priceData) internal pure returns (Float) {
         // slither-disable-next-line pyth-unchecked-confidence
         int256 conservativePrice = int256(priceData.price) - int256(uint256(priceData.conf));
         if (conservativePrice <= 0) {
             revert NonPositivePrice(conservativePrice);
         }
-        Float conservativePriceFloat = LibDecimalFloat.packLossless(conservativePrice, int256(priceData.expo));
-        //slither-disable-next-line unused-return
-        (uint256 price8,) = LibDecimalFloat.toFixedDecimalLossy(conservativePriceFloat, 8);
-        return int256(price8);
+        return LibDecimalFloat.packLossless(conservativePrice, int256(priceData.expo));
     }
 
-    /// @dev Computes the vault share price by multiplying the conservative
-    /// Pyth price by the vault's assets-per-share ratio.
-    /// vaultSharePrice = pythPrice8 * totalAssets / totalSupply
+    /// @dev Computes the vault share price using Rain float arithmetic
+    /// throughout to avoid overflow. The conservative Pyth price is multiplied
+    /// by the vault's assets-per-share ratio entirely in float space, then
+    /// converted to 8-decimal fixed point only at the end.
+    /// vaultSharePrice = conservativePrice * totalAssets / totalSupply
     /// Reverts if the vault has zero total supply.
     /// @param priceData The Pyth price data.
     /// @return The vault share price at 8 decimals.
     function _vaultSharePrice(PythStructs.Price memory priceData) internal view returns (int256) {
-        int256 price8 = _conservativeScaledPrice(priceData);
+        Float priceFloat = _conservativePriceFloat(priceData);
 
         IERC4626 vaultContract = IERC4626(vault);
         uint256 totalAssets = vaultContract.totalAssets();
@@ -149,10 +147,16 @@ abstract contract BasePythOracleAdapter is AggregatorV3Interface {
 
         if (totalSupply == 0) revert ZeroVaultSupply();
 
-        int256 vaultSharePrice = int256(uint256(price8) * totalAssets / totalSupply);
+        // Perform vault ratio multiplication entirely in float space.
+        Float assetsFloat = LibDecimalFloat.fromFixedDecimalLosslessPacked(totalAssets, 0);
+        Float supplyFloat = LibDecimalFloat.fromFixedDecimalLosslessPacked(totalSupply, 0);
+        Float vaultSharePriceFloat = LibDecimalFloat.div(LibDecimalFloat.mul(priceFloat, assetsFloat), supplyFloat);
 
-        if (vaultSharePrice == 0) revert ZeroVaultSharePrice();
+        //slither-disable-next-line unused-return
+        (uint256 price8,) = LibDecimalFloat.toFixedDecimalLossy(vaultSharePriceFloat, 8);
 
-        return vaultSharePrice;
+        if (price8 == 0) revert ZeroVaultSharePrice();
+
+        return int256(price8);
     }
 }

--- a/src/abstract/BasePythOracleAdapter.sol
+++ b/src/abstract/BasePythOracleAdapter.sol
@@ -29,6 +29,9 @@ error ZeroVaultSupply();
 /// @dev Error raised when the computed vault share price is zero.
 error ZeroVaultSharePrice();
 
+/// @dev Error raised when the vault share price overflows int256.
+error VaultSharePriceOverflow(uint256 price8);
+
 /// @title BasePythOracleAdapter
 /// @notice Abstract base for Pyth oracle adapters that price ERC-4626 vault
 /// shares. Provides shared logic for conservative pricing, vault share price
@@ -152,10 +155,13 @@ abstract contract BasePythOracleAdapter is AggregatorV3Interface {
         Float supplyFloat = LibDecimalFloat.fromFixedDecimalLosslessPacked(totalSupply, 0);
         Float vaultSharePriceFloat = LibDecimalFloat.div(LibDecimalFloat.mul(priceFloat, assetsFloat), supplyFloat);
 
-        //slither-disable-next-line unused-return
+        // slither-disable-next-line unused-return
+        // The second return (bool lossy) is intentionally ignored — lossy
+        // conversion is expected and acceptable when scaling to 8 decimals.
         (uint256 price8,) = LibDecimalFloat.toFixedDecimalLossy(vaultSharePriceFloat, 8);
 
         if (price8 == 0) revert ZeroVaultSharePrice();
+        if (price8 > uint256(type(int256).max)) revert VaultSharePriceOverflow(price8);
 
         return int256(price8);
     }

--- a/src/concrete/oracle/MultiPythOracleAdapter.sol
+++ b/src/concrete/oracle/MultiPythOracleAdapter.sol
@@ -143,7 +143,7 @@ contract MultiPythOracleAdapter is BasePythOracleAdapter, ICloneableV2, Initiali
     /// @inheritdoc BasePythOracleAdapter
     // Slither false positives:
     // - pyth-unchecked-confidence: confidence is checked downstream in
-    //   _conservativeScaledPrice (price - conf).
+    //   _conservativePriceFloat (price - conf).
     // - calls-inside-a-loop: intentional cascading design — max 8 iterations,
     //   each calling the immutable Pyth contract. Not a reentrancy risk.
     // slither-disable-next-line calls-loop
@@ -165,7 +165,7 @@ contract MultiPythOracleAdapter is BasePythOracleAdapter, ICloneableV2, Initiali
     /// @dev Attempts to get a price from Pyth, returning success flag.
     /// Extracted to avoid slither's pyth-unchecked-confidence detector
     /// crashing on try/catch with Pyth calls (slither bug).
-    /// Confidence IS checked downstream in _conservativeScaledPrice.
+    /// Confidence IS checked downstream in _conservativePriceFloat.
     // slither-disable-next-line pyth-unchecked-confidence,calls-loop
     function _tryGetPrice(IPyth pyth, bytes32 feedPriceId, uint256 feedMaxAge)
         internal


### PR DESCRIPTION
## Motivation

The existing `_vaultSharePrice` calculation uses fixed-point integer math (`price * totalAssets / totalSupply`) which can overflow for large values. Rain float arithmetic (224-bit coefficient) eliminates this risk entirely.

## Solution

- Replace `_conservativeScaledPrice` (returns `int256`) with `_conservativePriceFloat` (returns `Float`)
- Perform vault ratio math entirely in Rain float space: `price * assets / supply`
- Convert to 8-decimal fixed point only at the final output step
- Add explicit overflow and zero-result guards
- AggregatorV3Interface output is unchanged — internal refactor only

## Checks

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to a front-end/dashboard)