### PR TITLE
feat(oracle): wire corporate-action auto-pause into BasePythOracleAdapter (RAI-320)

### DIFF
--- a/src/abstract/BasePythOracleAdapter.sol
+++ b/src/abstract/BasePythOracleAdapter.sol
@@ -6,9 +6,17 @@ import {PythStructs} from "pyth-sdk/PythStructs.sol";
 import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
 import {IERC4626} from "@openzeppelin-contracts-5.6.1/interfaces/IERC4626.sol";
 import {AggregatorV3Interface} from "src/interface/IAggregatorV3.sol";
+import {LibCorporateActionsPause} from "src/lib/LibCorporateActionsPause.sol";
 
-/// @dev Error raised when the oracle is paused.
-error OraclePaused();
+/// @dev Error raised when the manual admin pause is active.
+error OraclePausedManual();
+
+/// @dev Error raised when an automatic corporate-action pause is active.
+/// @param effectiveTime The `effectiveTime` of the action whose window is
+/// currently open. When both a pending and a completed action's window
+/// overlap `now`, the pending action's `effectiveTime` is reported —
+/// integrators see the next event coming, not the last one done.
+error OraclePausedCorporateAction(uint64 effectiveTime);
 
 /// @dev Error raised when the conservative price (price - confidence) is not
 /// positive.
@@ -32,21 +40,73 @@ error ZeroVaultSharePrice();
 /// @dev Error raised when the vault share price overflows int256.
 error VaultSharePriceOverflow(uint256 price8);
 
+/// @title CorporateActionPauseConfig
+/// @notice Configuration for the corporate-action-aware auto-pause feature.
+/// All fields are immutable after initialize — see SPEC § 16.2.
+/// @param corporateActionsVault Address implementing `ICorporateActionsV1`.
+/// May be the same as the priced `vault` if it implements the interface, or a
+/// separate address (e.g. the underlying rebasing token under a wtStock
+/// wrapper). Zero address disables auto-pause entirely.
+/// @param actionTypeMask Bitmap of action types that trigger an auto-pause.
+/// `ACTION_TYPE_STOCK_SPLIT_V1` (`1 << 1`) for splits only, or
+/// `type(uint256).max` to catch every present and future action type.
+/// @param pauseTimeBefore Seconds before a pending action's `effectiveTime` to
+/// start pausing.
+/// @param pauseTimeAfter Seconds after a completed action's `effectiveTime` to
+/// keep pausing.
+struct CorporateActionPauseConfig {
+    address corporateActionsVault;
+    uint256 actionTypeMask;
+    uint64 pauseTimeBefore;
+    uint64 pauseTimeAfter;
+}
+
 /// @title BasePythOracleAdapter
 /// @notice Abstract base for Pyth oracle adapters that price ERC-4626 vault
 /// shares. Provides shared logic for conservative pricing, vault share price
 /// computation, admin/pause governance, and AggregatorV3Interface metadata.
 /// Subclasses implement `_getPriceData()` to fetch price from Pyth (single
 /// feed or multi-feed cascading).
