### PR TITLE
feat(lib): LibCorporateActionsPause reader helper (RAI-319)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ out
 dependencies
 
 .env
+
+.fixes/
+audit/

--- a/foundry.toml
+++ b/foundry.toml
@@ -31,6 +31,12 @@ remappings = [
   # packages instead so transitive resolution works without nested submodules.
   "rain.math.float/=dependencies/rain-math-float-0.1.1/src/",
   "rain.intorastring/=dependencies/rain-intorastring-0.1.0/src/",
+  # rain-tofu-erc20-decimals is a transitive dep of st0x-deploy (via
+  # LibStockSplit). Soldeer's auto-generated remap for this dep points at
+  # `src/` (the dep's `script/` dir confuses its heuristic), but upstream
+  # imports use `rain-tofu-erc20-decimals-0.1.1/src/lib/...`. Override
+  # explicitly so the prefix resolves to the dep root.
+  "rain-tofu-erc20-decimals-0.1.1/=dependencies/rain-tofu-erc20-decimals-0.1.1/",
 ]
 
 [dependencies]
@@ -41,6 +47,7 @@ forge-std = "1.16.1"
 "rain-intorastring" = "0.1.0"
 "st0x-deploy" = "0.1.1"
 "rain-vats" = "0.1.5"
+"rain-tofu-erc20-decimals" = "0.1.1"
 
 [dependencies.rain-pyth]
 # rain-pyth is not yet published to soldeer; consume directly from git, pinned

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -40,6 +40,13 @@ git = "https://github.com/rainlanguage/rain.pyth"
 rev = "e7a45068d5aac93e92aec55d7bf1f58e66319a53"
 
 [[dependencies]]
+name = "rain-tofu-erc20-decimals"
+version = "0.1.1"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-tofu-erc20-decimals/0_1_1_12-05-2026_15:44:19_rain.tofu.zip"
+checksum = "2a48a362ac80a85a8792492fcaf943a86a95009a8aeaced3b50554bbed1e5874"
+integrity = "9e1fccf893dd0d90aeb445c78f9eee3904bc50287ff1da30b954508f18412cd2"
+
+[[dependencies]]
 name = "rain-vats"
 version = "0.1.5"
 url = "https://soldeer-revisions.s3.amazonaws.com/rain-vats/0_1_5_20-05-2026_14:20:38_rain.zip"

