### PR TITLE
docs: add production update runbook to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,52 +118,44 @@ All production addresses are hardcoded in `src/lib/LibProdDeploy.sol`. The oracl
 
 ### Update Runbook
 
-When oracle adapter logic changes (e.g. price calculation, float math), the beacon implementation must be upgraded and the subgraph redeployed. Follow these steps:
+There are two paths depending on whether existing proxies are live in production.
 
-#### 1. Deploy new implementation
+#### Path A: Fresh deploy (pre-production / no live consumers)
 
-Deploy a new `PythOracleAdapter` (or `MultiPythOracleAdapter`) implementation contract via the forge deploy script:
+When there are no live integrations depending on existing proxy addresses, it's simpler to redeploy everything from scratch.
 
-```bash
-DEPLOYMENT_KEY=<key> nix develop -c forge script script/Deploy.sol \
-  --sig "deployPythOracleAdapterBeaconSet(uint256)" $DEPLOYMENT_KEY \
-  --rpc-url <base-rpc> --broadcast --verify
-```
+1. **Redeploy all beacon set deployers** — run the full deploy script to get fresh deployer + implementation contracts:
+   ```bash
+   DEPLOYMENT_KEY=<key> nix develop -c forge script script/Deploy.sol \
+     --sig "deployAll(uint256)" $DEPLOYMENT_KEY \
+     --rpc-url <base-rpc> --broadcast --verify
+   ```
+2. **Deploy a new OracleRegistry** — if the registry ABI changed, or to start clean
+3. **Update `LibProdDeploy.sol`** — replace all address constants with the new deployments, with date + run ID comments
+4. **Re-register vault oracles** — call `registry.setOracle()` (or `setOracleBulk()`) for each vault
+5. **Update the front end** — new contract addresses, ABIs, and subgraph endpoint in st0x.io
+6. **Redeploy the subgraph** — trigger the "Deploy subgraph" workflow (GitHub Actions, network: `base`). Update `subgraph.yaml` with new contract addresses if they changed
+7. **Verify** — check `latestRoundData()` on a proxy and confirm the subgraph is indexing
 
-Record the new deployer address from the broadcast output.
+#### Path B: Production upgrade (live proxies serving consumers)
 
-#### 2. Upgrade the beacon
+When existing proxies are live and their addresses are referenced by external protocols (Morpho, Aave, etc.), use the beacon upgrade path to avoid changing addresses.
 
-Call `upgradeTo(newImplementation)` on the existing beacon (owned by the multisig at `0x8E4b...9f5b`). This upgrades all existing proxy instances in-place — no per-vault redeployment needed.
-
-#### 3. Update `LibProdDeploy.sol`
-
-Update the relevant address constant(s) and add a comment with the deployment date and CI run ID:
-
-```solidity
-/// Re-deployed to Base YYYY-MM-DD. Run: <run-id>.
-address constant PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER = 0x...;
-```
-
-#### 4. Verify on-chain
-
-Confirm the upgrade took effect:
-
-```bash
-cast call <any-existing-proxy> "latestRoundData()(uint80,int256,uint256,uint256,uint80)" --rpc-url <base-rpc>
-```
-
-#### 5. Update the front end
-
-If the ABI or contract addresses changed, update the front end (st0x.io) to reference the new deployment. This includes any ABI imports, contract address constants, and subgraph query endpoints.
-
-#### 6. Redeploy the subgraph
-
-Trigger the "Deploy subgraph" workflow from GitHub Actions (workflow_dispatch, network: `base`). This picks up any ABI changes and reindexes from the existing contract addresses.
-
-#### 7. Verify the subgraph
-
-Check the Goldsky dashboard or query the subgraph endpoint to confirm data is flowing correctly after redeployment.
+1. **Deploy new implementation** — deploy a new `PythOracleAdapter` (or `MultiPythOracleAdapter`) implementation:
+   ```bash
+   DEPLOYMENT_KEY=<key> nix develop -c forge script script/Deploy.sol \
+     --sig "deployPythOracleAdapterBeaconSet(uint256)" $DEPLOYMENT_KEY \
+     --rpc-url <base-rpc> --broadcast --verify
+   ```
+2. **Upgrade the beacon** — call `upgradeTo(newImplementation)` on the existing beacon (owned by the multisig at `0x8E4b...9f5b`). All existing proxy instances upgrade in-place — no per-vault redeployment needed
+3. **Update `LibProdDeploy.sol`** — update the relevant deployer address constant with date + run ID
+4. **Verify on-chain** — confirm the upgrade took effect:
+   ```bash
+   cast call <any-existing-proxy> "latestRoundData()(uint80,int256,uint256,uint256,uint80)" --rpc-url <base-rpc>
+   ```
+5. **Update the front end** — if ABIs changed, update st0x.io. Contract addresses stay the same
+6. **Redeploy the subgraph** — trigger the "Deploy subgraph" workflow to pick up ABI changes
+7. **Verify the subgraph** — check Goldsky dashboard or query the endpoint to confirm data is flowing
 
 ### Adding a new vault oracle
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ When there are no live integrations depending on existing proxy addresses, it's 
 2. **Deploy a new OracleRegistry** — if the registry ABI changed, or to start clean
 3. **Update `LibProdDeploy.sol`** — replace all address constants with the new deployments, with date + run ID comments
 4. **Re-register vault oracles** — call `registry.setOracle()` (or `setOracleBulk()`) for each vault