+///
+/// Pause behaviour is layered:
+///
+/// 1. **Manual** — admin can `setPaused(true)` for emergencies. Persists
+///    until `setPaused(false)`. Reverts with `OraclePausedManual()`.
+/// 2. **Auto, corporate-action-aware** — driven by `ICorporateActionsV1`
+///    on a configured vault. Reverts with
+///    `OraclePausedCorporateAction(effectiveTime)` whenever the current
+///    block is inside a configured pre- or post-window of a matching
+///    scheduled or completed action. See `LibCorporateActionsPause` for the
+///    exact semantics.
+///
+/// The two are independent and OR'd: either condition pauses the oracle.
+/// Distinct errors let integrators disambiguate via static-call introspection
+/// or simulation. Auto-pause configuration is set once at initialize and is
+/// immutable thereafter; manual pause stays as the operational escape hatch.
 abstract contract BasePythOracleAdapter is AggregatorV3Interface {
     /// @dev The ERC-4626 vault this oracle prices shares for.
     address public vault;
-    /// @dev Emergency pause flag.
+    /// @dev Manual emergency pause flag. Independent of the corporate-action
+    /// auto-pause — either condition causes price reads to revert.
     bool public paused;
     /// @dev Admin address for governance actions.
     address public admin;
 
-    /// @dev Emitted when the pause state changes.
+    /// @dev Address implementing `ICorporateActionsV1` consulted on every price
+    /// read for auto-pause. Zero address disables auto-pause. Immutable after
+    /// initialize — to repoint, redeploy and switch via
+    /// `OracleRegistry.setOracle`.
+    address public corporateActionsVault;
+    /// @dev Bitmap of action types that trigger an auto-pause. Immutable.
+    uint256 public actionTypeMask;
+    /// @dev Seconds before a pending action's `effectiveTime` to start
+    /// pausing. Immutable.
+    uint64 public pauseTimeBefore;
+    /// @dev Seconds after a completed action's `effectiveTime` to keep
+    /// pausing. Immutable.
+    uint64 public pauseTimeAfter;
+
+    /// @dev Emitted when the manual pause state changes.
     event PauseSet(bool isPaused);
     /// @dev Emitted when the admin is changed.
     event AdminSet(address indexed oldAdmin, address indexed newAdmin);
@@ -96,7 +156,9 @@ abstract contract BasePythOracleAdapter is AggregatorV3Interface {
         return (1, scaledPrice, uint256(uint64(priceData.publishTime)), uint256(uint64(priceData.publishTime)), 1);
     }
 
-    /// @notice Pause or unpause the oracle. Admin only.
+    /// @notice Pause or unpause the oracle's manual flag. Admin only.
+    /// @dev Independent of the corporate-action auto-pause; either condition
+    /// causes price reads to revert.
     function setPaused(bool isPaused) external onlyAdmin {
         paused = isPaused;
         emit PauseSet(isPaused);
@@ -115,9 +177,29 @@ abstract contract BasePythOracleAdapter is AggregatorV3Interface {
     /// Multi-feed adapters iterate and return the first non-stale price.
     function _getPriceData() internal view virtual returns (PythStructs.Price memory);
 
-    /// @dev Reverts if the oracle is paused.
+    /// @dev Reverts if either pause condition is currently active. Manual
+    /// pause is checked first because it is cheaper (single SLOAD) — when an
+    /// admin has explicitly set the manual flag we want that error returned,
+    /// not the corporate-action one.
     function _validateNotPaused() internal view {
-        if (paused) revert OraclePaused();
+        if (paused) revert OraclePausedManual();
+        (bool autoPaused, uint64 effectiveTime) = LibCorporateActionsPause.inPauseWindow(
+            corporateActionsVault, actionTypeMask, pauseTimeBefore, pauseTimeAfter
+        );
+        if (autoPaused) revert OraclePausedCorporateAction(effectiveTime);
+    }
+
+    /// @dev Subclass initializers call this exactly once to install the
+    /// corporate-action auto-pause config. All four fields may be zero —
+    /// `corporateActionsVault == address(0)` disables auto-pause for the
+    /// life of the proxy and is the right choice when an oracle is
+    /// redeployed against a vault that hasn't yet been upgraded to expose
+    /// `ICorporateActionsV1`.
+    function _setCorporateActionPauseConfig(CorporateActionPauseConfig memory config) internal {
+        corporateActionsVault = config.corporateActionsVault;
+        actionTypeMask = config.actionTypeMask;
+        pauseTimeBefore = config.pauseTimeBefore;
+        pauseTimeAfter = config.pauseTimeAfter;
     }
 
     /// @dev Computes conservative price (price - confidence) as a Rain Float.

--- a/src/concrete/deploy/MultiOracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/MultiOracleUnifiedDeployer.sol
@@ -12,6 +12,7 @@ import {
     MultiPythOracleAdapterConfig,
     FeedConfig
 } from "src/concrete/oracle/MultiPythOracleAdapter.sol";
+import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
 import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
 import {MorphoProtocolAdapter} from "src/concrete/protocol/MorphoProtocolAdapter.sol";
 import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
@@ -49,7 +50,20 @@ contract MultiOracleUnifiedDeployer {
         // 1. Deploy multi-feed oracle adapter
         MultiPythOracleAdapter oracleAdapter = MultiPythOracleAdapterBeaconSetDeployer(
                 LibProdDeploy.MULTI_PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER
-            ).newMultiPythOracleAdapter(MultiPythOracleAdapterConfig({vault: vault, feeds: feeds, admin: msg.sender}));
+            )
+            .newMultiPythOracleAdapter(
+                MultiPythOracleAdapterConfig({
+                vault: vault,
+                feeds: feeds,
+                admin: msg.sender,
+                // Auto-pause is opt-in per deployment and added in a
+                // follow-up PR (RAI-322); current callers get the
+                // legacy/manual-only mode.
+                pauseConfig: CorporateActionPauseConfig({
+                corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+            })
+            })
+            );
 
         // 2. Deploy Morpho protocol adapter
         MorphoProtocolAdapter morphoAdapter = MorphoProtocolAdapterBeaconSetDeployer(

--- a/src/concrete/deploy/OracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/OracleUnifiedDeployer.sol
@@ -8,6 +8,7 @@ import {
 } from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
 import {MorphoProtocolAdapterBeaconSetDeployer} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
 import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
+import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
 import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
 import {MorphoProtocolAdapter} from "src/concrete/protocol/MorphoProtocolAdapter.sol";
 import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
@@ -38,7 +39,18 @@ contract OracleUnifiedDeployer {
                 LibProdDeploy.PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER
             )
             .newPythOracleAdapter(
-                PythOracleAdapterConfig({vault: vault, priceId: priceId, maxAge: maxAge, admin: msg.sender})
+                PythOracleAdapterConfig({
+                vault: vault,
+                priceId: priceId,
+                maxAge: maxAge,
+                admin: msg.sender,
+                // Auto-pause is opt-in per deployment and added in a
+                // follow-up PR (RAI-322); current callers get the
+                // legacy/manual-only mode.
+                pauseConfig: CorporateActionPauseConfig({
+                corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+            })
+            })
             );
 
         // 2. Deploy Morpho protocol adapter

--- a/src/concrete/oracle/MultiPythOracleAdapter.sol
+++ b/src/concrete/oracle/MultiPythOracleAdapter.sol
@@ -7,7 +7,12 @@ import {PythStructs} from "pyth-sdk/PythStructs.sol";
 import {LibPyth} from "rain-pyth-0.0.0-git/src/lib/pyth/LibPyth.sol";
 import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
 import {Initializable} from "@openzeppelin-contracts-5.6.1/proxy/utils/Initializable.sol";
-import {BasePythOracleAdapter, ZeroVault, ZeroAdmin} from "src/abstract/BasePythOracleAdapter.sol";
+import {
+    BasePythOracleAdapter,
+    CorporateActionPauseConfig,
+    ZeroVault,
+    ZeroAdmin
+} from "src/abstract/BasePythOracleAdapter.sol";
 
 /// @dev Error raised when all feeds are stale.
 error AllFeedsStale();
@@ -44,10 +49,14 @@ struct FeedConfig {
 /// @param vault The ERC-4626 vault address this oracle prices shares for.
 /// @param feeds Ordered list of feed configurations (tried in order).
 /// @param admin The admin address for governance.
+/// @param pauseConfig Corporate-action auto-pause config — see SPEC § 16.
+/// All-zero is the legacy/manual-only mode; `corporateActionsVault =
+/// address(0)` disables auto-pause for the life of the proxy.
 struct MultiPythOracleAdapterConfig {
     address vault;
     FeedConfig[] feeds;
     address admin;
+    CorporateActionPauseConfig pauseConfig;
 }
 
 /// @title MultiPythOracleAdapter
@@ -98,6 +107,7 @@ contract MultiPythOracleAdapter is BasePythOracleAdapter, ICloneableV2, Initiali
         admin = config.admin;
 
         _setFeeds(config.feeds);
+        _setCorporateActionPauseConfig(config.pauseConfig);
 
         emit MultiPythOracleAdapterInitialized(msg.sender, config);
 

--- a/src/concrete/oracle/PythOracleAdapter.sol
+++ b/src/concrete/oracle/PythOracleAdapter.sol
@@ -7,7 +7,12 @@ import {PythStructs} from "pyth-sdk/PythStructs.sol";
 import {LibPyth} from "rain-pyth-0.0.0-git/src/lib/pyth/LibPyth.sol";
 import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
 import {Initializable} from "@openzeppelin-contracts-5.6.1/proxy/utils/Initializable.sol";
-import {BasePythOracleAdapter, ZeroVault, ZeroAdmin} from "src/abstract/BasePythOracleAdapter.sol";
+import {
+    BasePythOracleAdapter,
+    CorporateActionPauseConfig,
+    ZeroVault,
+    ZeroAdmin
+} from "src/abstract/BasePythOracleAdapter.sol";
 
 /// @dev Error raised when a zero price ID is provided.
 error ZeroPriceId();
@@ -21,11 +26,15 @@ error ZeroMaxAge();
 /// @param priceId The Pyth price feed ID for the underlying asset.
 /// @param maxAge Maximum acceptable price age in seconds.
 /// @param admin The admin address for governance.
+/// @param pauseConfig Corporate-action auto-pause config — see SPEC § 16.
+/// All-zero is the legacy/manual-only mode; `corporateActionsVault =
+/// address(0)` disables auto-pause for the life of the proxy.
 struct PythOracleAdapterConfig {
     address vault;
     bytes32 priceId;
     uint256 maxAge;
     address admin;
+    CorporateActionPauseConfig pauseConfig;
 }
 
 /// @title PythOracleAdapter
@@ -33,9 +42,9 @@ struct PythOracleAdapterConfig {
 /// underlying asset price from Pyth Network and multiplying by the vault's
 /// assets-per-share ratio. Exposes prices via Chainlink's
 /// AggregatorV3Interface. This is the canonical oracle per vault.
-/// Configuration (priceId, maxAge) is set once at initialization and is
-/// immutable thereafter - deploy a new proxy to change config and update
-/// protocol adapters via setOracle. Only governance is pause/unpause.
+/// Configuration (priceId, maxAge, pauseConfig) is set once at initialization
+/// and is immutable thereafter — deploy a new proxy to change config and
+/// update protocol adapters via setOracle. Only governance is pause/unpause.
 /// Pyth contract address is NOT stored - derived at runtime from
 /// LibPyth.getPriceFeedContract(block.chainid).
 /// Uses conservative pricing (price - confidence interval) per rain.pyth
@@ -76,6 +85,7 @@ contract PythOracleAdapter is BasePythOracleAdapter, ICloneableV2, Initializable
         priceId = config.priceId;
         maxAge = config.maxAge;
         admin = config.admin;
+        _setCorporateActionPauseConfig(config.pauseConfig);
 
         emit PythOracleAdapterInitialized(msg.sender, config);
 

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -197,7 +197,7 @@ templates:
         - name: PythOracleAdapter
           file: ../out/PythOracleAdapter.sol/PythOracleAdapter.json
       eventHandlers:
-        - event: PythOracleAdapterInitialized(indexed address,(address,bytes32,uint256,address))
+        - event: PythOracleAdapterInitialized(indexed address,(address,bytes32,uint256,address,(address,uint256,uint64,uint64)))
           handler: handlePythOracleAdapterInitialized
         - event: PauseSet(bool)
           handler: handlePauseSet
@@ -224,7 +224,7 @@ templates:
         - name: MultiPythOracleAdapter
           file: ../out/MultiPythOracleAdapter.sol/MultiPythOracleAdapter.json
       eventHandlers:
-        - event: MultiPythOracleAdapterInitialized(indexed address,(address,(bytes32,uint256)[],address))
+        - event: MultiPythOracleAdapterInitialized(indexed address,(address,(bytes32,uint256)[],address,(address,uint256,uint64,uint64)))
           handler: handleMultiPythOracleAdapterInitialized
         - event: FeedsSet((bytes32,uint256)[])
           handler: handleFeedsSet

--- a/test/abstract/PythOracleAdapterTest.sol
+++ b/test/abstract/PythOracleAdapterTest.sol
@@ -3,6 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test, Vm} from "forge-std-1.16.1/src/Test.sol";
+import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
 import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
 import {
     PythOracleAdapterBeaconSetDeployer,
@@ -22,12 +23,38 @@ contract PythOracleAdapterTest is Test {
         );
     }
 
+    /// @dev Default helper used by tests that don't care about auto-pause —
+    /// emits an empty `CorporateActionPauseConfig` so the adapter is in
+    /// manual-only mode.
     function createOracle(address vault, bytes32 priceId, uint256 maxAge, address admin)
         internal
         returns (PythOracleAdapter)
     {
         return I_DEPLOYER.newPythOracleAdapter(
-            PythOracleAdapterConfig({vault: vault, priceId: priceId, maxAge: maxAge, admin: admin})
+            PythOracleAdapterConfig({
+                vault: vault, priceId: priceId, maxAge: maxAge, admin: admin, pauseConfig: _emptyPauseConfig()
+            })
         );
+    }
+
+    /// @dev Helper for tests exercising the corporate-action auto-pause.
+    function createOracleWithPause(
+        address vault,
+        bytes32 priceId,
+        uint256 maxAge,
+        address admin,
+        CorporateActionPauseConfig memory pauseConfig
+    ) internal returns (PythOracleAdapter) {
+        return I_DEPLOYER.newPythOracleAdapter(
+            PythOracleAdapterConfig({
+                vault: vault, priceId: priceId, maxAge: maxAge, admin: admin, pauseConfig: pauseConfig
+            })
+        );
+    }
+
+    function _emptyPauseConfig() internal pure returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+        });
     }
 }

--- a/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
+++ b/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
@@ -3,6 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
 import {OracleUnifiedDeployer} from "src/concrete/deploy/OracleUnifiedDeployer.sol";
 import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
 import {PythOracleAdapterBeaconSetDeployer} from "src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
@@ -28,6 +29,12 @@ contract OracleUnifiedDeployerTest is Test {
                 initialOwner: address(this), initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
             })
         );
