### PR TITLE
fix(morpho): require 8-decimal upstream oracle (audit #187)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,23 @@ Deployments happen via GitHub Actions (`manual-sol-artifacts.yaml`), not locally
 3. PR the addresses into `src/lib/LibProdDeploy.sol` (for deployer addresses) or `test/src/concrete/ProdFork.t.sol` `LibProdOracles` (for oracle/adapter addresses)
 4. Use `cast send` with `--interactive` for any onchain calls that need a private key
 
+> **Pipeline drift risk.** The current pipeline is **GitHub Action → operator
+> parses logs → operator opens PR with addresses pasted into
+> `src/lib/LibProdDeploy.sol` and `test/src/concrete/ProdFork.t.sol`
+> (`LibProdOracles`)**. The drift risks are:
+>
+> - Typo'd address copied from log to source.
+> - Paste into the wrong constant slot (right address, wrong name).
+> - PR opened late / merged out of order, leaving the constants pointing at
+>   a stale deployment while the new one is already live on-chain.
+> - `subgraph/networks.json` duplicates every deployer address from
+>   `LibProdDeploy.sol` and is currently maintained by hand on the same PR
+>   (see `subgraph/README.md`, issue #220).
+>
+> Tracked at **#210**. Future work: emit a JSON artifact from the workflow
+> that the PR is auto-generated from (and that drives `networks.json`),
+> removing the human-in-the-loop copy step entirely.
+
 ### Deployment Suites
 
 - `pyth-oracle-adapter-beacon-set` — PythOracleAdapter beacon + impl

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Solidity oracle adapter system that prices ERC-4626 vault shares by combining Pyth Network price feeds with vault share ratios, for DeFi lending protocols (Morpho Blue, Aave V3, Compound V3). Three-layer architecture: oracle adapters (price source), oracle registry (centralized vault→oracle mapping), and protocol adapters (protocol-specific interface). The oracle computes `vaultSharePrice = pythPrice * totalAssets / totalSupply`.
+Solidity oracle adapter system that prices ERC-4626 vault shares by combining Pyth Network price feeds with vault share ratios, for DeFi lending protocols (Morpho Blue, Aave V3, Compound V3). Three-layer architecture: oracle adapters (price source), oracle registry (centralized vault→oracle mapping), and protocol adapters (protocol-specific interface). The oracle computes `vaultSharePrice = pythPrice * totalAssets / totalSupply`. Single-feed (`PythOracleAdapter`) and multi-feed cascading (`MultiPythOracleAdapter`) variants share an abstract `BasePythOracleAdapter`. Both expose an auto-pause mechanism keyed off the vault's `ICorporateActionsV1` schedule, reverting with `OraclePausedCorporateAction(uint64 effectiveTime)` when a scheduled action sits inside its pre- or post-window; the manual admin flag remains as the independent `OraclePausedManual()` escape hatch.
 
 ## Environment Setup
 
@@ -28,8 +28,11 @@ forge fmt --check    # Check formatting without modifying
 
 ## Architecture (Three Layers)
 
-**Oracle Layer** — canonical price source per vault, implements `AggregatorV3Interface` (8 decimals):
-- `PythOracleAdapter` — fetches from Pyth, multiplies by vault share ratio (totalAssets/totalSupply), scales to 8 decimals, has governance (pause)
+**Oracle Layer** — canonical price source per vault, implements `AggregatorV2V3Interface` (8 decimals):
+- `BasePythOracleAdapter` (abstract) — shared logic for conservative pricing (price - confidence), vault-share-ratio scaling via `LibDecimalFloat`, admin/manual-pause governance, and `ICorporateActionsV1` auto-pause via `LibCorporateActionsPause`. Subclasses only implement `_getPriceData()`.
+- `PythOracleAdapter` — single-feed concrete. Fully immutable post-init; only governance is `setPaused` / `setAdmin`.
+- `MultiPythOracleAdapter` — cascading multi-feed variant. Tries up to 8 feeds in order, returns the first non-stale price. Admin can `setFeeds` and `setMaxAge` (per-feed). Used for equities with separate session feeds (regular / pre-market / post-market / overnight).
+- Both adapters revert via two distinct selectors: `OraclePausedManual()` (admin set the manual flag) and `OraclePausedCorporateAction(uint64 effectiveTime)` (a matching `ICorporateActionsV1` action's pre- or post-window is open). The auto-pause logic lives in `src/lib/LibCorporateActionsPause.sol` and is driven by `corporateActionsVault` / `actionTypeMask` / `pauseTimeBefore` / `pauseTimeAfter`, all immutable after initialize.
 
 **Registry Layer** — centralized vault→oracle mapping:
 - `OracleRegistry` — maintains `vault → oracle adapter` mapping, allows admin to update oracles for all protocol adapters at once via single `setOracle()` call
@@ -40,7 +43,8 @@ forge fmt --check    # Check formatting without modifying
 
 **Deployers** — beacon proxy pattern per `st0x.deploy`:
 - Each contract type has a `BeaconSetDeployer` that owns a beacon and deploys proxies
-- `OracleUnifiedDeployer` orchestrates deploying oracle + all protocol adapters for a new vault
+- `OracleUnifiedDeployer` orchestrates deploying a single-feed oracle + all protocol adapters for a new vault
+- `MultiOracleUnifiedDeployer` is the same flow for multi-feed oracles (uses `MultiPythOracleAdapterBeaconSetDeployer`)
 
 ## Key Design Decisions
 
@@ -58,21 +62,29 @@ forge fmt --check    # Check formatting without modifying
 
 ```
 src/
+├── abstract/
+│   └── BasePythOracleAdapter.sol           # shared base for both oracle adapters
 ├── concrete/
 │   ├── oracle/
-│   │   └── PythOracleAdapter.sol          # Vault-aware oracle, AggregatorV3Interface
+│   │   ├── PythOracleAdapter.sol           # Single-feed concrete, AggregatorV2V3Interface
+│   │   └── MultiPythOracleAdapter.sol      # Multi-feed cascading variant
 │   ├── registry/
-│   │   └── OracleRegistry.sol             # Centralized vault→oracle mapping
+│   │   └── OracleRegistry.sol              # Centralized vault→oracle mapping
 │   ├── protocol/
-│   │   ├── MorphoProtocolAdapter.sol      # IOracle, scales 8→36, uses registry
-│   │   └── PassthroughProtocolAdapter.sol # AggregatorV3Interface passthrough, uses registry
+│   │   ├── MorphoProtocolAdapter.sol       # IOracle, scales 8→36, uses registry
+│   │   └── PassthroughProtocolAdapter.sol  # AggregatorV2V3Interface passthrough, uses registry
 │   └── deploy/
 │       ├── PythOracleAdapterBeaconSetDeployer.sol
+│       ├── MultiPythOracleAdapterBeaconSetDeployer.sol
 │       ├── OracleRegistryBeaconSetDeployer.sol
 │       ├── MorphoProtocolAdapterBeaconSetDeployer.sol
 │       ├── PassthroughProtocolAdapterBeaconSetDeployer.sol
-│       └── OracleUnifiedDeployer.sol
+│       ├── OracleUnifiedDeployer.sol
+│       └── MultiOracleUnifiedDeployer.sol
+├── interface/
+│   └── IAggregatorV2V3.sol                 # Hand-typed Chainlink-compatible interface
 └── lib/
+    ├── LibCorporateActionsPause.sol        # Auto-pause reader (consults ICorporateActionsV1)
     └── LibProdDeploy.sol
 ```
 
@@ -80,6 +92,7 @@ src/
 
 - `rain.pyth` — `LibPyth.getPriceFeedContract()` and price feed ID constants
 - `pyth-sdk-solidity` — `IPyth`, `PythStructs`
+- `st0x.deploy` — `BeaconSetDeployer` pattern, `ICloneableV2`, `ICorporateActionsV1` (consumed by `LibCorporateActionsPause`)
 - `openzeppelin-contracts` — `UpgradeableBeacon`, `BeaconProxy`, `Initializable`, `IERC4626`
 
 ## Security Rules

--- a/SPEC.md
+++ b/SPEC.md
@@ -44,7 +44,7 @@ The underlying price source is **Pyth Network**, which provides NBBO pricing for
 | Interface | Returns `Float` (Rain format) | Returns `int256` (8 decimals) |
 | Lookup | Runtime symbol lookup | Per-token deployed proxy |
 | Pattern | Direct deployment | BeaconSetDeployer pattern |
-| Governance | None (stateless) | Admin controls (pause, setPriceId) |
+| Governance | None (stateless) | Admin controls (pause; multi-feed adapter also `setFeeds` / `setMaxAge`) |
 
 **What we reuse from rain.pyth:**
 
@@ -90,16 +90,40 @@ PROTOCOL ADAPTERS
           ▼                          ▼
 ┌─────────────────────┐    ┌─────────────────────┐
 │ PythOracleAdapter   │    │ ChainlinkOracle     │
-│                     │    │ Adapter (future)    │
+│ (single-feed)       │    │ Adapter (future)    │
 │ Governance:         │    │                     │
-│  - set priceId      │    │                     │
-│  - set maxAge       │    │                     │
 │  - pause/unpause    │    │                     │
+│  - setAdmin         │    │                     │
+│  (priceId/maxAge    │    │                     │
+│   immutable)        │    │                     │
 └─────────────────────┘    └─────────────────────┘
+         ▲
+         │ also implemented by
+┌─────────────────────┐
+│ MultiPythOracleAd.. │
+│ (cascading feeds)   │
+│ Governance:         │
+│  - pause/unpause    │
+│  - setAdmin         │
+│  - setFeeds         │
+│  - setMaxAge        │
+└─────────────────────┘
 
 ORACLE ADAPTERS
 (canonical oracle per asset, all governance here)
 ```
+
+`BasePythOracleAdapter` (abstract, in `src/abstract/`) factors the common
+behaviour out of both oracle implementations: vault-share-ratio scaling,
+conservative pricing, admin / manual-pause governance, and the
+corporate-action auto-pause that consults `LibCorporateActionsPause`.
+`PythOracleAdapter` and `MultiPythOracleAdapter` are thin concrete subclasses
+that only differ in `_getPriceData()` — see §§ 6 and 6A. Both are reached via
+`AggregatorV2V3Interface` (the project-local `src/interface/IAggregatorV2V3.sol`,
+hand-typed to avoid pulling Chainlink as a dependency — see § 11).
+`PythOracleAdapter` is fully immutable post-init; `MultiPythOracleAdapter`
+exposes admin-only `setFeeds` / `setMaxAge`. Manual `setPaused` / `setAdmin`
+exist on both.
 
 **Why a registry layer:**
 
@@ -188,15 +212,25 @@ Deploy multiple proxy *instances* from the same beacon for different protocols.
 
 ## 6. PythOracleAdapter Implementation
 
-**Storage:**
+**Single-feed concrete subclass of `BasePythOracleAdapter`.** All shared
+storage and behaviour (vault, paused, admin, the four
+`CorporateActionPauseConfig` fields, `_validateNotPaused`, `_vaultSharePrice`,
+`_conservativePriceFloat`) live on the base — see § 6B. This contract only
+adds the two single-feed fields and an override of `_getPriceData()`.
+
+**Storage (in addition to base):**
 
 ```solidity
-address public vault;            // ERC-4626 vault, set once, no setter
 bytes32 public priceId;          // Pyth feed ID for underlying asset
 uint256 public maxAge;           // Max acceptable price age
-bool public paused;              // Emergency pause
-address public admin;            // Admin for governance
 ```
+
+`priceId` and `maxAge` are set once at `initialize` and have **no setters** —
+to change either, deploy a new oracle proxy and switch over via
+`OracleRegistry.setOracle(vault, newOracle)`. The same is true of the
+corporate-action pause config — see § 16.2. The only governance surface is
+`setPaused` and `setAdmin`, both inherited from the base. See § 6A for the
+multi-feed variant which adds admin-controlled `setFeeds` / `setMaxAge`.
 
 Note: No `pyth` address storage - derived from `LibPyth.getPriceFeedContract(block.chainid)` at runtime.
 
@@ -235,6 +269,98 @@ function _vaultSharePrice(PythStructs.Price memory priceData) internal view retu
     return int256(uint256(price8) * totalAssets / totalSupply);
 }
 ```
+
+---
+
+## 6A. MultiPythOracleAdapter Implementation
+
+Cascading version of § 6 for equities that publish through multiple Pyth
+feeds — e.g. regular session, pre-market, post-market, overnight. Tries
+feeds in configured order, returns the first non-stale price, reverts with
+`AllFeedsStale()` if none answer. Same external surface as
+`PythOracleAdapter` (`AggregatorV2V3Interface`).
+
+**Differences vs § 6:**
+
+- **Storage**: replaces `priceId` / `maxAge` with `feedCount` (`uint256`) and
+  `mapping(uint256 => FeedConfig) internal _feeds`, where
+  `FeedConfig { bytes32 priceId; uint256 maxAge; }`. Up to `MAX_FEEDS = 8`
+  feeds per oracle. Each feed has its own `maxAge` because update frequency
+  varies by session.
+- **Governance surface**: in addition to inherited `setPaused` / `setAdmin`,
+  exposes:
+  - `setFeeds(FeedConfig[] calldata feeds)` — admin only, replaces the whole
+    feed list (validates `0 < length <= MAX_FEEDS` and non-zero
+    `priceId` / `maxAge` per entry).
+  - `setMaxAge(uint256 index, uint256 newMaxAge)` — admin only, updates a
+    single feed's `maxAge` in place. Both emit events
+    (`FeedsSet` / `FeedMaxAgeSet`). The corporate-action pause config remains
+    immutable post-init exactly as in § 6 / § 16.2.
+- **`_getPriceData()`**: iterates `_feeds[0..feedCount)`. For each, calls
+  `pyth.getPriceNoOlderThan(priceId, maxAge)` inside a `try/catch`; the first
+  successful return wins. Bounded by `MAX_FEEDS = 8` so the loop is gas-safe.
+- **Errors added**: `AllFeedsStale`, `ZeroFeeds`, `TooManyFeeds`,
+  `FeedIndexOutOfBounds(uint256, uint256)`, `ZeroPriceId(uint256)`,
+  `ZeroMaxAge(uint256)`. All other errors are shared with § 6 via the base.
+- **Auto-pause**: identical to § 6 — same `CorporateActionPauseConfig`,
+  same two-error revert pair, same `LibCorporateActionsPause` call site on
+  the base.
+
+Deployed via `MultiPythOracleAdapterBeaconSetDeployer` and orchestrated by
+`MultiOracleUnifiedDeployer` (see §§ 9, 10).
+
+---
+
+## 6B. BasePythOracleAdapter (abstract)
+
+Abstract base in `src/abstract/BasePythOracleAdapter.sol`. Defines the shared
+surface for both oracle adapters; subclasses only implement `_getPriceData()`.
+
+**Storage on the base:**
+
+```solidity
+address public vault;                 // ERC-4626 vault
+bool    public paused;                // manual emergency pause
+address public admin;                 // governance
+// Corporate-action auto-pause config, immutable after _setCorporateActionPauseConfig:
+address public corporateActionsVault;
+uint256 public actionTypeMask;
+uint64  public pauseTimeBefore;
+uint64  public pauseTimeAfter;
+```
+
+**External / public surface on the base:**
+
+- `decimals()`, `description()`, `version()`, `latestAnswer()`,
+  `latestRoundData()` — `AggregatorV2V3Interface`. Eight decimals, fixed.
+- `getRoundData(uint80)` — always reverts with
+  `HistoricalRoundDataUnsupported(_roundId)`. Pyth does not expose
+  per-round history through this interface; callers needing point-in-time
+  data must use Pyth's `getPriceAtPublishTime` directly.
+- `setPaused(bool)` — admin only, toggles the manual flag.
+- `setAdmin(address)` — admin only, rejects zero.
+
+**Internal hooks:**
+
+- `_getPriceData()` — abstract, implemented by subclasses (§ 6, § 6A).
+- `_validateNotPaused()` — checks manual flag, then calls
+  `LibCorporateActionsPause.inPauseWindow` and reverts with
+  `OraclePausedCorporateAction(effectiveTime)` if the window is open.
+  Manual check runs first so an admin-set pause surfaces the
+  `OraclePausedManual()` selector even when a corporate action also
+  qualifies.
+- `_conservativePriceFloat(PythStructs.Price memory)` — price minus
+  confidence, returned as a Rain `Float`. Reverts `NonPositivePrice` if the
+  conservative price is `<= 0`.
+- `_vaultSharePrice(PythStructs.Price memory)` — multiplies the conservative
+  price by `vault.totalAssets() / vault.totalSupply()` entirely in float
+  space (no integer overflow) and returns 8-decimal fixed point. Reverts
+  `ZeroVaultSupply`, `ZeroVaultSharePrice`, or `VaultSharePriceOverflow` on
+  edge cases.
+- `_setCorporateActionPauseConfig(CorporateActionPauseConfig memory)` —
+  called once by each subclass `initialize`. There is no setter on either
+  concrete subclass; changing any of the four fields requires a redeploy
+  and `OracleRegistry.setOracle` switchover (§ 16.2).
 
 ---
 
@@ -331,10 +457,16 @@ Following `st0x.deploy` patterns:
 contract OracleRegistryBeaconSetDeployer {
     IBeacon public immutable I_ORACLE_REGISTRY_BEACON;
 
-    function newOracleRegistry(OracleRegistryConfig memory config)
-        external returns (OracleRegistry);
+    /// admin is hardcoded to msg.sender — no config struct.
+    function newOracleRegistry() external returns (OracleRegistry);
 }
 ```
+
+`newOracleRegistry()` takes no arguments. Hardcoding `msg.sender = admin`
+mirrors the BeaconSet pattern used by every other deployer in this repo and
+eliminates an attacker-controlled admin slot in a permissionless factory — a
+caller cannot deploy a registry on someone else's behalf and assign them
+admin without their consent.
 
 **Oracle Adapter Layer:**
 
@@ -344,6 +476,13 @@ contract PythOracleAdapterBeaconSetDeployer {
 
     function newPythOracleAdapter(PythOracleAdapterConfig memory config)
         external returns (PythOracleAdapter);
+}
+
+contract MultiPythOracleAdapterBeaconSetDeployer {
+    IBeacon public immutable I_MULTI_PYTH_ORACLE_ADAPTER_BEACON;
+
+    function newMultiPythOracleAdapter(MultiPythOracleAdapterConfig memory config)
+        external returns (MultiPythOracleAdapter);
 }
 ```
 
@@ -379,14 +518,18 @@ contract MorphoProtocolAdapterBeaconSetDeployer {
 
 1. Deploy OracleRegistryV1 implementation
 2. Deploy OracleRegistryBeaconSetDeployer (creates beacon internally)
-3. Deploy the canonical OracleRegistry proxy
+3. Deploy the canonical OracleRegistry proxy via `newOracleRegistry()` —
+   takes no arguments; the caller becomes registry admin
 4. Deploy PythOracleAdapterV1 implementation
 5. Deploy PythOracleAdapterBeaconSetDeployer
-6. Deploy MorphoProtocolAdapterV1 implementation
-7. Deploy MorphoProtocolAdapterBeaconSetDeployer
-8. Deploy PassthroughProtocolAdapterV1 implementation
-9. Deploy PassthroughProtocolAdapterBeaconSetDeployer
-10. Deploy OracleUnifiedDeployer
+6. Deploy MultiPythOracleAdapterV1 implementation
+7. Deploy MultiPythOracleAdapterBeaconSetDeployer
+8. Deploy MorphoProtocolAdapterV1 implementation
+9. Deploy MorphoProtocolAdapterBeaconSetDeployer
+10. Deploy PassthroughProtocolAdapterV1 implementation
+11. Deploy PassthroughProtocolAdapterBeaconSetDeployer
+12. Deploy OracleUnifiedDeployer (orchestrates single-feed adapters)
+13. Deploy MultiOracleUnifiedDeployer (orchestrates multi-feed adapters)
 
 **For a new vault (e.g., wrapped AAPL):**
 
@@ -404,6 +547,14 @@ OracleUnifiedDeployer.newOracleAndProtocolAdapters(
 registry.setOracle(vault, oracleAdapter);
 ```
 
+**Multi-feed variant:** for equities that need near-24/7 session coverage,
+use `MultiOracleUnifiedDeployer.newMultiOracleAndProtocolAdapters(vault,
+feeds, registry, pauseConfig)` instead. Identical orchestration —
+oracle + Morpho adapter + Passthrough adapter — but the oracle is a
+`MultiPythOracleAdapter` configured with an ordered `FeedConfig[]` (up to
+8 entries; each carries its own `priceId` and `maxAge`). The two-step
+registry handshake is unchanged.
+
 **Why two-step deployment:**
 
 - `OracleUnifiedDeployer` can be called by anyone to deploy adapters
@@ -418,11 +569,15 @@ registry.setOracle(vault, oracleAdapter);
 st0x.oracle/
 ├── lib/
 │   ├── rain.pyth/                              # For LibPyth
-│   └── pyth-sdk-solidity/                      # Pyth structs
+│   ├── pyth-sdk-solidity/                      # Pyth structs
+│   └── st0x.deploy/                            # ICloneableV2, ICorporateActionsV1
 ├── src/
+│   ├── abstract/
+│   │   └── BasePythOracleAdapter.sol           # Shared base (vault/pause/admin + auto-pause)
 │   ├── concrete/
 │   │   ├── oracle/
-│   │   │   └── PythOracleAdapter.sol
+│   │   │   ├── PythOracleAdapter.sol           # Single-feed concrete
+│   │   │   └── MultiPythOracleAdapter.sol      # Cascading multi-feed concrete
 │   │   ├── registry/
 │   │   │   └── OracleRegistry.sol              # Centralized vault→oracle mapping
 │   │   ├── protocol/
@@ -431,10 +586,15 @@ st0x.oracle/
 │   │   └── deploy/
 │   │       ├── OracleRegistryBeaconSetDeployer.sol
 │   │       ├── PythOracleAdapterBeaconSetDeployer.sol
+│   │       ├── MultiPythOracleAdapterBeaconSetDeployer.sol
 │   │       ├── MorphoProtocolAdapterBeaconSetDeployer.sol
 │   │       ├── PassthroughProtocolAdapterBeaconSetDeployer.sol
-│   │       └── OracleUnifiedDeployer.sol
+│   │       ├── OracleUnifiedDeployer.sol
+│   │       └── MultiOracleUnifiedDeployer.sol
+│   ├── interface/
+│   │   └── IAggregatorV2V3.sol                 # Hand-typed Chainlink-compatible interface
 │   └── lib/
+│       ├── LibCorporateActionsPause.sol        # Auto-pause reader (ICorporateActionsV1)
 │       └── LibProdDeploy.sol
 └── test/
 ```
@@ -470,9 +630,19 @@ IPyth constant PRICE_FEED_CONTRACT_BASE = IPyth(0x8250f4aF4B972684F7b336503E2D6d
 All admin roles held by founder multisig:
 
 - **Beacon Owner**: Can upgrade implementation
-- **Registry Admin**: Can register/update vault→oracle mappings
-- **Oracle Admin**: Can update priceId, maxAge, pause/unpause
-- **Protocol Adapter Admin**: Can update registry reference (opt-out mechanism)
+- **Registry Admin**: Can register/update vault→oracle mappings (`setOracle`,
+  `setOracleBulk`). Set to `msg.sender` at `newOracleRegistry()` time;
+  `setAdmin` rotates it thereafter.
+- **Oracle Admin (`PythOracleAdapter`, single-feed)**: Can `setPaused` and
+  `setAdmin`. `priceId`, `maxAge`, and the corporate-action pause config are
+  **immutable post-init** — to change any of them, deploy a new oracle and
+  switch over via `OracleRegistry.setOracle`.
+- **Oracle Admin (`MultiPythOracleAdapter`, multi-feed)**: Same as above
+  plus `setFeeds` (replace the entire feed list) and `setMaxAge` (update a
+  single feed's `maxAge`). The corporate-action pause config remains
+  immutable post-init for both adapters.
+- **Protocol Adapter Admin**: Can update registry reference (`setRegistry`)
+  as an opt-out mechanism.
 
 No separation of roles.
 

--- a/src/concrete/deploy/OracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/OracleUnifiedDeployer.sol
@@ -19,6 +19,13 @@ import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
 /// (Morpho, Passthrough for Aave/Compound) for a new vault. The beacon set
 /// deployer addresses are hardcoded to simplify and harden deployment by
 /// providing an audit trail in git of any address modifications.
+/// @dev The sub-deployer addresses (`LibProdDeploy.PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER`,
+/// `LibProdDeploy.MORPHO_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER`,
+/// `LibProdDeploy.PASSTHROUGH_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER`) are
+/// inlined into this contract's runtime bytecode at compile time.
+/// Redeploying any sub-deployer requires redeploying this contract too —
+/// otherwise calls route to the old sub-deployer until this bytecode is
+/// replaced. There is no on-chain pointer to chase. Tracked at #209.
 contract OracleUnifiedDeployer {
     /// Emitted when a new oracle and protocol adapter set is deployed.
     event Deployment(

--- a/src/concrete/protocol/MorphoProtocolAdapter.sol
+++ b/src/concrete/protocol/MorphoProtocolAdapter.sol
@@ -25,6 +25,13 @@ error NonPositivePrice();
 /// @dev Error raised when no oracle is found for the vault in the registry.
 error OracleNotFound();
 
+/// @dev Error raised when the registered oracle reports decimals other than 8.
+/// The `* 1e28` scaling in `price()` assumes an 8-decimal upstream; any other
+/// value would silently mis-price collateral by orders of magnitude. Surfaces
+/// loudly to force a fix at registry-rebind time rather than letting
+/// Morpho borrow against a 10^N×-wrong price.
+error UnexpectedOracleDecimals(uint8 actual, uint8 expected);
+
 /// @dev Morpho Blue's IOracle interface.
 interface IOracle {
     function price() external view returns (uint256);
@@ -111,12 +118,25 @@ contract MorphoProtocolAdapter is IOracle, ICloneableV2, Initializable {
         admin = newAdmin;
     }
 
+    /// @dev Expected upstream oracle decimals. Hard-coded because the `* 1e28`
+    /// scaling factor below is derived from `36 - 8`.
+    uint8 internal constant EXPECTED_ORACLE_DECIMALS = 8;
+
     /// @notice Returns the price scaled to 36 decimals as required by Morpho
     /// Blue.
     /// @return The price as uint256 scaled to 1e36.
+    /// @dev Verifies the upstream oracle reports exactly
+    /// `EXPECTED_ORACLE_DECIMALS` (= 8) before scaling. A registry swap to a
+    /// non-8-decimal feed would otherwise silently mis-price by `10^N` —
+    /// catch loudly with `UnexpectedOracleDecimals` instead.
     function price() external view override returns (uint256) {
         AggregatorV2V3Interface oracle = registry.getOracle(vault);
         if (address(oracle) == address(0)) revert OracleNotFound();
+
+        uint8 oracleDecimals = oracle.decimals();
+        if (oracleDecimals != EXPECTED_ORACLE_DECIMALS) {
+            revert UnexpectedOracleDecimals(oracleDecimals, EXPECTED_ORACLE_DECIMALS);
+        }
 
         int256 answer = oracle.latestAnswer();
         if (answer <= 0) revert NonPositivePrice();

--- a/src/interface/IAggregatorV2V3.sol
+++ b/src/interface/IAggregatorV2V3.sol
@@ -2,6 +2,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
+// SYNC NOTE: This interface is a hand-typed copy of Chainlink's canonical
+// `AggregatorV2V3Interface` from
+// `smartcontractkit/chainlink:contracts/src/v0.8/shared/interfaces/AggregatorV2V3Interface.sol`,
+// last synced 2026-05-11 (pin TBD — track in #212). Re-sync on any
+// Chainlink interface version bump. No drift-detection test exists yet —
+// tracked at #212.
+
 /// @title AggregatorV2V3Interface
 /// @notice Hybrid of Chainlink's `AggregatorInterface` (v2 — `latestAnswer`)
 /// and `AggregatorV3Interface` (v3 — `latestRoundData`, `getRoundData`).

--- a/src/lib/LibCorporateActionsPause.sol
+++ b/src/lib/LibCorporateActionsPause.sol
@@ -45,6 +45,18 @@ library LibCorporateActionsPause {
     /// and a completed action's window contain `now` (e.g. a back-to-back
     /// schedule), the pending action's `effectiveTime` is returned —
     /// integrators see the next event coming, not the last one done.
+    /// @dev The upper-bound predicates on each branch — `pendingEffective >
+    /// block.timestamp` in the pre-window and `completedEffective <=
+    /// block.timestamp` in the post-window — are **enforced by the
+    /// consumed `ICorporateActionsV1` filter (`CompletionFilter.PENDING` /
+    /// `CompletionFilter.COMPLETED`), not locally**. This library trusts
+    /// the upstream's invariants and only checks the configurable side of
+    /// each window. A future vault regression that returned a PENDING
+    /// action with `effectiveTime <= now`, or a COMPLETED action with
+    /// `effectiveTime > now`, would surface here as a fail-open (the
+    /// oracle would not pause when it should). Mitigation is an upstream
+    /// conformance test on `ICorporateActionsV1` itself — tracked at
+    /// #216 (H11-style).
     function inPauseWindow(address corporateActionsVault, uint256 mask, uint64 pauseTimeBefore, uint64 pauseTimeAfter)
         internal
         view

--- a/subgraph/README.md
+++ b/subgraph/README.md
@@ -1,0 +1,37 @@
+# st0x.oracle subgraph
+
+The Graph subgraph that indexes deployment events from the `BeaconSetDeployer`
+contracts and the `OracleRegistry`. Driven by `subgraph.yaml` and the network
+address book in `networks.json`.
+
+## Address duplication with `src/lib/LibProdDeploy.sol`
+
+> **Heads up.** `subgraph/networks.json` duplicates every deployer address
+> from `src/lib/LibProdDeploy.sol` (Solidity constants). The two files are
+> currently kept in sync **by hand** as part of the deployment-PR ritual
+> documented in `AGENTS.md` § Deployment.
+>
+> Concretely, every `LibProdDeploy.*_BEACON_SET_DEPLOYER` /
+> `LibProdDeploy.*_UNIFIED_DEPLOYER` / `LibProdDeploy.ORACLE_REGISTRY*`
+> address has a mirror entry under `base.<ContractName>.address` in
+> `networks.json`. If the two ever diverge, the subgraph indexes a
+> different deployment than the contracts ship against.
+>
+> Drift risks are the same ones called out in `AGENTS.md`: typo on copy,
+> paste into the wrong key, PR merged out of order. The gen-pipeline
+> overhaul that would replace this hand-maintenance with a JSON artifact
+> emitted by the deployment workflow is tracked at **#220** (parent: the
+> broader deployment-pipeline rework at #210).
+
+## Local development
+
+```bash
+cd subgraph
+npm install
+npm run codegen
+npm run build
+npm run test       # matchstick unit tests
+```
+
+`docker-compose.yml` brings up a local graph-node + ipfs + postgres for
+end-to-end smoke testing. See `package.json` for the full script list.

--- a/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
@@ -11,7 +11,8 @@ import {
     ZeroRegistry,
     ZeroVault,
     OracleNotFound,
-    NonPositivePrice
+    NonPositivePrice,
+    UnexpectedOracleDecimals
 } from "src/concrete/protocol/MorphoProtocolAdapter.sol";
 import {
     MorphoProtocolAdapterBeaconSetDeployer,
@@ -171,6 +172,12 @@ contract MorphoProtocolAdapterTest is Test {
         adapter.price();
     }
 
+    /// Helper: mock the oracle's `decimals()` to return 8 so the
+    /// `EXPECTED_ORACLE_DECIMALS` check in `price()` passes.
+    function _mockDecimals(address mockOracle, uint8 d) internal {
+        vm.mockCall(mockOracle, abi.encodeWithSelector(AggregatorV2V3Interface.decimals.selector), abi.encode(d));
+    }
+
     /// Test price() scales 8 decimals to 36 decimals correctly.
     function testPriceScaling(address admin) external {
         vm.assume(admin != address(0));
@@ -183,6 +190,7 @@ contract MorphoProtocolAdapterTest is Test {
         vm.prank(admin);
         registry.setOracle(vault, AggregatorV2V3Interface(mockOracle));
 
+        _mockDecimals(mockOracle, 8);
         // Mock a price of 100.00000000 (100 USD at 8 decimals)
         int256 mockPrice = 100e8;
         vm.mockCall(
@@ -210,6 +218,7 @@ contract MorphoProtocolAdapterTest is Test {
         vm.prank(admin);
         registry.setOracle(vault, AggregatorV2V3Interface(mockOracle));
 
+        _mockDecimals(mockOracle, 8);
         vm.mockCall(
             mockOracle, abi.encodeWithSelector(AggregatorV2V3Interface.latestAnswer.selector), abi.encode(mockPrice)
         );
@@ -232,6 +241,7 @@ contract MorphoProtocolAdapterTest is Test {
         vm.prank(admin);
         registry.setOracle(vault, AggregatorV2V3Interface(mockOracle));
 
+        _mockDecimals(mockOracle, 8);
         vm.mockCall(
             mockOracle, abi.encodeWithSelector(AggregatorV2V3Interface.latestAnswer.selector), abi.encode(int256(0))
         );
@@ -255,6 +265,7 @@ contract MorphoProtocolAdapterTest is Test {
         vm.prank(admin);
         registry.setOracle(vault, AggregatorV2V3Interface(mockOracle));
 
+        _mockDecimals(mockOracle, 8);
         vm.mockCall(
             mockOracle, abi.encodeWithSelector(AggregatorV2V3Interface.latestAnswer.selector), abi.encode(negativePrice)
         );
@@ -262,6 +273,58 @@ contract MorphoProtocolAdapterTest is Test {
         MorphoProtocolAdapter adapter = I_DEPLOYER.newMorphoProtocolAdapter(registry, vault, admin);
 
         vm.expectRevert(abi.encodeWithSelector(NonPositivePrice.selector));
+        adapter.price();
+    }
+
+    /// `price()` must revert when the registered oracle reports any decimals
+    /// value other than 8 — preventing silent `10^N`-magnitude mis-pricing if
+    /// the registry is repointed to e.g. an 18-decimal Chainlink feed.
+    function testPriceRevertsOnNonEightDecimals(address admin, uint8 wrongDecimals) external {
+        vm.assume(admin != address(0));
+        vm.assume(wrongDecimals != 8);
+
+        address vault = address(uint160(uint256(keccak256("vault"))));
+        address mockOracle = address(uint160(uint256(keccak256("mock.oracle"))));
+
+        OracleRegistry registry = _createRegistry(admin);
+        vm.prank(admin);
+        registry.setOracle(vault, AggregatorV2V3Interface(mockOracle));
+
+        _mockDecimals(mockOracle, wrongDecimals);
+        // Set a non-zero answer so we can prove the decimals check fires
+        // BEFORE the latestAnswer/NonPositivePrice path.
+        vm.mockCall(
+            mockOracle, abi.encodeWithSelector(AggregatorV2V3Interface.latestAnswer.selector), abi.encode(int256(100e8))
+        );
+
+        MorphoProtocolAdapter adapter = I_DEPLOYER.newMorphoProtocolAdapter(registry, vault, admin);
+
+        vm.expectRevert(abi.encodeWithSelector(UnexpectedOracleDecimals.selector, wrongDecimals, uint8(8)));
+        adapter.price();
+    }
+
+    /// The decimals check happens BEFORE `latestAnswer()` is called — verify
+    /// by mocking `latestAnswer` to revert and confirming the decimals error
+    /// surfaces first (not the latestAnswer revert).
+    function testPriceDecimalsCheckRunsBeforeAnswer(address admin, uint8 wrongDecimals) external {
+        vm.assume(admin != address(0));
+        vm.assume(wrongDecimals != 8);
+
+        address vault = address(uint160(uint256(keccak256("vault"))));
+        address mockOracle = address(uint160(uint256(keccak256("mock.oracle"))));
+
+        OracleRegistry registry = _createRegistry(admin);
+        vm.prank(admin);
+        registry.setOracle(vault, AggregatorV2V3Interface(mockOracle));
+
+        _mockDecimals(mockOracle, wrongDecimals);
+        vm.mockCallRevert(
+            mockOracle, abi.encodeWithSelector(AggregatorV2V3Interface.latestAnswer.selector), "should not reach"
+        );
+
+        MorphoProtocolAdapter adapter = I_DEPLOYER.newMorphoProtocolAdapter(registry, vault, admin);
+
+        vm.expectRevert(abi.encodeWithSelector(UnexpectedOracleDecimals.selector, wrongDecimals, uint8(8)));
         adapter.price();
     }
 


### PR DESCRIPTION
MorphoProtocolAdapter.price() unconditionally scales `latestAnswer() *
1e28`, which is correct iff the upstream oracle reports 8 decimals.
`OracleRegistry.setOracle()` doesn't constrain decimals — a registry
swap to an 18-decimal feed (e.g. a future Chainlink integration) would
silently mis-price Morpho collateral by 10^10×. There is no observable
revert; Morpho would just see a wildly wrong number.

Adds:
- `EXPECTED_ORACLE_DECIMALS` constant (= 8) derived from the `36 - 8`
  scaling exponent.
- `UnexpectedOracleDecimals(uint8 actual, uint8 expected)` error.
- A `decimals()` check at the top of `price()`, BEFORE `latestAnswer()`
  is read, so a misconfigured oracle fails loudly before the wrong
  number ever enters the computation.

Tests:
- testPriceRevertsOnNonEightDecimals — fuzz over every uint8 != 8 and
  assert the new revert fires with the right payload.
- testPriceDecimalsCheckRunsBeforeAnswer — mocks `latestAnswer` to
  revert; confirms the decimals check fires first.
- All four existing positive tests updated to mock `oracle.decimals()`
  to 8 (default-zero would now hit the new revert).
- AutoPausePropagation tests continue to pass — they use the real
  PythOracleAdapter which hardcodes `decimals = 8`.

Closes #187.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>