-5. **Update the front end** — new contract addresses, ABIs, and subgraph endpoint in [sft-tokenisation](https://github.com/h20liquidity/sft-tokenisation)
+5. **Update the front end** — update the subgraph URL in [sft-tokenisation](https://github.com/h20liquidity/sft-tokenisation) to point to the new subgraph deployment
 6. **Redeploy the subgraph** — trigger the "Deploy subgraph" workflow (GitHub Actions, network: `base`). Update `subgraph.yaml` with new contract addresses if they changed
 7. **Verify** — check `latestRoundData()` on a proxy and confirm the subgraph is indexing
 
@@ -153,7 +153,7 @@ When existing proxies are live and their addresses are referenced by external pr
    ```bash
    cast call <any-existing-proxy> "latestRoundData()(uint80,int256,uint256,uint256,uint80)" --rpc-url <base-rpc>
    ```
-5. **Update the front end** — update the subgraph URL in [sft-tokenisation](https://github.com/h20liquidity/sft-tokenisation) (contract addresses stay the same but the subgraph is redeployed with a new versioned name). Update ABIs if the interface changed
+5. **Update the front end** — update the subgraph URL in [sft-tokenisation](https://github.com/h20liquidity/sft-tokenisation) to point to the new subgraph deployment
 6. **Redeploy the subgraph** — trigger the "Deploy subgraph" workflow to pick up ABI changes
 7. **Verify the subgraph** — check Goldsky dashboard or query the endpoint to confirm data is flowing
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ When there are no live integrations depending on existing proxy addresses, it's 
 2. **Deploy a new OracleRegistry** — if the registry ABI changed, or to start clean
 3. **Update `LibProdDeploy.sol`** — replace all address constants with the new deployments, with date + run ID comments
 4. **Re-register vault oracles** — call `registry.setOracle()` (or `setOracleBulk()`) for each vault
-5. **Update the front end** — new contract addresses, ABIs, and subgraph endpoint in st0x.io
+5. **Update the front end** — new contract addresses, ABIs, and subgraph endpoint in [sft-tokenisation](https://github.com/h20liquidity/sft-tokenisation)
 6. **Redeploy the subgraph** — trigger the "Deploy subgraph" workflow (GitHub Actions, network: `base`). Update `subgraph.yaml` with new contract addresses if they changed
 7. **Verify** — check `latestRoundData()` on a proxy and confirm the subgraph is indexing
 
@@ -153,7 +153,7 @@ When existing proxies are live and their addresses are referenced by external pr
    ```bash
    cast call <any-existing-proxy> "latestRoundData()(uint80,int256,uint256,uint256,uint80)" --rpc-url <base-rpc>
    ```
-5. **Update the front end** — if ABIs changed, update st0x.io. Contract addresses stay the same
+5. **Update the front end** — if ABIs changed, update [sft-tokenisation](https://github.com/h20liquidity/sft-tokenisation). Contract addresses stay the same
 6. **Redeploy the subgraph** — trigger the "Deploy subgraph" workflow to pick up ABI changes
 7. **Verify the subgraph** — check Goldsky dashboard or query the endpoint to confirm data is flowing
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ When existing proxies are live and their addresses are referenced by external pr
    ```bash
    cast call <any-existing-proxy> "latestRoundData()(uint80,int256,uint256,uint256,uint80)" --rpc-url <base-rpc>
    ```
-5. **Update the front end** — if ABIs changed, update [sft-tokenisation](https://github.com/h20liquidity/sft-tokenisation). Contract addresses stay the same
+5. **Update the front end** — update the subgraph URL in [sft-tokenisation](https://github.com/h20liquidity/sft-tokenisation) (contract addresses stay the same but the subgraph is redeployed with a new versioned name). Update ABIs if the interface changed
 6. **Redeploy the subgraph** — trigger the "Deploy subgraph" workflow to pick up ABI changes
 7. **Verify the subgraph** — check Goldsky dashboard or query the endpoint to confirm data is flowing
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,63 @@ test/
         └── protocol/
 ```
 
+## Production Deployment (Base)
+
+All production addresses are hardcoded in `src/lib/LibProdDeploy.sol`. The oracle registry is at `0x36a14d00a8597731fb6dB1e0e7EeA0BB81ffD156`.
+
+### Update Runbook
+
+When oracle adapter logic changes (e.g. price calculation, float math), the beacon implementation must be upgraded and the subgraph redeployed. Follow these steps:
+
+#### 1. Deploy new implementation
+
+Deploy a new `PythOracleAdapter` (or `MultiPythOracleAdapter`) implementation contract via the forge deploy script:
+
+```bash
+DEPLOYMENT_KEY=<key> nix develop -c forge script script/Deploy.sol \
+  --sig "deployPythOracleAdapterBeaconSet(uint256)" $DEPLOYMENT_KEY \
+  --rpc-url <base-rpc> --broadcast --verify
+```
+
+Record the new deployer address from the broadcast output.
+
+#### 2. Upgrade the beacon
+
+Call `upgradeTo(newImplementation)` on the existing beacon (owned by the multisig at `0x8E4b...9f5b`). This upgrades all existing proxy instances in-place — no per-vault redeployment needed.
+
+#### 3. Update `LibProdDeploy.sol`
+
+Update the relevant address constant(s) and add a comment with the deployment date and CI run ID:
+
+```solidity
+/// Re-deployed to Base YYYY-MM-DD. Run: <run-id>.
+address constant PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER = 0x...;
+```
+
+#### 4. Verify on-chain
+
+Confirm the upgrade took effect:
+
+```bash
+cast call <any-existing-proxy> "latestRoundData()(uint80,int256,uint256,uint256,uint80)" --rpc-url <base-rpc>
+```
+
+#### 5. Redeploy the subgraph
+
+Trigger the "Deploy subgraph" workflow from GitHub Actions (workflow_dispatch, network: `base`). This picks up any ABI changes and reindexes from the existing contract addresses.
+
+#### 6. Verify the subgraph
+
+Check the Goldsky dashboard or query the subgraph endpoint to confirm data is flowing correctly after redeployment.
+
+### Adding a new vault oracle
+
+To deploy oracle + protocol adapters for a new vault:
+
+1. Call `OracleUnifiedDeployer.deploy(...)` (or `MultiOracleUnifiedDeployer` for multi-feed) with the vault address, Pyth feed ID(s), and protocol adapter config
+2. Call `OracleRegistry.setOracle(vault, oracleAdapter)` from the registry admin to register the new oracle
+3. Redeploy the subgraph to index the new contracts
+
 ## Dependencies
 
 - [rain.pyth](https://github.com/rainlanguage/rain.pyth) -- `LibPyth.getPriceFeedContract()` and price feed ID constants

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ test/
 
 ## Production Deployment (Base)
 
-All production addresses are hardcoded in `src/lib/LibProdDeploy.sol`. The oracle registry is at `0x36a14d00a8597731fb6dB1e0e7EeA0BB81ffD156`.
+All production addresses are hardcoded in `src/lib/LibProdDeploy.sol`.
 
 ### Update Runbook
 

--- a/README.md
+++ b/README.md
@@ -153,11 +153,15 @@ Confirm the upgrade took effect:
 cast call <any-existing-proxy> "latestRoundData()(uint80,int256,uint256,uint256,uint80)" --rpc-url <base-rpc>
 ```
 
-#### 5. Redeploy the subgraph
+#### 5. Update the front end
+
+If the ABI or contract addresses changed, update the front end (st0x.io) to reference the new deployment. This includes any ABI imports, contract address constants, and subgraph query endpoints.
+
+#### 6. Redeploy the subgraph
 
 Trigger the "Deploy subgraph" workflow from GitHub Actions (workflow_dispatch, network: `base`). This picks up any ABI changes and reindexes from the existing contract addresses.
 
-#### 6. Verify the subgraph
+#### 7. Verify the subgraph
 
 Check the Goldsky dashboard or query the subgraph endpoint to confirm data is flowing correctly after redeployment.
 

--- a/README.md
+++ b/README.md
@@ -124,12 +124,20 @@ There are two paths depending on whether existing proxies are live in production
 
 When there are no live integrations depending on existing proxy addresses, it's simpler to redeploy everything from scratch.
 
-1. **Redeploy all beacon set deployers** — run the full deploy script to get fresh deployer + implementation contracts:
+1. **Redeploy required suites** — run `script/Deploy.sol` once per suite via the `DEPLOYMENT_SUITE` env var:
    ```bash
-   DEPLOYMENT_KEY=<key> nix develop -c forge script script/Deploy.sol \
-     --sig "deployAll(uint256)" $DEPLOYMENT_KEY \
+   export DEPLOYMENT_KEY=<key>
+   export DEPLOYMENT_SUITE=pyth-oracle-adapter-beacon-set
+   nix develop -c forge script script/Deploy.sol \
      --rpc-url <base-rpc> --broadcast --verify
    ```
+   Repeat for each suite as needed:
+   - `morpho-protocol-adapter-beacon-set`
+   - `passthrough-protocol-adapter-beacon-set`
+   - `oracle-unified-deployer`
+   - `oracle-registry-beacon-set`
+   - `multi-pyth-oracle-adapter-beacon-set`
+   - `multi-oracle-unified-deployer`
 2. **Deploy a new OracleRegistry** — if the registry ABI changed, or to start clean
 3. **Update `LibProdDeploy.sol`** — replace all address constants with the new deployments, with date + run ID comments
 4. **Re-register vault oracles** — call `registry.setOracle()` (or `setOracleBulk()`) for each vault
@@ -141,13 +149,15 @@ When there are no live integrations depending on existing proxy addresses, it's 
 
 When existing proxies are live and their addresses are referenced by external protocols (Morpho, Aave, etc.), use the beacon upgrade path to avoid changing addresses.
 
-1. **Deploy new implementation** — deploy a new `PythOracleAdapter` (or `MultiPythOracleAdapter`) implementation:
+1. **Deploy new implementation** — run the matching suite:
    ```bash
-   DEPLOYMENT_KEY=<key> nix develop -c forge script script/Deploy.sol \
-     --sig "deployPythOracleAdapterBeaconSet(uint256)" $DEPLOYMENT_KEY \
+   export DEPLOYMENT_KEY=<key>
+   export DEPLOYMENT_SUITE=pyth-oracle-adapter-beacon-set
+   nix develop -c forge script script/Deploy.sol \
      --rpc-url <base-rpc> --broadcast --verify
    ```
-2. **Upgrade the beacon** — call `upgradeTo(newImplementation)` on the existing beacon (owned by the multisig at `0x8E4b...9f5b`). All existing proxy instances upgrade in-place — no per-vault redeployment needed
+   Use `multi-pyth-oracle-adapter-beacon-set` for multi-feed adapters.
+2. **Upgrade the beacon** — call `upgradeTo(newImplementation)` on the existing beacon from the current beacon owner (see `BEACON_INITIAL_OWNER` in `LibProdDeploy.sol`). All existing proxy instances upgrade in-place — no per-vault redeployment needed
 3. **Update `LibProdDeploy.sol`** — update the relevant deployer address constant with date + run ID
 4. **Verify on-chain** — confirm the upgrade took effect:
    ```bash


### PR DESCRIPTION
## Motivation

No documented process for what needs to happen when oracle adapter logic changes. Easy to miss steps (beacon upgrade, subgraph redeploy, address updates).

## Solution

Adds an "Update Runbook" section to the README covering:
1. Deploy new implementation
2. Upgrade the beacon (multisig)
3. Update `LibProdDeploy.sol` addresses
4. Verify on-chain
5. Redeploy the subgraph
6. Verify the subgraph

Also documents the process for adding a new vault oracle.

## Checks

- [ ] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to a front-end/dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive "Production Deployment (Base)" runbook describing two deployment flows: full redeploy and in-place production upgrade that preserves existing addresses, with step-by-step deployment and verification guidance.
  * Added a procedure for registering and deploying new vault oracles and guidance for updating front-end/subgraph endpoints and reindexing.
  * Documentation-only change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->