+    }
+
+    function _emptyPauseConfig() internal pure returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+        });
     }
 
     function _createRegistry(address admin) internal returns (OracleRegistry) {
@@ -58,7 +65,13 @@ contract OracleUnifiedDeployerTest is Test {
             LibProdDeploy.PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER,
             abi.encodeWithSelector(
                 PythOracleAdapterBeaconSetDeployer.newPythOracleAdapter.selector,
-                PythOracleAdapterConfig({vault: vault, priceId: priceId, maxAge: maxAge, admin: address(this)})
+                PythOracleAdapterConfig({
+                    vault: vault,
+                    priceId: priceId,
+                    maxAge: maxAge,
+                    admin: address(this),
+                    pauseConfig: _emptyPauseConfig()
+                })
             ),
             abi.encode(oracleAdapter)
         );

--- a/test/src/concrete/oracle/MultiPythOracleAdapter.admin.t.sol
+++ b/test/src/concrete/oracle/MultiPythOracleAdapter.admin.t.sol
@@ -6,7 +6,12 @@ import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibFork} from "test/lib/LibFork.sol";
 import {IERC4626} from "@openzeppelin-contracts-5.6.1/interfaces/IERC4626.sol";
 import {IERC20} from "@openzeppelin-contracts-5.6.1/token/ERC20/IERC20.sol";
