### PR TITLE
fix(prodfork): replace silent skips with vm.skip + dedup ORACLE_REGISTRY (audit #208 #213)

### DIFF
--- a/test/src/concrete/ProdFork.t.sol
+++ b/test/src/concrete/ProdFork.t.sol
@@ -27,10 +27,6 @@ library LibProdOracles {
     /// Deployed to Base 2026-02-13.
     address constant WTCOIN_PASSTHROUGH = 0x2e73ef522E9369576bD5fC8f25Bf2f0E4cC6b57E;
 
-    /// OracleRegistry instance.
-    /// Deployed to Base 2026-02-13.
-    address constant ORACLE_REGISTRY = 0x36a14d00a8597731fb6dB1e0e7EeA0BB81ffD156;
-
     /// wtCOIN ERC-4626 vault.
     address constant WTCOIN_VAULT = 0x5cDa0E1CA4ce2af96315f7F8963C85399c172204;
 
@@ -58,12 +54,16 @@ library LibProdOracles {
 ///
 /// To run: forge test --match-contract ProdForkTest --fork-url $RPC_URL_BASE_FORK
 ///
-/// NOTE: Tests will be skipped (pass vacuously) until oracle addresses are
-/// set in LibProdOracles. This allows the PR to merge before deployment.
+/// Tests in this contract use `vm.skip(true)` rather than silent `return;` when
+/// the fork RPC env var (`RPC_URL_BASE_FORK`) is missing or a required prod
+/// address is unset / has no code on the fork. This makes missing fork
+/// availability surface as SKIPPED in `forge test` output (and in CI), rather
+/// than as a vacuously-passing test with zero assertions.
 contract ProdForkTest is Test {
     /// @dev Skip modifier for oracle-only tests.
     modifier onlyIfOracleDeployed() {
         if (LibProdOracles.WTCOIN_ORACLE == address(0)) {
+            vm.skip(true);
             return;
         }
         _;
@@ -72,6 +72,7 @@ contract ProdForkTest is Test {
     /// @dev Skip modifier for Morpho adapter tests.
     modifier onlyIfMorphoDeployed() {
         if (LibProdOracles.WTCOIN_MORPHO == address(0)) {
+            vm.skip(true);
             return;
         }
         _;
@@ -80,6 +81,7 @@ contract ProdForkTest is Test {
     /// @dev Skip modifier for Passthrough adapter tests.
     modifier onlyIfPassthroughDeployed() {
         if (LibProdOracles.WTCOIN_PASSTHROUGH == address(0)) {
+            vm.skip(true);
             return;
         }
         _;
@@ -87,7 +89,8 @@ contract ProdForkTest is Test {
 
     /// @dev Skip modifier for registry tests.
     modifier onlyIfRegistryDeployed() {
-        if (LibProdOracles.ORACLE_REGISTRY == address(0)) {
+        if (LibProdDeploy.ORACLE_REGISTRY == address(0)) {
+            vm.skip(true);
             return;
         }
         _;
@@ -99,6 +102,7 @@ contract ProdForkTest is Test {
             LibProdOracles.WTCOIN_ORACLE == address(0) || LibProdOracles.WTCOIN_MORPHO == address(0)
                 || LibProdOracles.WTCOIN_PASSTHROUGH == address(0)
         ) {
+            vm.skip(true);
             return;
         }
         _;
@@ -294,9 +298,12 @@ contract ProdForkTest is Test {
     function testProdRegistryHasWtcoinOracle() external onlyIfRegistryDeployed onlyIfOracleDeployed {
         _forkBase();
         // Registry now points to multi oracle after swap; skip on post-swap fork blocks.
-        if (_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) return;
+        if (_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) {
+            vm.skip(true);
+            return;
+        }
 
-        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        OracleRegistry registry = OracleRegistry(LibProdDeploy.ORACLE_REGISTRY);
         AggregatorV2V3Interface oracle = registry.getOracle(LibProdOracles.WTCOIN_VAULT);
         assertEq(address(oracle), LibProdOracles.WTCOIN_ORACLE, "Registry should map wtCOIN vault to oracle");
     }
@@ -305,7 +312,7 @@ contract ProdForkTest is Test {
     function testProdRegistrySetOracle() external onlyIfRegistryDeployed {
         _forkBase();
 
-        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        OracleRegistry registry = OracleRegistry(LibProdDeploy.ORACLE_REGISTRY);
         address registryAdmin = registry.admin();
 
         // Set a dummy oracle for a dummy vault
@@ -322,7 +329,7 @@ contract ProdForkTest is Test {
     function testProdRegistrySetOracleBulk() external onlyIfRegistryDeployed {
         _forkBase();
 
-        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        OracleRegistry registry = OracleRegistry(LibProdDeploy.ORACLE_REGISTRY);
         address registryAdmin = registry.admin();
 
         address[] memory vaults = new address[](3);
@@ -347,7 +354,7 @@ contract ProdForkTest is Test {
     function testProdRegistryOnlyAdminCanSetOracle() external onlyIfRegistryDeployed {
         _forkBase();
 
-        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        OracleRegistry registry = OracleRegistry(LibProdDeploy.ORACLE_REGISTRY);
 
         vm.prank(address(0xdead));
         vm.expectRevert();
@@ -361,7 +368,7 @@ contract ProdForkTest is Test {
     function testProdRegistryOnlyAdminCanSetOracleBulk() external onlyIfRegistryDeployed {
         _forkBase();
 
-        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        OracleRegistry registry = OracleRegistry(LibProdDeploy.ORACLE_REGISTRY);
 
         address[] memory vaults = new address[](1);
         vaults[0] = address(0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa);
@@ -377,7 +384,7 @@ contract ProdForkTest is Test {
     function testProdRegistryBulkMismatchedLengthsReverts() external onlyIfRegistryDeployed {
         _forkBase();
 
-        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        OracleRegistry registry = OracleRegistry(LibProdDeploy.ORACLE_REGISTRY);
         address registryAdmin = registry.admin();
 
         address[] memory vaults = new address[](2);
@@ -395,7 +402,7 @@ contract ProdForkTest is Test {
     function testProdRegistrySetOracleZeroVaultReverts() external onlyIfRegistryDeployed {
         _forkBase();
 
-        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        OracleRegistry registry = OracleRegistry(LibProdDeploy.ORACLE_REGISTRY);
         address registryAdmin = registry.admin();
 
         vm.prank(registryAdmin);
@@ -407,7 +414,7 @@ contract ProdForkTest is Test {
     function testProdRegistrySetOracleZeroOracleReverts() external onlyIfRegistryDeployed {
         _forkBase();
 
-        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        OracleRegistry registry = OracleRegistry(LibProdDeploy.ORACLE_REGISTRY);
         address registryAdmin = registry.admin();
 
         vm.prank(registryAdmin);
@@ -419,7 +426,7 @@ contract ProdForkTest is Test {
     function testProdRegistrySetAdmin() external onlyIfRegistryDeployed {
         _forkBase();
 
-        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        OracleRegistry registry = OracleRegistry(LibProdDeploy.ORACLE_REGISTRY);
         address registryAdmin = registry.admin();
         address newAdmin = address(0x4444444444444444444444444444444444444444);
 
@@ -447,7 +454,7 @@ contract ProdForkTest is Test {
     function testProdRegistryUpdatePropagates() external onlyIfRegistryDeployed onlyIfAllDeployed {
         _forkBase();
 
-        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        OracleRegistry registry = OracleRegistry(LibProdDeploy.ORACLE_REGISTRY);
         MorphoProtocolAdapter morpho = MorphoProtocolAdapter(LibProdOracles.WTCOIN_MORPHO);
         PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_PASSTHROUGH);
 
@@ -523,7 +530,10 @@ contract ProdForkTest is Test {
     /// @notice Multi-feed oracle returns a positive price.
     function testProdWtcoinMultiOracleLatestAnswer() external {
         _forkBase();
-        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) return;
+        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) {
+            vm.skip(true);
+            return;
+        }
 
         MultiPythOracleAdapter oracle = MultiPythOracleAdapter(LibProdOracles.WTCOIN_MULTI_ORACLE);
         int256 answer = oracle.latestAnswer();
@@ -535,7 +545,10 @@ contract ProdForkTest is Test {
     /// @notice Multi-feed oracle returns valid latestRoundData.
     function testProdWtcoinMultiOracleLatestRoundData() external {
         _forkBase();
-        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) return;
+        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) {
+            vm.skip(true);
+            return;
+        }
 
         MultiPythOracleAdapter oracle = MultiPythOracleAdapter(LibProdOracles.WTCOIN_MULTI_ORACLE);
         (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
@@ -552,7 +565,10 @@ contract ProdForkTest is Test {
     /// @notice Multi-feed oracle reports 8 decimals.
     function testProdWtcoinMultiOracleDecimals() external {
         _forkBase();
-        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) return;
+        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) {
+            vm.skip(true);
+            return;
+        }
 
         MultiPythOracleAdapter oracle = MultiPythOracleAdapter(LibProdOracles.WTCOIN_MULTI_ORACLE);
         assertEq(oracle.decimals(), 8);
@@ -561,7 +577,10 @@ contract ProdForkTest is Test {
     /// @notice Multi-feed oracle config: vault, feed count, not paused.
     function testProdWtcoinMultiOracleConfig() external {
         _forkBase();
-        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) return;
+        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) {
+            vm.skip(true);
+            return;
+        }
 
         MultiPythOracleAdapter oracle = MultiPythOracleAdapter(LibProdOracles.WTCOIN_MULTI_ORACLE);
         assertEq(oracle.vault(), LibProdOracles.WTCOIN_VAULT, "Wrong vault");
@@ -572,7 +591,10 @@ contract ProdForkTest is Test {
     /// @notice Multi-feed oracle reverts when paused.
     function testProdWtcoinMultiOracleRevertsWhenPaused() external {
         _forkBase();
-        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) return;
+        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) {
+            vm.skip(true);
+            return;
+        }
 
         MultiPythOracleAdapter oracle = MultiPythOracleAdapter(LibProdOracles.WTCOIN_MULTI_ORACLE);
         address oracleAdmin = oracle.admin();
@@ -593,7 +615,10 @@ contract ProdForkTest is Test {
     /// @notice Multi-feed Morpho adapter returns price scaled to 36 decimals.
     function testProdWtcoinMultiMorphoPrice() external {
         _forkBase();
-        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_MORPHO)) return;
+        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_MORPHO)) {
+            vm.skip(true);
+            return;
+        }
 
         MorphoProtocolAdapter morpho = MorphoProtocolAdapter(LibProdOracles.WTCOIN_MULTI_MORPHO);
         uint256 morphoPrice = morpho.price();
@@ -605,7 +630,10 @@ contract ProdForkTest is Test {
     /// @notice Multi-feed passthrough returns same answer as multi-feed oracle.
     function testProdWtcoinMultiPassthroughAnswer() external {
         _forkBase();
-        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_PASSTHROUGH)) return;
+        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_PASSTHROUGH)) {
+            vm.skip(true);
+            return;
+        }
 
         PassthroughProtocolAdapter passthrough = PassthroughProtocolAdapter(LibProdOracles.WTCOIN_MULTI_PASSTHROUGH);
         int256 answer = passthrough.latestAnswer();
@@ -620,7 +648,10 @@ contract ProdForkTest is Test {
         if (
             !_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE) || !_existsOnFork(LibProdOracles.WTCOIN_MULTI_MORPHO)
                 || !_existsOnFork(LibProdOracles.WTCOIN_MULTI_PASSTHROUGH)
-        ) return;
+        ) {
+            vm.skip(true);
+            return;
+        }
 
         MultiPythOracleAdapter oracle = MultiPythOracleAdapter(LibProdOracles.WTCOIN_MULTI_ORACLE);
         MorphoProtocolAdapter morpho = MorphoProtocolAdapter(LibProdOracles.WTCOIN_MULTI_MORPHO);
@@ -637,9 +668,12 @@ contract ProdForkTest is Test {
     /// @notice Multi-feed oracle registered in registry matches expected address.
     function testProdRegistryHasWtcoinMultiOracle() external onlyIfRegistryDeployed {
         _forkBase();
-        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) return;
+        if (!_existsOnFork(LibProdOracles.WTCOIN_MULTI_ORACLE)) {
+            vm.skip(true);
+            return;
+        }
 
-        OracleRegistry registry = OracleRegistry(LibProdOracles.ORACLE_REGISTRY);
+        OracleRegistry registry = OracleRegistry(LibProdDeploy.ORACLE_REGISTRY);
         AggregatorV2V3Interface oracle = registry.getOracle(LibProdOracles.WTCOIN_VAULT);
         // After multi-feed deployment, registry should point to the multi oracle.
         assertEq(address(oracle), LibProdOracles.WTCOIN_MULTI_ORACLE, "Registry should map to multi oracle");


### PR DESCRIPTION
#213: ProdFork tests used `return;` in fork-availability modifiers,
making forge report PASSED for tests that never ran an assertion. Replace
with `vm.skip(true)` so missing fork env or unset prod addresses surface
as SKIPPED in CI output instead of false-green.

#208: ORACLE_REGISTRY address was independently encoded in both
`src/lib/LibProdDeploy.sol` and `test/src/concrete/ProdFork.t.sol`'s
`LibProdOracles`. Test now imports from `LibProdDeploy` so a future
prod-address rotation only requires one edit.

Closes #208, #213.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>