### PR TITLE
feat(deploy): thread CorporateActionPauseConfig through unified deployers (RAI-322)

### DIFF
--- a/src/concrete/deploy/MultiOracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/MultiOracleUnifiedDeployer.sol
@@ -39,10 +39,16 @@ contract MultiOracleUnifiedDeployer {
     /// @param vault The ERC-4626 vault address.
     /// @param feeds Ordered list of Pyth feed configurations (tried in order).
     /// @param registry The oracle registry. Admin must call registry.setOracle() separately.
+    /// @param pauseConfig Corporate-action auto-pause configuration — see
+    /// SPEC § 16. Pass an all-zero struct to disable auto-pause (legacy /
+    /// manual-only mode).
     // slither-disable-next-line reentrancy-events
-    function newMultiOracleAndProtocolAdapters(address vault, FeedConfig[] calldata feeds, OracleRegistry registry)
-        external
-    {
+    function newMultiOracleAndProtocolAdapters(
+        address vault,
+        FeedConfig[] calldata feeds,
+        OracleRegistry registry,
+        CorporateActionPauseConfig calldata pauseConfig
+    ) external {
         if (LibProdDeploy.MULTI_PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER == address(0)) {
             revert MultiPythBeaconSetDeployerNotSet();
         }
@@ -52,17 +58,7 @@ contract MultiOracleUnifiedDeployer {
                 LibProdDeploy.MULTI_PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER
             )
             .newMultiPythOracleAdapter(
-                MultiPythOracleAdapterConfig({
-                vault: vault,
-                feeds: feeds,
-                admin: msg.sender,
-                // Auto-pause is opt-in per deployment and added in a
-                // follow-up PR (RAI-322); current callers get the
-                // legacy/manual-only mode.
-                pauseConfig: CorporateActionPauseConfig({
-                corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
-            })
-            })
+                MultiPythOracleAdapterConfig({vault: vault, feeds: feeds, admin: msg.sender, pauseConfig: pauseConfig})
             );
 
         // 2. Deploy Morpho protocol adapter

--- a/src/concrete/deploy/OracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/OracleUnifiedDeployer.sol
@@ -30,26 +30,24 @@ contract OracleUnifiedDeployer {
     /// @param priceId The Pyth price feed ID for the underlying asset.
     /// @param maxAge Maximum acceptable price age in seconds.
     /// @param registry The oracle registry. Admin must call registry.setOracle() separately.
+    /// @param pauseConfig Corporate-action auto-pause configuration — see
+    /// SPEC § 16. Pass an all-zero struct to disable auto-pause (legacy /
+    /// manual-only mode).
     // slither-disable-next-line reentrancy-events
-    function newOracleAndProtocolAdapters(address vault, bytes32 priceId, uint256 maxAge, OracleRegistry registry)
-        external
-    {
+    function newOracleAndProtocolAdapters(
+        address vault,
+        bytes32 priceId,
+        uint256 maxAge,
+        OracleRegistry registry,
+        CorporateActionPauseConfig calldata pauseConfig
+    ) external {
         // 1. Deploy oracle adapter
         PythOracleAdapter oracleAdapter = PythOracleAdapterBeaconSetDeployer(
                 LibProdDeploy.PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER
             )
             .newPythOracleAdapter(
                 PythOracleAdapterConfig({
-                vault: vault,
-                priceId: priceId,
-                maxAge: maxAge,
-                admin: msg.sender,
-                // Auto-pause is opt-in per deployment and added in a
-                // follow-up PR (RAI-322); current callers get the
-                // legacy/manual-only mode.
-                pauseConfig: CorporateActionPauseConfig({
-                corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
-            })
+                vault: vault, priceId: priceId, maxAge: maxAge, admin: msg.sender, pauseConfig: pauseConfig
             })
             );
 

--- a/test/src/concrete/deploy/MultiOracleUnifiedDeployer.t.sol
+++ b/test/src/concrete/deploy/MultiOracleUnifiedDeployer.t.sol
@@ -19,6 +19,7 @@ import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig
 } from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
+import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
 
 contract MultiOracleUnifiedDeployerTest is Test {
     OracleRegistry internal immutable I_REGISTRY_IMPLEMENTATION;
@@ -31,6 +32,12 @@ contract MultiOracleUnifiedDeployerTest is Test {
                 initialOwner: address(this), initialOracleRegistryImplementation: address(I_REGISTRY_IMPLEMENTATION)
             })
         );
+    }
+
+    function _emptyPauseConfig() internal pure returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+        });
     }
 
     function _createRegistry(address admin) internal returns (OracleRegistry) {
@@ -55,6 +62,6 @@ contract MultiOracleUnifiedDeployerTest is Test {
 
         // Should not revert with MultiPythBeaconSetDeployerNotSet
         // (will revert for other reasons since feed ID is fake, but that's fine)
-        try deployer.newMultiOracleAndProtocolAdapters(address(1), feeds, registry) {} catch {}
+        try deployer.newMultiOracleAndProtocolAdapters(address(1), feeds, registry, _emptyPauseConfig()) {} catch {}
     }
 }

--- a/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
+++ b/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
@@ -107,6 +107,6 @@ contract OracleUnifiedDeployerTest is Test {
 
         vm.expectEmit();
         emit OracleUnifiedDeployer.Deployment(address(this), oracleAdapter, morphoAdapter, passthroughAdapter);
-        unifiedDeployer.newOracleAndProtocolAdapters(vault, priceId, maxAge, registry);
+        unifiedDeployer.newOracleAndProtocolAdapters(vault, priceId, maxAge, registry, _emptyPauseConfig());
     }
 }


### PR DESCRIPTION
Extends OracleUnifiedDeployer.newOracleAndProtocolAdapters and MultiOracleUnifiedDeployer.newMultiOracleAndProtocolAdapters with a CorporateActionPauseConfig pauseConfig parameter (calldata) that is forwarded into the oracle adapter's initialize call.

The placeholder all-zero CorporateActionPauseConfig that PR for RAI-320 wired in for compile compatibility is removed; deployment scripts now decide auto-pause configuration explicitly per vault. Pass an all-zero struct for legacy / manual-only mode.

The BeaconSetDeployers (PythOracleAdapterBeaconSetDeployer, MultiPythOracleAdapterBeaconSetDeployer) already accept the full Config struct so they propagate pauseConfig transparently — no signature change required at that layer. Confirms the deployer surface still matches the patterns used in st0x.deploy and the existing OracleRegistry flow is unchanged.

Tests for both unified deployers are updated to thread an empty pauseConfig (existing semantics preserved).