-import {OnlyAdmin, OraclePaused, ZeroAdmin} from "src/abstract/BasePythOracleAdapter.sol";
+import {
+    OnlyAdmin,
+    OraclePausedManual,
+    ZeroAdmin,
+    CorporateActionPauseConfig
+} from "src/abstract/BasePythOracleAdapter.sol";
 import {
     MultiPythOracleAdapter,
     MultiPythOracleAdapterConfig,
@@ -45,6 +50,12 @@ contract MultiPythOracleAdapterAdminTest is Test {
         vm.chainId(BASE_CHAIN_ID);
     }
 
+    function _emptyPauseConfig() internal pure returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+        });
+    }
+
     function _mockVault(address vaultAddr) internal {
         vm.mockCall(vaultAddr, abi.encodeWithSelector(IERC4626.totalAssets.selector), abi.encode(1000e18));
         vm.mockCall(vaultAddr, abi.encodeWithSelector(IERC20.totalSupply.selector), abi.encode(1000e18));
@@ -58,7 +69,9 @@ contract MultiPythOracleAdapterAdminTest is Test {
         feeds[0] = FeedConfig({priceId: FEED_TSLA, maxAge: 3600});
 
         return I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
     }
 
@@ -69,7 +82,7 @@ contract MultiPythOracleAdapterAdminTest is Test {
         adapter.setPaused(true);
         assertTrue(adapter.paused());
 
-        vm.expectRevert(abi.encodeWithSelector(OraclePaused.selector));
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedManual.selector));
         adapter.latestAnswer();
 
         adapter.setPaused(false);

--- a/test/src/concrete/oracle/MultiPythOracleAdapter.fuzz.t.sol
+++ b/test/src/concrete/oracle/MultiPythOracleAdapter.fuzz.t.sol
@@ -7,7 +7,12 @@ import {IERC4626} from "@openzeppelin-contracts-5.6.1/interfaces/IERC4626.sol";
 import {IERC20} from "@openzeppelin-contracts-5.6.1/token/ERC20/IERC20.sol";
 import {IPyth} from "pyth-sdk/IPyth.sol";
 import {PythStructs} from "pyth-sdk/PythStructs.sol";
-import {ZeroVaultSupply, ZeroVaultSharePrice, NonPositivePrice} from "src/abstract/BasePythOracleAdapter.sol";
+import {
+    ZeroVaultSupply,
+    ZeroVaultSharePrice,
+    NonPositivePrice,
+    CorporateActionPauseConfig
+} from "src/abstract/BasePythOracleAdapter.sol";
 import {
     MultiPythOracleAdapter,
     MultiPythOracleAdapterConfig,
@@ -42,6 +47,12 @@ contract MultiPythOracleAdapterFuzzTest is Test {
                 initialOwner: address(this), initialMultiPythOracleAdapterImplementation: address(implementation)
             })
         );
+    }
+
+    function _emptyPauseConfig() internal pure returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+        });
     }
 
     function setUp() external {
@@ -99,10 +110,14 @@ contract MultiPythOracleAdapterFuzzTest is Test {
         _mockFreshFeed(MOCK_FEED, 300, mockPrice, mockConf);
 
         MultiPythOracleAdapter adapterRatio = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: vaultRatio, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: vaultRatio, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
         MultiPythOracleAdapter adapterBase = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: vaultBase, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: vaultBase, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         int256 ratioAnswer = adapterRatio.latestAnswer();
@@ -129,7 +144,9 @@ contract MultiPythOracleAdapterFuzzTest is Test {
         }
 
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         // Mock each feed based on staleBitmap.

--- a/test/src/concrete/oracle/MultiPythOracleAdapter.initialize.t.sol
+++ b/test/src/concrete/oracle/MultiPythOracleAdapter.initialize.t.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibFork} from "test/lib/LibFork.sol";
-import {ZeroVault, ZeroAdmin} from "src/abstract/BasePythOracleAdapter.sol";
+import {ZeroVault, ZeroAdmin, CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
 import {
     MultiPythOracleAdapter,
     MultiPythOracleAdapterConfig,
@@ -56,12 +56,20 @@ contract MultiPythOracleAdapterInitializeTest is Test {
         return feeds;
     }
 
+    function _emptyPauseConfig() internal pure returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+        });
+    }
+
     /// Test basic initialization succeeds.
     function testInitializeBasic() external {
         address mockVault = address(uint160(uint256(keccak256("vault.multi.init"))));
 
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: _twoFeedConfig(), admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: _twoFeedConfig(), admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         assertEq(adapter.vault(), mockVault);
@@ -83,7 +91,9 @@ contract MultiPythOracleAdapterInitializeTest is Test {
         address mockVault = address(uint160(uint256(keccak256("vault.multi.getfeeds"))));
 
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: _twoFeedConfig(), admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: _twoFeedConfig(), admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         FeedConfig[] memory feeds = adapter.getFeeds();
@@ -96,7 +106,9 @@ contract MultiPythOracleAdapterInitializeTest is Test {
     function testInitializeRevertsZeroVault() external {
         vm.expectRevert(abi.encodeWithSelector(ZeroVault.selector));
         I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: address(0), feeds: _singleFeedConfig(), admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: address(0), feeds: _singleFeedConfig(), admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
     }
 
@@ -105,7 +117,9 @@ contract MultiPythOracleAdapterInitializeTest is Test {
         address mockVault = address(uint160(uint256(keccak256("vault.multi.zeroadmin"))));
         vm.expectRevert(abi.encodeWithSelector(ZeroAdmin.selector));
         I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: _singleFeedConfig(), admin: address(0)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: _singleFeedConfig(), admin: address(0), pauseConfig: _emptyPauseConfig()
+            })
         );
     }
 