--- a/src/lib/LibCorporateActionsPause.sol
+++ b/src/lib/LibCorporateActionsPause.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {ICorporateActionsV1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
+import {CompletionFilter, NODE_NONE} from "st0x-deploy-0.1.1/src/lib/LibCorporateActionNode.sol";
+
+/// @title LibCorporateActionsPause
+/// @notice Helper for oracle adapters that decide whether to auto-pause based
+/// on a vault's `ICorporateActionsV1` schedule. Stateless, view-only.
+///
+/// The decision is the disjunction of two windows around any matching action:
+///
+/// 1. **Pre-window**: The earliest pending action `A` matching the mask, where
+///    `effectiveTime - pauseTimeBefore <= block.timestamp < effectiveTime`.
+///    Earliest pending is the one closest to `now`; if its window doesn't
+///    open yet, no later pending's will either (their effectiveTimes are
+///    strictly larger).
+///
+/// 2. **Post-window**: The latest completed action `A` matching the mask,
+///    where `effectiveTime <= block.timestamp <= effectiveTime + pauseTimeAfter`.
+///    Latest completed is the one closest to `now`; if its window has closed,
+///    no earlier completed's is open (their effectiveTimes are strictly
+///    smaller).
+///
+/// Each query is at most two view calls into the vault. Cancelled action
+/// nodes are unlinked from the traversal API in `LibCorporateAction.cancel`,
+/// so neither `earliestActionOfType` nor `latestActionOfType` will return
+/// them — no explicit filter required here.
+library LibCorporateActionsPause {
+    /// @notice Whether the oracle should auto-pause right now.
+    /// @param corporateActionsVault Address implementing `ICorporateActionsV1`.
+    /// `address(0)` short-circuits to `false` (auto-pause disabled).
+    /// @param mask Bitmap of action types to consider. `0` short-circuits
+    /// to `false` (no action types match anything). `type(uint256).max`
+    /// matches every present and future action type.
+    /// @param pauseTimeBefore Seconds before a pending action's `effectiveTime`
+    /// to start pausing.
+    /// @param pauseTimeAfter Seconds after a completed action's `effectiveTime`
+    /// to keep pausing.
+    /// @return paused True if the current block is inside any pre- or
+    /// post-window of a matching action.
+    /// @return effectiveTime The `effectiveTime` of the action whose window
+    /// is currently open. Zero when `paused` is false. When both a pending
+    /// and a completed action's window contain `now` (e.g. a back-to-back
+    /// schedule), the pending action's `effectiveTime` is returned —
+    /// integrators see the next event coming, not the last one done.
+    function inPauseWindow(address corporateActionsVault, uint256 mask, uint64 pauseTimeBefore, uint64 pauseTimeAfter)
+        internal
+        view
+        returns (bool paused, uint64 effectiveTime)
+    {
+        if (corporateActionsVault == address(0) || mask == 0) {
+            return (false, 0);
+        }
+
+        ICorporateActionsV1 vault = ICorporateActionsV1(corporateActionsVault);
+
+        // slither-disable-next-line unused-return
+        (uint256 pendingCursor,, uint64 pendingEffective) = vault.earliestActionOfType(mask, CompletionFilter.PENDING);
+        // `NODE_NONE = type(uint256).max` is the documented no-match sentinel
+        // from `ICorporateActionsV1` — cursor `0` is a real bootstrap node and
+        // must NOT be treated as "no match".
+        if (pendingCursor != NODE_NONE) {
+            // pendingEffective > now is guaranteed by the PENDING filter.
+            // We compare via addition on uint256-promoted operands so neither
+            // underflow nor overflow is possible for any realistic timestamp.
+            // slither-disable-next-line timestamp
+            if (block.timestamp + uint256(pauseTimeBefore) >= uint256(pendingEffective)) {
+                return (true, pendingEffective);
+            }
+        }
+
+        // slither-disable-next-line unused-return
+        (uint256 completedCursor,, uint64 completedEffective) =
+            vault.latestActionOfType(mask, CompletionFilter.COMPLETED);
+        if (completedCursor != NODE_NONE) {
+            // completedEffective <= now is guaranteed by the COMPLETED filter.
+            // slither-disable-next-line timestamp
+            if (block.timestamp <= uint256(completedEffective) + uint256(pauseTimeAfter)) {
+                return (true, completedEffective);
+            }
+        }
+
+        return (false, 0);
+    }
+}

--- a/test/mocks/MockCorporateActions.sol
+++ b/test/mocks/MockCorporateActions.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {ICorporateActionsV1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
+import {CompletionFilter, NODE_NONE} from "st0x-deploy-0.1.1/src/lib/LibCorporateActionNode.sol";
+
+/// @title MockCorporateActions
+/// @notice Minimal mock of `ICorporateActionsV1` exposing only the two read
+/// paths `LibCorporateActionsPause` consumes. Other interface methods revert
+/// so a regression that calls them is caught loudly.
+///
+/// Setters accept a caller-supplied cursor so tests can exercise both the
+/// no-match sentinel (`NODE_NONE`) and the bootstrap node (cursor 0). Tests
+/// that don't care about cursor can just pass `1`.
+contract MockCorporateActions is ICorporateActionsV1 {
+    struct StubAction {
+        bool exists;
+        uint256 cursor;
+        uint256 actionType;
+        uint64 effectiveTime;
+    }
+
+    StubAction private _earliestPending;
+    StubAction private _latestCompleted;
+
+    function setEarliestPending(uint256 cursor, uint256 actionType, uint64 effectiveTime) external {
+        _earliestPending = StubAction({
+            exists: cursor != NODE_NONE, cursor: cursor, actionType: actionType, effectiveTime: effectiveTime
+        });
+    }
+
+    function setLatestCompleted(uint256 cursor, uint256 actionType, uint64 effectiveTime) external {
+        _latestCompleted = StubAction({
+            exists: cursor != NODE_NONE, cursor: cursor, actionType: actionType, effectiveTime: effectiveTime
+        });
+    }
+
+    function earliestActionOfType(uint256 mask, CompletionFilter filter)
+        external
+        view
+        override
+        returns (uint256, uint256, uint64)
+    {
+        if (filter != CompletionFilter.PENDING) revert("mock: only PENDING supported");
+        if (!_earliestPending.exists) return (NODE_NONE, 0, 0);
+        if (_earliestPending.actionType & mask == 0) return (NODE_NONE, 0, 0);
+        return (_earliestPending.cursor, _earliestPending.actionType, _earliestPending.effectiveTime);
+    }
+
+    function latestActionOfType(uint256 mask, CompletionFilter filter)
+        external
+        view
+        override
+        returns (uint256, uint256, uint64)
+    {
+        if (filter != CompletionFilter.COMPLETED) revert("mock: only COMPLETED supported");
+        if (!_latestCompleted.exists) return (NODE_NONE, 0, 0);
+        if (_latestCompleted.actionType & mask == 0) return (NODE_NONE, 0, 0);
+        return (_latestCompleted.cursor, _latestCompleted.actionType, _latestCompleted.effectiveTime);
+    }
+
+    function scheduleCorporateAction(bytes32, uint64, bytes calldata) external pure override returns (uint256) {
+        revert("mock: not implemented");
+    }
+
+    function cancelCorporateAction(uint256) external pure override {
+        revert("mock: not implemented");
+    }
+
+    function completedActionCount() external pure override returns (uint256) {
+        revert("mock: not implemented");
+    }
+
+    function nextOfType(uint256, uint256, CompletionFilter) external pure override returns (uint256, uint256, uint64) {
+        revert("mock: not implemented");
+    }
+
+    function prevOfType(uint256, uint256, CompletionFilter) external pure override returns (uint256, uint256, uint64) {
+        revert("mock: not implemented");
+    }
+
+    function getActionParameters(uint256) external pure override returns (bytes memory) {
+        revert("mock: not implemented");
+    }
+}

--- a/test/src/lib/LibCorporateActionsPause.t.sol
+++ b/test/src/lib/LibCorporateActionsPause.t.sol
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {NODE_NONE} from "st0x-deploy-0.1.1/src/lib/LibCorporateActionNode.sol";
+import {LibCorporateActionsPause} from "src/lib/LibCorporateActionsPause.sol";
+import {ACTION_TYPE_STOCK_SPLIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
+import {MockCorporateActions} from "test/mocks/MockCorporateActions.sol";
+
+contract LibCorporateActionsPauseTest is Test {
+    MockCorporateActions internal mock;
+    uint64 internal constant BEFORE = 3600;
+    uint64 internal constant AFTER = 3600;
+
+    function setUp() public {
+        mock = new MockCorporateActions();
+        vm.warp(1_000_000);
+    }
+
+    // -------- Disable short-circuits --------
+
+    function testZeroVaultAddressDisablesPause() external {
+        // Even with a fully-armed mock, address(0) returns false without a call.
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 60));
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(0), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, false);
+        assertEq(ts, 0);
+    }
+
+    function testZeroMaskDisablesPause() external {
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 60));
+        (bool paused, uint64 ts) = LibCorporateActionsPause.inPauseWindow(address(mock), 0, BEFORE, AFTER);
+        assertEq(paused, false);
+        assertEq(ts, 0);
+    }
+
+    // -------- No actions --------
+
+    function testNoPendingNoCompletedReturnsFalse() external {
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, false);
+        assertEq(ts, 0);
+    }
+
+    // -------- Pending action / pre-window --------
+
+    function testPendingOutsideBeforeWindowReturnsFalse() external {
+        // Pending action 2h in the future, window is 1h before.
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 2 * BEFORE));
+        (bool paused,) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, false);
+    }
+
+    function testPendingExactlyAtBeforeWindowEdgeReturnsTrue() external {
+        // now + before == effectiveTime: window is closed-open at the start.
+        uint64 effectiveTime = uint64(block.timestamp + BEFORE);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, true);
+        assertEq(ts, effectiveTime);
+    }
+
+    function testPendingInsideBeforeWindowReturnsTrue() external {
+        uint64 effectiveTime = uint64(block.timestamp + BEFORE / 2);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, true);
+        assertEq(ts, effectiveTime);
+    }
+
+    // -------- Completed action / post-window --------
+
+    function testCompletedExactlyAtAfterWindowEdgeReturnsTrue() external {
+        // now == effectiveTime + after: window is inclusive on both ends.
+        uint64 effectiveTime = uint64(block.timestamp - AFTER);
+        mock.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, true);
+        assertEq(ts, effectiveTime);
+    }
+
+    function testCompletedJustOutsideAfterWindowReturnsFalse() external {
+        uint64 effectiveTime = uint64(block.timestamp - AFTER - 1);
+        mock.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        (bool paused,) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, false);
+    }
+
+    function testCompletedInsideAfterWindowReturnsTrue() external {
+        uint64 effectiveTime = uint64(block.timestamp - AFTER / 2);
+        mock.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, true);
+        assertEq(ts, effectiveTime);
+    }
+
+    // -------- Mask filtering --------
+
+    function testMaskExcludesNonMatchingType() external {
+        // Action exists but its type bit is not in the supplied mask.
+        uint256 someOtherType = 1 << 5;
+        mock.setEarliestPending(1, someOtherType, uint64(block.timestamp + 10));
+        mock.setLatestCompleted(2, someOtherType, uint64(block.timestamp - 10));
+        (bool paused,) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, false);
+    }
+
+    function testWildcardMaskMatchesAnyType() external {
+        uint256 someOtherType = 1 << 5;
+        mock.setEarliestPending(1, someOtherType, uint64(block.timestamp + 10));
+        (bool paused,) = LibCorporateActionsPause.inPauseWindow(address(mock), type(uint256).max, BEFORE, AFTER);
+        assertEq(paused, true);
+    }
+
+    // -------- Pending takes precedence over completed --------
+
+    function testPendingReportedWhenBothWindowsOpen() external {
+        // Completed action 30min ago (post-window open).
+        uint64 completedTime = uint64(block.timestamp - 1800);
+        // Pending action 30min away (pre-window also open).
+        uint64 pendingTime = uint64(block.timestamp + 1800);
+        mock.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, completedTime);
+        mock.setEarliestPending(2, ACTION_TYPE_STOCK_SPLIT_V1, pendingTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, true);
+        assertEq(ts, pendingTime, "pending action's effectiveTime should be returned when both windows open");
+    }
+
+    // -------- Zero-window edge cases --------
+
+    function testZeroBeforeWithExactPendingReturnsFalse() external {
+        // pauseTimeBefore = 0 means no pre-window — pending action does not pause.
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 1));
+        (bool paused,) = LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, 0, AFTER);
+        assertEq(paused, false);
+    }
+
+    function testZeroAfterWithJustCompletedReturnsTrue() external {
+        // Edge: effectiveTime == now, pauseTimeAfter == 0. Window is exactly
+        // one block wide and includes that block.
+        mock.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp));
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, 0);
+        assertEq(paused, true);
+        assertEq(ts, uint64(block.timestamp));
+    }
+
+    // -------- Audit regression: NODE_NONE no-match sentinel --------
+
+    /// `ICorporateActionsV1.{earliest,latest}ActionOfType` return `NODE_NONE`
+    /// for no-match. The lib's pre-fix `cursor != 0` check entered the match
+    /// branch and returned `(true, 0)`, bricking every oracle that had
+    /// `corporateActionsVault` set. After fix, `cursor != NODE_NONE` correctly
+    /// short-circuits to `(false, 0)`.
+    function testNodeNoneSentinelOnBothSidesDoesNotPause() external {
+        // Both branches explicitly set to no-match via NODE_NONE.
+        mock.setEarliestPending(NODE_NONE, ACTION_TYPE_STOCK_SPLIT_V1, 0);
+        mock.setLatestCompleted(NODE_NONE, ACTION_TYPE_STOCK_SPLIT_V1, 0);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, false);
+        assertEq(ts, 0);
+    }
+
+    /// Wildcard-mask deployment must accept the bootstrap node at cursor 0
+    /// (`ACTION_TYPE_INIT_V1 = 1 << 0`) as a real match. Pre-fix the
+    /// `cursor != 0` check silently dropped it.
+    function testWildcardMaskAcceptsBootstrapCursorZero() external {
+        uint256 INIT = 1 << 0;
+        uint64 effectiveTime = uint64(block.timestamp - 60);
+        // No pending; completed is the bootstrap node at cursor 0.
+        mock.setLatestCompleted(0, INIT, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), type(uint256).max, BEFORE, AFTER);
+        assertEq(paused, true);
+        assertEq(ts, effectiveTime);
+    }
+
+    // -------- Defensive boundary tests (audit #72) --------
+
+    /// Per the library's comment, `pendingEffective > block.timestamp` is
+    /// guaranteed by the PENDING completion filter on the upstream vault, not
+    /// re-validated here. If a misbehaving upstream returned a pending action
+    /// with `effectiveTime <= now`, the pre-window predicate `now + before >=
+    /// pendingEffective` is trivially satisfied for any non-negative
+    /// `pauseTimeBefore`, so the oracle would pause. Pin this behaviour so a
+    /// future refactor that adds a local guard surfaces as a deliberate test
+    /// update. Closes audit #72 (a).
+    function testPendingEffectiveAtNowStillPausesDefensive() external {
+        // Upstream invariant violation: PENDING action with effective time at
+        // exactly `now`.
+        uint64 effectiveTime = uint64(block.timestamp);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        // Current behaviour: pauses because `now + BEFORE >= now`.
+        assertEq(paused, true, "current lib pauses when upstream returns pendingEffective <= now");
+        assertEq(ts, effectiveTime);
+    }
+
+    /// `pauseTimeAfter == type(uint64).max` must not overflow the post-window
+    /// addition `completedEffective + pauseTimeAfter`. The addition is in
+    /// uint256 space so it cannot overflow for any realistic timestamp; this
+    /// test pins that guarantee against accidental narrowing to uint64. Closes
+    /// audit #72 (b).
+    function testMaxPauseTimeAfterDoesNotOverflow() external {
+        uint64 effectiveTime = uint64(block.timestamp - 1);
+        mock.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, type(uint64).max);
+        assertEq(paused, true, "max pauseTimeAfter must not overflow");
+        assertEq(ts, effectiveTime);
+    }
+
+    /// `pauseTimeBefore == 0` collapses the pre-window to a single instant:
+    /// the predicate `block.timestamp + 0 >= pendingEffective` is true iff
+    /// `pendingEffective <= now`. When the upstream honours the PENDING
+    /// invariant (`pendingEffective > now`), the predicate is false and the
+    /// oracle does not pause — already covered by
+    /// `testZeroBeforeWithExactPendingReturnsFalse`. The symmetric boundary,
+    /// where `pendingEffective` equals exactly `now`, is the upstream-
+    /// invariant edge: lib trusts the filter, but if the filter ever
+    /// included an `effectiveTime == now` action as PENDING, the oracle
+    /// would pause. Closes audit #72 (c).
+    function testZeroBeforeWithPendingAtNowPauses() external {
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp));
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, 0, AFTER);
+        // `now + 0 >= now` is true, so the pre-window matches at the instant.
+        assertEq(paused, true);
+        assertEq(ts, uint64(block.timestamp));
+    }
+
+    /// SPEC §16.3: `effectiveTime` is zero iff `paused` is false. Fuzz the
+    /// presence and timing of pending and completed actions and assert the
+    /// invariant holds.
+    function testFuzzPausedFalseImpliesEffectiveTimeZero(
+        uint64 pauseBefore,
+        uint64 pauseAfter,
+        bool pendingPresent,
+        uint64 pendingDelta,
+        bool completedPresent,
+        uint64 completedDelta
+    ) external {
+        // Warp into 2033 so 30-day deltas never underflow the timestamp.
+        vm.warp(2_000_000_000);
+        pauseBefore = uint64(bound(pauseBefore, 0, 10 days));
+        pauseAfter = uint64(bound(pauseAfter, 0, 10 days));
+        uint64 pendingEffective = uint64(block.timestamp) + uint64(bound(pendingDelta, 1, 30 days));
+        uint64 completedEffective = uint64(block.timestamp) - uint64(bound(completedDelta, 0, 30 days));
+
+        if (pendingPresent) {
+            mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, pendingEffective);
+        } else {
+            mock.setEarliestPending(NODE_NONE, 0, 0);
+        }
+        if (completedPresent) {
+            mock.setLatestCompleted(2, ACTION_TYPE_STOCK_SPLIT_V1, completedEffective);
+        } else {
+            mock.setLatestCompleted(NODE_NONE, 0, 0);
+        }
+
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, pauseBefore, pauseAfter);
+
+        if (!paused) {
+            assertEq(ts, 0, "SPEC 16.3: paused=false must imply effectiveTime=0");
+        } else {
+            assertGt(ts, 0, "paused=true must report a non-zero effectiveTime");
+        }
+    }
+}


