### PR TITLE
fix(lib): correct LibCorporateActionsPause no-match sentinel to NODE_NONE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ cache
 out
 
 .env
+
+.fixes/
+audit/

--- a/src/lib/LibCorporateActionsPause.sol
+++ b/src/lib/LibCorporateActionsPause.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {ICorporateActionsV1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
-import {CompletionFilter} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
+import {CompletionFilter, NODE_NONE} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
 
 /// @title LibCorporateActionsPause
 /// @notice Helper for oracle adapters that decide whether to auto-pause based
@@ -57,10 +57,13 @@ library LibCorporateActionsPause {
         ICorporateActionsV1 vault = ICorporateActionsV1(corporateActionsVault);
 
         (uint256 pendingCursor,, uint64 pendingEffective) = vault.earliestActionOfType(mask, CompletionFilter.PENDING);
-        if (pendingCursor != 0) {
+        // `NODE_NONE = type(uint256).max` is the documented no-match sentinel
+        // from `ICorporateActionsV1` — cursor `0` is a real bootstrap node and
+        // must NOT be treated as "no match".
+        if (pendingCursor != NODE_NONE) {
             // pendingEffective > now is guaranteed by the PENDING filter.
-            // Subtraction underflow is impossible because pendingEffective
-            // is uint64 and we explicitly compare via addition.
+            // We compare via addition on uint256-promoted operands so neither
+            // underflow nor overflow is possible for any realistic timestamp.
             if (block.timestamp + uint256(pauseTimeBefore) >= uint256(pendingEffective)) {
                 return (true, pendingEffective);
             }
@@ -68,7 +71,7 @@ library LibCorporateActionsPause {
 
         (uint256 completedCursor,, uint64 completedEffective) =
             vault.latestActionOfType(mask, CompletionFilter.COMPLETED);
-        if (completedCursor != 0) {
+        if (completedCursor != NODE_NONE) {
             // completedEffective <= now is guaranteed by the COMPLETED filter.
             if (block.timestamp <= uint256(completedEffective) + uint256(pauseTimeAfter)) {
                 return (true, completedEffective);

--- a/test/src/concrete/oracle/PythOracleAdapter.autoPause.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.autoPause.t.sol
@@ -9,7 +9,7 @@ import {IPyth} from "pyth-sdk/IPyth.sol";
 import {PythStructs} from "pyth-sdk/PythStructs.sol";
 import {LibPyth} from "rain.pyth/src/lib/pyth/LibPyth.sol";
 import {ICorporateActionsV1, ACTION_TYPE_STOCK_SPLIT_V1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
-import {CompletionFilter} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
+import {CompletionFilter, NODE_NONE} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
 import {
     CorporateActionPauseConfig,
     OraclePausedManual,
@@ -55,8 +55,8 @@ contract MockCorporateActions is ICorporateActionsV1 {
         returns (uint256, uint256, uint64)
     {
         if (filter != CompletionFilter.PENDING) revert("mock: only PENDING expected");
-        if (!_earliestPending.exists) return (0, 0, 0);
-        if (_earliestPending.actionType & mask == 0) return (0, 0, 0);
+        if (!_earliestPending.exists) return (NODE_NONE, 0, 0);
+        if (_earliestPending.actionType & mask == 0) return (NODE_NONE, 0, 0);
         return (1, _earliestPending.actionType, _earliestPending.effectiveTime);
     }
 
@@ -67,8 +67,8 @@ contract MockCorporateActions is ICorporateActionsV1 {
         returns (uint256, uint256, uint64)
     {
         if (filter != CompletionFilter.COMPLETED) revert("mock: only COMPLETED expected");
-        if (!_latestCompleted.exists) return (0, 0, 0);
-        if (_latestCompleted.actionType & mask == 0) return (0, 0, 0);
+        if (!_latestCompleted.exists) return (NODE_NONE, 0, 0);
+        if (_latestCompleted.actionType & mask == 0) return (NODE_NONE, 0, 0);
         return (1, _latestCompleted.actionType, _latestCompleted.effectiveTime);
     }
 

--- a/test/src/concrete/protocol/AutoPausePropagation.t.sol
+++ b/test/src/concrete/protocol/AutoPausePropagation.t.sol
@@ -9,7 +9,7 @@ import {IPyth} from "pyth-sdk/IPyth.sol";
 import {PythStructs} from "pyth-sdk/PythStructs.sol";
 import {AggregatorV3Interface} from "src/interface/IAggregatorV3.sol";
 import {ICorporateActionsV1, ACTION_TYPE_STOCK_SPLIT_V1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
-import {CompletionFilter} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
+import {CompletionFilter, NODE_NONE} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
 import {
     CorporateActionPauseConfig,
     OraclePausedCorporateAction,
@@ -70,8 +70,8 @@ contract MockCorporateActions is ICorporateActionsV1 {
         returns (uint256, uint256, uint64)
     {
         if (filter != CompletionFilter.PENDING) revert("mock: only PENDING expected");
-        if (pendingEffectiveTime == 0) return (0, 0, 0);
-        if (pendingActionType & mask == 0) return (0, 0, 0);
+        if (pendingEffectiveTime == 0) return (NODE_NONE, 0, 0);
+        if (pendingActionType & mask == 0) return (NODE_NONE, 0, 0);
         return (1, pendingActionType, pendingEffectiveTime);
     }
 
@@ -82,8 +82,8 @@ contract MockCorporateActions is ICorporateActionsV1 {
         returns (uint256, uint256, uint64)
     {
         if (filter != CompletionFilter.COMPLETED) revert("mock: only COMPLETED expected");
-        if (completedEffectiveTime == 0) return (0, 0, 0);
-        if (completedActionType & mask == 0) return (0, 0, 0);
+        if (completedEffectiveTime == 0) return (NODE_NONE, 0, 0);
+        if (completedActionType & mask == 0) return (NODE_NONE, 0, 0);
         return (1, completedActionType, completedEffectiveTime);
     }
 

--- a/test/src/lib/LibCorporateActionsPause.t.sol
+++ b/test/src/lib/LibCorporateActionsPause.t.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {ICorporateActionsV1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
-import {CompletionFilter} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
+import {CompletionFilter, NODE_NONE} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
 import {LibCorporateActionsPause} from "src/lib/LibCorporateActionsPause.sol";
 import {ACTION_TYPE_STOCK_SPLIT_V1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
 
@@ -23,13 +23,15 @@ contract MockCorporateActions is ICorporateActionsV1 {
     StubAction private _latestCompleted;
 
     function setEarliestPending(uint256 cursor, uint256 actionType, uint64 effectiveTime) external {
-        _earliestPending =
-            StubAction({exists: cursor != 0, cursor: cursor, actionType: actionType, effectiveTime: effectiveTime});
+        _earliestPending = StubAction({
+            exists: cursor != NODE_NONE, cursor: cursor, actionType: actionType, effectiveTime: effectiveTime
+        });
     }
 
     function setLatestCompleted(uint256 cursor, uint256 actionType, uint64 effectiveTime) external {
-        _latestCompleted =
-            StubAction({exists: cursor != 0, cursor: cursor, actionType: actionType, effectiveTime: effectiveTime});
+        _latestCompleted = StubAction({
+            exists: cursor != NODE_NONE, cursor: cursor, actionType: actionType, effectiveTime: effectiveTime
+        });
     }
 
     function earliestActionOfType(uint256 mask, CompletionFilter filter)
@@ -39,8 +41,8 @@ contract MockCorporateActions is ICorporateActionsV1 {
         returns (uint256, uint256, uint64)
     {
         if (filter != CompletionFilter.PENDING) revert("mock: only PENDING supported");
-        if (!_earliestPending.exists) return (0, 0, 0);
-        if (_earliestPending.actionType & mask == 0) return (0, 0, 0);
+        if (!_earliestPending.exists) return (NODE_NONE, 0, 0);
+        if (_earliestPending.actionType & mask == 0) return (NODE_NONE, 0, 0);
         return (_earliestPending.cursor, _earliestPending.actionType, _earliestPending.effectiveTime);
     }
 
@@ -51,8 +53,8 @@ contract MockCorporateActions is ICorporateActionsV1 {
         returns (uint256, uint256, uint64)
     {
         if (filter != CompletionFilter.COMPLETED) revert("mock: only COMPLETED supported");
-        if (!_latestCompleted.exists) return (0, 0, 0);
-        if (_latestCompleted.actionType & mask == 0) return (0, 0, 0);
+        if (!_latestCompleted.exists) return (NODE_NONE, 0, 0);
+        if (_latestCompleted.actionType & mask == 0) return (NODE_NONE, 0, 0);
         return (_latestCompleted.cursor, _latestCompleted.actionType, _latestCompleted.effectiveTime);
     }
 
@@ -227,5 +229,75 @@ contract LibCorporateActionsPauseTest is Test {
             LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, 0);
         assertEq(paused, true);
         assertEq(ts, uint64(block.timestamp));
+    }
+
+    // -------- Audit regression: NODE_NONE no-match sentinel --------
+
+    /// `ICorporateActionsV1.{earliest,latest}ActionOfType` return `NODE_NONE`
+    /// for no-match. The lib's pre-fix `cursor != 0` check entered the match
+    /// branch and returned `(true, 0)`, bricking every oracle that had
+    /// `corporateActionsVault` set. After fix, `cursor != NODE_NONE` correctly
+    /// short-circuits to `(false, 0)`.
+    function testNodeNoneSentinelOnBothSidesDoesNotPause() external {
+        // Both branches explicitly set to no-match via NODE_NONE.
+        mock.setEarliestPending(NODE_NONE, ACTION_TYPE_STOCK_SPLIT_V1, 0);
+        mock.setLatestCompleted(NODE_NONE, ACTION_TYPE_STOCK_SPLIT_V1, 0);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, false);
+        assertEq(ts, 0);
+    }
+
+    /// Wildcard-mask deployment must accept the bootstrap node at cursor 0
+    /// (`ACTION_TYPE_INIT_V1 = 1 << 0`) as a real match. Pre-fix the
+    /// `cursor != 0` check silently dropped it.
+    function testWildcardMaskAcceptsBootstrapCursorZero() external {
+        uint256 INIT = 1 << 0;
+        uint64 effectiveTime = uint64(block.timestamp - 60);
+        // No pending; completed is the bootstrap node at cursor 0.
+        mock.setLatestCompleted(0, INIT, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), type(uint256).max, BEFORE, AFTER);
+        assertEq(paused, true);
+        assertEq(ts, effectiveTime);
+    }
+
+    /// SPEC §16.3: `effectiveTime` is zero iff `paused` is false. Fuzz the
+    /// presence and timing of pending and completed actions and assert the
+    /// invariant holds.
+    function testFuzzPausedFalseImpliesEffectiveTimeZero(
+        uint64 pauseBefore,
+        uint64 pauseAfter,
+        bool pendingPresent,
+        uint64 pendingDelta,
+        bool completedPresent,
+        uint64 completedDelta
+    ) external {
+        // Warp into 2033 so 30-day deltas never underflow the timestamp.
+        vm.warp(2_000_000_000);
+        pauseBefore = uint64(bound(pauseBefore, 0, 10 days));
+        pauseAfter = uint64(bound(pauseAfter, 0, 10 days));
+        uint64 pendingEffective = uint64(block.timestamp) + uint64(bound(pendingDelta, 1, 30 days));
+        uint64 completedEffective = uint64(block.timestamp) - uint64(bound(completedDelta, 0, 30 days));
+
+        if (pendingPresent) {
+            mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, pendingEffective);
+        } else {
+            mock.setEarliestPending(NODE_NONE, 0, 0);
+        }
+        if (completedPresent) {
+            mock.setLatestCompleted(2, ACTION_TYPE_STOCK_SPLIT_V1, completedEffective);
+        } else {
+            mock.setLatestCompleted(NODE_NONE, 0, 0);
+        }
+
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, pauseBefore, pauseAfter);
+
+        if (!paused) {
+            assertEq(ts, 0, "SPEC 16.3: paused=false must imply effectiveTime=0");
+        } else {
+            assertGt(ts, 0, "paused=true must report a non-zero effectiveTime");
+        }
     }
 }


### PR DESCRIPTION
LibCorporateActionsPause.inPauseWindow was checking `cursor != 0` to detect
"matching action exists", but ICorporateActionsV1.{earliest,latest}ActionOfType
documents and returns `NODE_NONE = type(uint256).max` as the no-match sentinel.
Cursor 0 is the bootstrap INIT node — a real walkable node — and must not be
treated as "no match".

Pre-fix, any oracle with `corporateActionsVault != address(0)` and
`actionTypeMask != 0` read `(NODE_NONE, _, 0)` from a real vault, entered
the "match found" branch with effectiveTime=0, evaluated
`block.timestamp + pauseTimeBefore >= 0` (always true), and reverted every
latestAnswer / latestRoundData call with `OraclePausedCorporateAction(0)`.
Latent until a vault is wired with the corporate-actions facet (RAI-327
testnet); has not affected mainnet.

The bug was masked by all three test mocks of `ICorporateActionsV1` returning
`(0, 0, 0)` on no-match (sharing the lib's wrong sentinel) instead of the
real `(NODE_NONE, 0, 0)`. This commit fixes the mocks first — existing
tests then reproduce the failure against the buggy lib (TDD red), and pass
after the lib fix (TDD green).

Adds three regression tests in `LibCorporateActionsPause.t.sol`:
- testNodeNoneSentinelOnBothSidesDoesNotPause — explicit no-match path
- testWildcardMaskAcceptsBootstrapCursorZero — bootstrap cursor-0 must be
  accepted as a real match under wildcard mask
- testFuzzPausedFalseImpliesEffectiveTimeZero — SPEC 16.3 invariant
  (paused=false iff effectiveTime=0)

Also gitignores `audit/` and `.fixes/` so the audit skill's local artifacts
don't pollute commits or REUSE compliance.

Found by /audit Pass 1 (Security) A15-1, Pass 5 (Correctness) A15p5-1, and
Pass 6 (Hazard Surface) H1 against ST0x-Technology/st0x.oracle at
3a24b5d..f45f652.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>