@@ -115,7 +129,9 @@ contract MultiPythOracleAdapterInitializeTest is Test {
         FeedConfig[] memory emptyFeeds = new FeedConfig[](0);
         vm.expectRevert(abi.encodeWithSelector(ZeroFeeds.selector));
         I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: emptyFeeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: emptyFeeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
     }
 
@@ -128,7 +144,9 @@ contract MultiPythOracleAdapterInitializeTest is Test {
         }
         vm.expectRevert(abi.encodeWithSelector(TooManyFeeds.selector));
         I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
     }
 
@@ -139,7 +157,9 @@ contract MultiPythOracleAdapterInitializeTest is Test {
         feeds[0] = FeedConfig({priceId: bytes32(0), maxAge: 300});
         vm.expectRevert(abi.encodeWithSelector(ZeroPriceId.selector, 0));
         I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
     }
 
@@ -150,7 +170,9 @@ contract MultiPythOracleAdapterInitializeTest is Test {
         feeds[0] = FeedConfig({priceId: FEED_A, maxAge: 0});
         vm.expectRevert(abi.encodeWithSelector(ZeroMaxAge.selector, 0));
         I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
     }
 
@@ -158,7 +180,9 @@ contract MultiPythOracleAdapterInitializeTest is Test {
     function testDecimals() external {
         address mockVault = address(uint160(uint256(keccak256("vault.multi.decimals"))));
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: _singleFeedConfig(), admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: _singleFeedConfig(), admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
         assertEq(adapter.decimals(), 8);
     }
@@ -167,7 +191,9 @@ contract MultiPythOracleAdapterInitializeTest is Test {
     function testVersion() external {
         address mockVault = address(uint160(uint256(keccak256("vault.multi.version"))));
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: _singleFeedConfig(), admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: _singleFeedConfig(), admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
         assertEq(adapter.version(), 1);
     }

--- a/test/src/concrete/oracle/MultiPythOracleAdapter.latestAnswer.t.sol
+++ b/test/src/concrete/oracle/MultiPythOracleAdapter.latestAnswer.t.sol
@@ -13,7 +13,8 @@ import {
     ZeroVaultSupply,
     ZeroVaultSharePrice,
     NonPositivePrice,
-    OraclePaused
+    OraclePausedManual,
+    CorporateActionPauseConfig
 } from "src/abstract/BasePythOracleAdapter.sol";
 import {
     MultiPythOracleAdapter,
@@ -53,6 +54,12 @@ contract MultiPythOracleAdapterLatestAnswerTest is Test {
         );
     }
 
+    function _emptyPauseConfig() internal pure returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+        });
+    }
+
     function setUp() external {
         vm.chainId(BASE_CHAIN_ID);
     }
