### PR TITLE
chore: bump st0x.deploy submodule for ICorporateActionsV1

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -16,7 +16,8 @@ remappings = [
     "openzeppelin-contracts/=lib/openzeppelin-contracts/",
     "pyth-sdk/=lib/rain.pyth/lib/pyth-crosschain/target_chains/ethereum/sdk/solidity/",
     "rain.pyth/=lib/rain.pyth/",
-    "rain.factory/=lib/st0x.deploy/lib/ethgild/lib/rain.factory/src/",
+    "rain.factory/=lib/st0x.deploy/lib/rain.vats/lib/rain.factory/src/",
+    "st0x.deploy/=lib/st0x.deploy/",
     "src/=src/",
     # Transitive deps (forge doesn't use each lib's own remappings)
     "rain.math.float/=lib/rain.pyth/lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float/src/",


### PR DESCRIPTION
Bumps lib/st0x.deploy from 766b468 to 9955248 (origin/main) and adds the st0x.deploy/= remapping. The newer ref exposes ICorporateActionsV1 — the interface the corporate-action-aware oracle work (RAI-318..328) consumes — along with its supporting libs and the cancelled-node sentinel semantics those rely on.

No functional changes to oracle code in this commit; later PRs in the stack import from the new remapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency mapping configuration to include st0x.deploy.
  * Updated st0x.deploy dependency to a new version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.oracle/pull/20)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->