### PR DESCRIPTION
Stateless library that wraps ICorporateActionsV1 and tells callers whether the current block is inside any pre- or post-window of a matching scheduled or completed action.

Algorithm (from SPEC § 16.3):
* Pending side: query earliestActionOfType(mask, PENDING). If now + pauseTimeBefore >= effectiveTime, return paused=true.
* Completed side: query latestActionOfType(mask, COMPLETED). If now <= effectiveTime + pauseTimeAfter, return paused=true.
* When both windows are open simultaneously, return the pending action's effectiveTime — integrators see the next event coming, not the last one done.

Short-circuits cleanly when corporateActionsVault == address(0) or mask == 0 — no external call, no state. Cancelled action nodes are unlinked from the linked list by st0x.deploy and unreachable from the traversal API, so no explicit filter is needed.

14 unit tests against a minimal MockCorporateActions stub cover:
* both short-circuits (zero vault, zero mask)
* no actions, pending only, completed only, both
* exact-edge inclusivity at both window boundaries
* mask filtering (matching and non-matching action types, wildcard)
* zero-width window edges (pauseTimeBefore=0, pauseTimeAfter=0)
* pending-takes-precedence-when-both-windows-open

Adds the rain.tofu.erc20-decimals foundry remapping needed by the transitive import chain ICorporateActionsV1 → LibCorporateActionNode → LibCorporateAction → LibStockSplit → LibTOFUTokenDecimals.