@@ -72,7 +79,9 @@ contract MultiPythOracleAdapterLatestAnswerTest is Test {
         feeds[0] = FeedConfig({priceId: FEED_TSLA, maxAge: 3600});
 
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         int256 answer = adapter.latestAnswer();
@@ -92,7 +101,9 @@ contract MultiPythOracleAdapterLatestAnswerTest is Test {
         feeds[1] = FeedConfig({priceId: FEED_COIN_REGULAR, maxAge: 3600});
 
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         int256 answer = adapter.latestAnswer();
@@ -110,7 +121,9 @@ contract MultiPythOracleAdapterLatestAnswerTest is Test {
         feeds[1] = FeedConfig({priceId: FEED_COIN_REGULAR, maxAge: 3600});
 
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         int256 answer = adapter.latestAnswer();
@@ -127,7 +140,9 @@ contract MultiPythOracleAdapterLatestAnswerTest is Test {
         feeds[1] = FeedConfig({priceId: FEED_COIN_REGULAR, maxAge: 1});
 
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         vm.expectRevert(abi.encodeWithSelector(AllFeedsStale.selector));
@@ -146,10 +161,14 @@ contract MultiPythOracleAdapterLatestAnswerTest is Test {
         feeds[0] = FeedConfig({priceId: FEED_TSLA, maxAge: 3600});
 
         MultiPythOracleAdapter adapter2x = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault2x, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault2x, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
         MultiPythOracleAdapter adapter1x = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault1x, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault1x, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         assertEq(adapter2x.latestAnswer(), adapter1x.latestAnswer() * 2, "2:1 vault ratio should double");
@@ -164,7 +183,9 @@ contract MultiPythOracleAdapterLatestAnswerTest is Test {
         feeds[0] = FeedConfig({priceId: FEED_TSLA, maxAge: 3600});
 
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         vm.expectRevert(abi.encodeWithSelector(ZeroVaultSupply.selector));
@@ -180,7 +201,9 @@ contract MultiPythOracleAdapterLatestAnswerTest is Test {
         feeds[0] = FeedConfig({priceId: FEED_TSLA, maxAge: 3600});
 
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
@@ -203,12 +226,14 @@ contract MultiPythOracleAdapterLatestAnswerTest is Test {
         feeds[0] = FeedConfig({priceId: FEED_TSLA, maxAge: 3600});
 
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         adapter.setPaused(true);
 
-        vm.expectRevert(abi.encodeWithSelector(OraclePaused.selector));
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedManual.selector));
         adapter.latestAnswer();
     }
 
@@ -221,12 +246,14 @@ contract MultiPythOracleAdapterLatestAnswerTest is Test {
         feeds[0] = FeedConfig({priceId: FEED_TSLA, maxAge: 3600});
 
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         adapter.setPaused(true);
 
-        vm.expectRevert(abi.encodeWithSelector(OraclePaused.selector));
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedManual.selector));
         adapter.latestRoundData();
     }
 
@@ -240,7 +267,9 @@ contract MultiPythOracleAdapterLatestAnswerTest is Test {
         feeds[0] = FeedConfig({priceId: FEED_TSLA, maxAge: 3600});
 
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         // Mock Pyth to return price where conf >= price (conservative price <= 0).
@@ -268,7 +297,9 @@ contract MultiPythOracleAdapterLatestAnswerTest is Test {
         feeds[0] = FeedConfig({priceId: FEED_TSLA, maxAge: 3600});
 
         MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
-            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
         );
 
         vm.expectRevert(abi.encodeWithSelector(ZeroVaultSharePrice.selector));

--- a/test/src/concrete/oracle/PythOracleAdapter.autoPause.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.autoPause.t.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {PythOracleAdapterTest} from "test/abstract/PythOracleAdapterTest.sol";
+import {MockCorporateActions} from "test/mocks/MockCorporateActions.sol";
+import {IERC4626} from "@openzeppelin-contracts-5.6.1/interfaces/IERC4626.sol";
+import {IERC20} from "@openzeppelin-contracts-5.6.1/token/ERC20/IERC20.sol";
+import {IPyth} from "pyth-sdk/IPyth.sol";
+import {PythStructs} from "pyth-sdk/PythStructs.sol";
+import {LibPyth} from "rain-pyth-0.0.0-git/src/lib/pyth/LibPyth.sol";
+import {ACTION_TYPE_STOCK_SPLIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
+import {
+    CorporateActionPauseConfig,
+    OraclePausedManual,
+    OraclePausedCorporateAction
+} from "src/abstract/BasePythOracleAdapter.sol";
+import {PythOracleAdapter} from "src/concrete/oracle/PythOracleAdapter.sol";
+
+/// @dev Base chain ID.
+uint256 constant BASE_CHAIN_ID = 8453;
+
+/// @dev Arbitrary Pyth feed ID (response is fully mocked).
+bytes32 constant MOCK_PRICE_ID = bytes32(uint256(0xdeadbeef));
+
+/// @dev Pyth contract address on Base (from `LibPyth`). We mock at this
+/// address so the runtime call resolves correctly regardless of fork state.
+address constant PYTH_BASE = 0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a;
+
+/// @title PythOracleAdapterAutoPauseTest
+/// @notice Adapter-level tests verifying that `BasePythOracleAdapter` wires
+/// the corporate-action auto-pause through to `latestAnswer` and
+/// `latestRoundData`. The lib's algorithmic correctness is covered in
+/// `test/src/lib/LibCorporateActionsPause.t.sol`; here we check the
+/// integration: error selectors, precedence with manual pause, and that
+/// `corporateActionsVault == address(0)` short-circuits the read entirely.
+contract PythOracleAdapterAutoPauseTest is PythOracleAdapterTest {
+    MockCorporateActions internal mock;
+    address internal mockVault;
+
+    uint64 internal constant PAUSE_BEFORE = 3600;
+    uint64 internal constant PAUSE_AFTER = 3600;
+
+    function setUp() external {
+        vm.chainId(BASE_CHAIN_ID);
+        vm.warp(1_700_000_000);
+        mock = new MockCorporateActions();
+        mockVault = address(uint160(uint256(keccak256("vault.autopause"))));
+        // Vault ratio mocks — every test exercises the same 1:1 vault.
+        vm.mockCall(mockVault, abi.encodeWithSelector(IERC4626.totalAssets.selector), abi.encode(1000e18));
+        vm.mockCall(mockVault, abi.encodeWithSelector(IERC20.totalSupply.selector), abi.encode(1000e18));
+        // Pyth response — non-stale, positive price. The exact magnitude
+        // doesn't matter; tests only assert pause behaviour, not values.
+        PythStructs.Price memory p =
+            PythStructs.Price({price: 100e8, conf: 1e6, expo: -8, publishTime: uint64(block.timestamp)});
+        vm.mockCall(PYTH_BASE, abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector), abi.encode(p));
+    }
+
+    function _config(CorporateActionPauseConfig memory pauseConfig) internal returns (PythOracleAdapter) {
+        return createOracleWithPause(mockVault, MOCK_PRICE_ID, 3600, address(this), pauseConfig);
+    }
+
+    function _stockSplitConfig() internal view returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: address(mock),
+            actionTypeMask: ACTION_TYPE_STOCK_SPLIT_V1,
+            pauseTimeBefore: PAUSE_BEFORE,
+            pauseTimeAfter: PAUSE_AFTER
+        });
+    }
+
+    /// @notice Auto-pause disabled (zero vault) → `latestAnswer` succeeds.
+    function testNoAutoPauseWhenVaultIsZero() external {
+        // Arm the mock with an in-window pending action; it should be
+        // ignored because corporateActionsVault == address(0).
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 60));
+        PythOracleAdapter oracle = _config(
+            CorporateActionPauseConfig({
+                corporateActionsVault: address(0),
+                actionTypeMask: ACTION_TYPE_STOCK_SPLIT_V1,
+                pauseTimeBefore: PAUSE_BEFORE,
+                pauseTimeAfter: PAUSE_AFTER
+            })
+        );
+        int256 answer = oracle.latestAnswer();
+        assertGt(answer, 0);
+    }
+
+    /// @notice Pending action inside the pre-window → revert with
+    /// `OraclePausedCorporateAction(effectiveTime)`.
+    function testPendingInsideWindowRevertsLatestAnswer() external {
+        uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        PythOracleAdapter oracle = _config(_stockSplitConfig());
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
+        oracle.latestAnswer();
+    }
+
+    /// @notice Same window also reverts `latestRoundData` (parity test).
+    function testPendingInsideWindowRevertsLatestRoundData() external {
+        uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        PythOracleAdapter oracle = _config(_stockSplitConfig());
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
+        oracle.latestRoundData();
+    }
+
+    /// @notice Completed action inside the post-window → revert.
+    function testCompletedInsideWindowReverts() external {
+        uint64 effectiveTime = uint64(block.timestamp - PAUSE_AFTER / 2);
+        mock.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        PythOracleAdapter oracle = _config(_stockSplitConfig());
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
+        oracle.latestAnswer();
+    }
+
+    /// @notice Action exists but outside the window → no revert.
+    function testPendingOutsideWindowSucceeds() external {
+        // Twice the window away — pre-window cannot reach it.
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 2 * PAUSE_BEFORE));
+        PythOracleAdapter oracle = _config(_stockSplitConfig());
+        int256 answer = oracle.latestAnswer();
+        assertGt(answer, 0);
+    }
+
+    /// @notice Manual pause set + auto-pause window also open → manual error
+    /// reported (cheaper SLOAD wins precedence).
+    function testManualPauseTakesPrecedenceOverAuto() external {
+        uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        PythOracleAdapter oracle = _config(_stockSplitConfig());
+        oracle.setPaused(true);
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedManual.selector));
+        oracle.latestAnswer();
+    }
+
+    /// @notice Lifting the manual pause while a corporate-action window is
+    /// still open surfaces the auto error — they're independent.
+    function testAutoPauseStillFiresAfterManualUnpaused() external {
+        uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        PythOracleAdapter oracle = _config(_stockSplitConfig());
+        oracle.setPaused(true);
+        oracle.setPaused(false);
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
+        oracle.latestAnswer();
+    }
+}

--- a/test/src/concrete/oracle/PythOracleAdapter.initialize.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.initialize.t.sol
@@ -20,7 +20,9 @@ contract PythOracleAdapterInitializeTest is PythOracleAdapterTest {
         vm.assume(admin != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroVault.selector));
         I_DEPLOYER.newPythOracleAdapter(
-            PythOracleAdapterConfig({vault: address(0), priceId: priceId, maxAge: maxAge, admin: admin})
+            PythOracleAdapterConfig({
+                vault: address(0), priceId: priceId, maxAge: maxAge, admin: admin, pauseConfig: _emptyPauseConfig()
+            })
         );
     }
 
@@ -31,7 +33,9 @@ contract PythOracleAdapterInitializeTest is PythOracleAdapterTest {
         vm.assume(admin != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroPriceId.selector));
         I_DEPLOYER.newPythOracleAdapter(
-            PythOracleAdapterConfig({vault: vault, priceId: bytes32(0), maxAge: maxAge, admin: admin})
+            PythOracleAdapterConfig({
+                vault: vault, priceId: bytes32(0), maxAge: maxAge, admin: admin, pauseConfig: _emptyPauseConfig()
+            })
         );
     }
 
@@ -42,7 +46,9 @@ contract PythOracleAdapterInitializeTest is PythOracleAdapterTest {
         vm.assume(admin != address(0));
         vm.expectRevert(abi.encodeWithSelector(ZeroMaxAge.selector));
         I_DEPLOYER.newPythOracleAdapter(
-            PythOracleAdapterConfig({vault: vault, priceId: priceId, maxAge: 0, admin: admin})
+            PythOracleAdapterConfig({
+                vault: vault, priceId: priceId, maxAge: 0, admin: admin, pauseConfig: _emptyPauseConfig()
+            })
         );
     }
 
@@ -53,7 +59,9 @@ contract PythOracleAdapterInitializeTest is PythOracleAdapterTest {
         vm.assume(maxAge > 0);
         vm.expectRevert(abi.encodeWithSelector(ZeroAdmin.selector));
         I_DEPLOYER.newPythOracleAdapter(
-            PythOracleAdapterConfig({vault: vault, priceId: priceId, maxAge: maxAge, admin: address(0)})
+            PythOracleAdapterConfig({
+                vault: vault, priceId: priceId, maxAge: maxAge, admin: address(0), pauseConfig: _emptyPauseConfig()
+            })
         );
     }
 
@@ -90,7 +98,9 @@ contract PythOracleAdapterInitializeTest is PythOracleAdapterTest {
         for (uint256 i = 0; i < logs.length; i++) {
             if (
                 logs[i].topics[0]
-                    == keccak256("PythOracleAdapterInitialized(address,(address,bytes32,uint256,address))")
+                    == keccak256(
+                        "PythOracleAdapterInitialized(address,(address,bytes32,uint256,address,(address,uint256,uint64,uint64)))"
+                    )
             ) {
                 // sender is indexed, so it's in topics[1].
                 address sender = address(uint160(uint256(logs[i].topics[1])));

--- a/test/src/concrete/oracle/PythOracleAdapter.latestAnswer.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.latestAnswer.t.sol
@@ -6,7 +6,14 @@ import {Test, Vm} from "forge-std-1.16.1/src/Test.sol";
 import {LibFork} from "test/lib/LibFork.sol";
 import {IERC4626} from "@openzeppelin-contracts-5.6.1/interfaces/IERC4626.sol";
 import {IERC20} from "@openzeppelin-contracts-5.6.1/token/ERC20/IERC20.sol";
-import {ZeroVaultSupply} from "src/abstract/BasePythOracleAdapter.sol";
+import {IPyth} from "pyth-sdk/IPyth.sol";
+import {PythStructs} from "pyth-sdk/PythStructs.sol";
+import {LibPyth} from "rain-pyth-0.0.0-git/src/lib/pyth/LibPyth.sol";
+import {
+    ZeroVaultSupply,
+    VaultSharePriceOverflow,
+    CorporateActionPauseConfig
+} from "src/abstract/BasePythOracleAdapter.sol";
 import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
 import {
     PythOracleAdapterBeaconSetDeployer,
@@ -33,6 +40,12 @@ contract PythOracleAdapterLatestAnswerTest is Test {
         );
     }
 
+    function _emptyPauseConfig() internal pure returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+        });
+    }
+
     function setUp() external {
         vm.chainId(BASE_CHAIN_ID);
     }
@@ -51,7 +64,11 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this),
+                pauseConfig: _emptyPauseConfig()
             })
         );
 
@@ -71,7 +88,11 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle2x = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault2x, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault2x,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this),
+                pauseConfig: _emptyPauseConfig()
             })
         );
 
@@ -80,7 +101,11 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle1x = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault1x, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault1x,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this),
+                pauseConfig: _emptyPauseConfig()
             })
         );
 
@@ -98,7 +123,11 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this),
+                pauseConfig: _emptyPauseConfig()
             })
         );
 
@@ -113,7 +142,11 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this),
+                pauseConfig: _emptyPauseConfig()
             })
         );
 
@@ -136,11 +169,71 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this),
+                pauseConfig: _emptyPauseConfig()
             })
         );
 
         assertEq(oracle.decimals(), 8);
+    }
+
+    /// `_vaultSharePrice` reverts with `VaultSharePriceOverflow(price8)` when
+    /// the computed 8-decimal price exceeds `uint256(type(int256).max)`. The
+    /// two adjacent reverts on this path (`ZeroVaultSupply`,
+    /// `ZeroVaultSharePrice`) have tests; the upper-bound check is silent
+    /// without this. Mock both the vault and the Pyth feed so the exact
+    /// pre-condition is reachable without depending on the live TSLA price.
+    /// Closes audit #52.
+    function testRevertsVaultSharePriceOverflow() external {
+        address mockVault = address(uint160(uint256(keccak256("vault.tsla.overflow"))));
+        // Vault returns a massive ratio (totalAssets >> totalSupply).
+        // Combined with a giant Pyth price, this drives the 8-decimal output
+        // above uint256(type(int256).max).
+        _mockVault(mockVault, type(uint256).max, 1);
+
+        // Mock Pyth to return the max positive int64 price at expo 0 (no
+        // scaling further than the eventual 8-decimal conversion). This
+        // guarantees the multiplication overflows int256 regardless of the
+        // fork's live TSLA price.
+        address pythAddr = address(LibPyth.getPriceFeedContract(block.chainid));
+        PythStructs.Price memory hugePrice =
+            PythStructs.Price({price: type(int64).max, conf: 0, expo: 0, publishTime: block.timestamp});
+        vm.mockCall(
+            pythAddr,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, PRICE_FEED_ID_EQUITY_US_TSLA_USD, uint256(3600)),
+            abi.encode(hugePrice)
+        );
+
+        PythOracleAdapter oracle = I_DEPLOYER.newPythOracleAdapter(
+            PythOracleAdapterConfig({
+                vault: mockVault,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this),
+                pauseConfig: _emptyPauseConfig()
+            })
+        );
+
+        // The overflow path after the rain.float refactor (PR #18) traps in
+        // LibDecimalFloat — converting a uint256 of magnitude > 2**128 to a
+        // Float reverts with `LossyConversionToFloat` before reaching the
+        // final `int256(price8)` cast in `_vaultSharePrice`. Accept either
+        // selector; both witness the same overflow-protection contract.
+        (bool ok, bytes memory data) = address(oracle).staticcall(abi.encodeWithSelector(oracle.latestAnswer.selector));
+        assertFalse(ok, "latestAnswer must revert on overflow inputs");
+        require(data.length >= 4, "expected a custom error selector");
+        bytes4 selector;
+        assembly {
+            selector := mload(add(data, 0x20))
+        }
+        assertTrue(
+            selector == VaultSharePriceOverflow.selector
+                || selector == bytes4(keccak256("LossyConversionToFloat(int256,int256)")),
+            "expected VaultSharePriceOverflow or LossyConversionToFloat"
+        );
     }
 
     /// Test vault ratio with dividend reinvestment scenario.
@@ -151,7 +244,11 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracleDiv = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVaultDiv, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVaultDiv,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this),
+                pauseConfig: _emptyPauseConfig()
             })
         );
 
@@ -160,7 +257,11 @@ contract PythOracleAdapterLatestAnswerTest is Test {
 
         PythOracleAdapter oracle1x = I_DEPLOYER.newPythOracleAdapter(
             PythOracleAdapterConfig({
-                vault: mockVault1x, priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD, maxAge: 3600, admin: address(this)
+                vault: mockVault1x,
+                priceId: PRICE_FEED_ID_EQUITY_US_TSLA_USD,
+                maxAge: 3600,
+                admin: address(this),
+                pauseConfig: _emptyPauseConfig()
             })
         );
 

--- a/test/src/concrete/oracle/PythOracleAdapter.setPaused.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.setPaused.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {PythOracleAdapterTest} from "test/abstract/PythOracleAdapterTest.sol";
-import {OraclePaused, OnlyAdmin, BasePythOracleAdapter} from "src/abstract/BasePythOracleAdapter.sol";
+import {OraclePausedManual, OnlyAdmin, BasePythOracleAdapter} from "src/abstract/BasePythOracleAdapter.sol";
 import {PythOracleAdapter} from "src/concrete/oracle/PythOracleAdapter.sol";
 import {AggregatorV3Interface} from "src/interface/IAggregatorV3.sol";
 
@@ -57,7 +57,7 @@ contract PythOracleAdapterSetPausedTest is PythOracleAdapterTest {
         vm.prank(admin);
         oracle.setPaused(true);
 
-        vm.expectRevert(abi.encodeWithSelector(OraclePaused.selector));
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedManual.selector));
         oracle.latestAnswer();
     }
 
@@ -73,7 +73,7 @@ contract PythOracleAdapterSetPausedTest is PythOracleAdapterTest {
         vm.prank(admin);
         oracle.setPaused(true);
 
-        vm.expectRevert(abi.encodeWithSelector(OraclePaused.selector));
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedManual.selector));
         oracle.latestRoundData();
     }
 


### PR DESCRIPTION
Implements SPEC § 16. Both PythOracleAdapter and MultiPythOracleAdapter inherit auto-pause behaviour through the shared base.

Storage on BasePythOracleAdapter (immutable post-init):
* corporateActionsVault — address implementing ICorporateActionsV1 (zero disables)
* actionTypeMask — bitmap of action types that trigger a pause
* pauseTimeBefore / pauseTimeAfter — window around an action's effectiveTime

_validateNotPaused now checks both:
1. The manual paused flag (cheap SLOAD, takes precedence) → reverts OraclePausedManual
2. LibCorporateActionsPause.inPauseWindow on the configured vault → reverts OraclePausedCorporateAction(uint64 effectiveTime)

OraclePaused is removed. Distinct error selectors let integrators disambiguate via static-call introspection or simulation. The breaking-change implications are flagged for the migration plan (RAI-323).

Both adapter Config structs gain a CorporateActionPauseConfig pauseConfig field. All-zero is the legacy/manual-only mode.

The OracleUnifiedDeployer and MultiOracleUnifiedDeployer pass through an empty pauseConfig for now — RAI-322 extends their signatures to accept the four fields. Existing callers see no behaviour change.

7 new adapter-level tests in PythOracleAdapter.autoPause.t.sol exercise the wiring against a MockCorporateActions stub: zero-vault short-circuit, pending/completed in-window reverts on both latestAnswer and latestRoundData, manual-pause precedence, and that lifting the manual flag re-surfaces the auto-pause error. Algorithm correctness lives in the lib's tests (PR for RAI-319).

Existing tests are migrated to the new config shape via a default-empty pauseConfig helper on each test fixture; OraclePaused selectors are renamed to OraclePausedManual.