### PR TITLE
refactor(test): extract shared MockCorporateActions fixture (audit #207)

### DIFF
--- a/test/mocks/MockCorporateActions.sol
+++ b/test/mocks/MockCorporateActions.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {ICorporateActionsV1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
+import {CompletionFilter, NODE_NONE} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
+
+/// @title MockCorporateActions
+/// @notice Minimal mock of `ICorporateActionsV1` exposing only the two read
+/// paths `LibCorporateActionsPause` consumes. Other interface methods revert
+/// so a regression that calls them is caught loudly.
+///
+/// Setters accept a caller-supplied cursor so tests can exercise both the
+/// no-match sentinel (`NODE_NONE`) and the bootstrap node (cursor 0). Tests
+/// that don't care about cursor can just pass `1`.
+contract MockCorporateActions is ICorporateActionsV1 {
+    struct StubAction {
+        bool exists;
+        uint256 cursor;
+        uint256 actionType;
+        uint64 effectiveTime;
+    }
+
+    StubAction private _earliestPending;
+    StubAction private _latestCompleted;
+
+    function setEarliestPending(uint256 cursor, uint256 actionType, uint64 effectiveTime) external {
+        _earliestPending = StubAction({
+            exists: cursor != NODE_NONE, cursor: cursor, actionType: actionType, effectiveTime: effectiveTime
+        });
+    }
+
+    function setLatestCompleted(uint256 cursor, uint256 actionType, uint64 effectiveTime) external {
+        _latestCompleted = StubAction({
+            exists: cursor != NODE_NONE, cursor: cursor, actionType: actionType, effectiveTime: effectiveTime
+        });
+    }
+
+    function earliestActionOfType(uint256 mask, CompletionFilter filter)
+        external
+        view
+        override
+        returns (uint256, uint256, uint64)
+    {
+        if (filter != CompletionFilter.PENDING) revert("mock: only PENDING supported");
+        if (!_earliestPending.exists) return (NODE_NONE, 0, 0);
+        if (_earliestPending.actionType & mask == 0) return (NODE_NONE, 0, 0);
+        return (_earliestPending.cursor, _earliestPending.actionType, _earliestPending.effectiveTime);
+    }
+
+    function latestActionOfType(uint256 mask, CompletionFilter filter)
+        external
+        view
+        override
+        returns (uint256, uint256, uint64)
+    {
+        if (filter != CompletionFilter.COMPLETED) revert("mock: only COMPLETED supported");
+        if (!_latestCompleted.exists) return (NODE_NONE, 0, 0);
+        if (_latestCompleted.actionType & mask == 0) return (NODE_NONE, 0, 0);
+        return (_latestCompleted.cursor, _latestCompleted.actionType, _latestCompleted.effectiveTime);
+    }
+
+    function scheduleCorporateAction(bytes32, uint64, bytes calldata) external pure override returns (uint256) {
+        revert("mock: not implemented");
+    }
+
+    function cancelCorporateAction(uint256) external pure override {
+        revert("mock: not implemented");
+    }
+
+    function completedActionCount() external pure override returns (uint256) {
+        revert("mock: not implemented");
+    }
+
+    function nextOfType(uint256, uint256, CompletionFilter) external pure override returns (uint256, uint256, uint64) {
+        revert("mock: not implemented");
+    }
+
+    function prevOfType(uint256, uint256, CompletionFilter) external pure override returns (uint256, uint256, uint64) {
+        revert("mock: not implemented");
+    }
+
+    function getActionParameters(uint256) external pure override returns (bytes memory) {
+        revert("mock: not implemented");
+    }
+}

--- a/test/src/concrete/oracle/PythOracleAdapter.autoPause.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.autoPause.t.sol
@@ -3,13 +3,13 @@
 pragma solidity =0.8.25;
 
 import {PythOracleAdapterTest} from "test/abstract/PythOracleAdapterTest.sol";
+import {MockCorporateActions} from "test/mocks/MockCorporateActions.sol";
 import {IERC4626} from "openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {IPyth} from "pyth-sdk/IPyth.sol";
 import {PythStructs} from "pyth-sdk/PythStructs.sol";
 import {LibPyth} from "rain.pyth/src/lib/pyth/LibPyth.sol";
-import {ICorporateActionsV1, ACTION_TYPE_STOCK_SPLIT_V1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
-import {CompletionFilter, NODE_NONE} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
+import {ACTION_TYPE_STOCK_SPLIT_V1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
 import {
     CorporateActionPauseConfig,
     OraclePausedManual,
@@ -27,76 +27,6 @@ bytes32 constant MOCK_PRICE_ID = bytes32(uint256(0xdeadbeef));
 /// @dev Pyth contract address on Base (from `LibPyth`). We mock at this
 /// address so the runtime call resolves correctly regardless of fork state.
 address constant PYTH_BASE = 0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a;
-
-/// @dev Minimal `ICorporateActionsV1` mock exposing the two read paths
-/// `LibCorporateActionsPause` consumes. Other interface methods revert so a
-/// regression that calls them is caught loudly.
-contract MockCorporateActions is ICorporateActionsV1 {
-    struct Stub {
-        bool exists;
-        uint256 actionType;
-        uint64 effectiveTime;
-    }
-
-    Stub private _earliestPending;
-    Stub private _latestCompleted;
-
-    function setEarliestPending(uint256 actionType, uint64 effectiveTime) external {
-        _earliestPending = Stub({exists: true, actionType: actionType, effectiveTime: effectiveTime});
-    }
-
-    function setLatestCompleted(uint256 actionType, uint64 effectiveTime) external {
-        _latestCompleted = Stub({exists: true, actionType: actionType, effectiveTime: effectiveTime});
-    }
-
-    function earliestActionOfType(uint256 mask, CompletionFilter filter)
-        external
-        view
-        override
-        returns (uint256, uint256, uint64)
-    {
-        if (filter != CompletionFilter.PENDING) revert("mock: only PENDING expected");
-        if (!_earliestPending.exists) return (NODE_NONE, 0, 0);
-        if (_earliestPending.actionType & mask == 0) return (NODE_NONE, 0, 0);
-        return (1, _earliestPending.actionType, _earliestPending.effectiveTime);
-    }
-
-    function latestActionOfType(uint256 mask, CompletionFilter filter)
-        external
-        view
-        override
-        returns (uint256, uint256, uint64)
-    {
-        if (filter != CompletionFilter.COMPLETED) revert("mock: only COMPLETED expected");
-        if (!_latestCompleted.exists) return (NODE_NONE, 0, 0);
-        if (_latestCompleted.actionType & mask == 0) return (NODE_NONE, 0, 0);
-        return (1, _latestCompleted.actionType, _latestCompleted.effectiveTime);
-    }
-
-    function scheduleCorporateAction(bytes32, uint64, bytes calldata) external pure override returns (uint256) {
-        revert("mock: not implemented");
-    }
-
-    function cancelCorporateAction(uint256) external pure override {
-        revert("mock: not implemented");
-    }
-
-    function completedActionCount() external pure override returns (uint256) {
-        revert("mock: not implemented");
-    }
-
-    function nextOfType(uint256, uint256, CompletionFilter) external pure override returns (uint256, uint256, uint64) {
-        revert("mock: not implemented");
-    }
-
-    function prevOfType(uint256, uint256, CompletionFilter) external pure override returns (uint256, uint256, uint64) {
-        revert("mock: not implemented");
-    }
-
-    function getActionParameters(uint256) external pure override returns (bytes memory) {
-        revert("mock: not implemented");
-    }
-}
 
 /// @title PythOracleAdapterAutoPauseTest
 /// @notice Adapter-level tests verifying that `BasePythOracleAdapter` wires
@@ -144,7 +74,7 @@ contract PythOracleAdapterAutoPauseTest is PythOracleAdapterTest {
     function testNoAutoPauseWhenVaultIsZero() external {
         // Arm the mock with an in-window pending action; it should be
         // ignored because corporateActionsVault == address(0).
-        mock.setEarliestPending(ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 60));
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 60));
         PythOracleAdapter oracle = _config(
             CorporateActionPauseConfig({
                 corporateActionsVault: address(0),
@@ -161,7 +91,7 @@ contract PythOracleAdapterAutoPauseTest is PythOracleAdapterTest {
     /// `OraclePausedCorporateAction(effectiveTime)`.
     function testPendingInsideWindowRevertsLatestAnswer() external {
         uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
-        mock.setEarliestPending(ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
         PythOracleAdapter oracle = _config(_stockSplitConfig());
         vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
         oracle.latestAnswer();
@@ -170,7 +100,7 @@ contract PythOracleAdapterAutoPauseTest is PythOracleAdapterTest {
     /// @notice Same window also reverts `latestRoundData` (parity test).
     function testPendingInsideWindowRevertsLatestRoundData() external {
         uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
-        mock.setEarliestPending(ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
         PythOracleAdapter oracle = _config(_stockSplitConfig());
         vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
         oracle.latestRoundData();
@@ -179,7 +109,7 @@ contract PythOracleAdapterAutoPauseTest is PythOracleAdapterTest {
     /// @notice Completed action inside the post-window → revert.
     function testCompletedInsideWindowReverts() external {
         uint64 effectiveTime = uint64(block.timestamp - PAUSE_AFTER / 2);
-        mock.setLatestCompleted(ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        mock.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
         PythOracleAdapter oracle = _config(_stockSplitConfig());
         vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
         oracle.latestAnswer();
@@ -188,7 +118,7 @@ contract PythOracleAdapterAutoPauseTest is PythOracleAdapterTest {
     /// @notice Action exists but outside the window → no revert.
     function testPendingOutsideWindowSucceeds() external {
         // Twice the window away — pre-window cannot reach it.
-        mock.setEarliestPending(ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 2 * PAUSE_BEFORE));
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 2 * PAUSE_BEFORE));
         PythOracleAdapter oracle = _config(_stockSplitConfig());
         int256 answer = oracle.latestAnswer();
         assertGt(answer, 0);
@@ -198,7 +128,7 @@ contract PythOracleAdapterAutoPauseTest is PythOracleAdapterTest {
     /// reported (cheaper SLOAD wins precedence).
     function testManualPauseTakesPrecedenceOverAuto() external {
         uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
-        mock.setEarliestPending(ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
         PythOracleAdapter oracle = _config(_stockSplitConfig());
         oracle.setPaused(true);
         vm.expectRevert(abi.encodeWithSelector(OraclePausedManual.selector));
@@ -209,7 +139,7 @@ contract PythOracleAdapterAutoPauseTest is PythOracleAdapterTest {
     /// still open surfaces the auto error — they're independent.
     function testAutoPauseStillFiresAfterManualUnpaused() external {
         uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
-        mock.setEarliestPending(ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
         PythOracleAdapter oracle = _config(_stockSplitConfig());
         oracle.setPaused(true);
         oracle.setPaused(false);

--- a/test/src/concrete/protocol/AutoPausePropagation.t.sol
+++ b/test/src/concrete/protocol/AutoPausePropagation.t.sol
@@ -3,13 +3,13 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std/Test.sol";
+import {MockCorporateActions} from "test/mocks/MockCorporateActions.sol";
 import {IERC4626} from "openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {IPyth} from "pyth-sdk/IPyth.sol";
 import {PythStructs} from "pyth-sdk/PythStructs.sol";
 import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
-import {ICorporateActionsV1, ACTION_TYPE_STOCK_SPLIT_V1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
-import {CompletionFilter, NODE_NONE} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
+import {ACTION_TYPE_STOCK_SPLIT_V1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
 import {
     CorporateActionPauseConfig,
     OraclePausedCorporateAction,
@@ -44,73 +44,6 @@ uint256 constant BASE_CHAIN_ID = 8453;
 
 /// @dev Arbitrary mock Pyth feed ID — responses are vm.mockCall'd.
 bytes32 constant MOCK_PRICE_ID = bytes32(uint256(0xd00dface));
-
-/// @dev Same shape as the auto-pause test; one place to maintain so the two
-/// fixtures stay coherent.
-contract MockCorporateActions is ICorporateActionsV1 {
-    uint64 internal pendingEffectiveTime;
-    uint256 internal pendingActionType;
-    uint64 internal completedEffectiveTime;
-    uint256 internal completedActionType;
-
-    function setEarliestPending(uint256 actionType, uint64 effectiveTime) external {
-        pendingActionType = actionType;
-        pendingEffectiveTime = effectiveTime;
-    }
-
-    function setLatestCompleted(uint256 actionType, uint64 effectiveTime) external {
-        completedActionType = actionType;
-        completedEffectiveTime = effectiveTime;
-    }
-
-    function earliestActionOfType(uint256 mask, CompletionFilter filter)
-        external
-        view
-        override
-        returns (uint256, uint256, uint64)
-    {
-        if (filter != CompletionFilter.PENDING) revert("mock: only PENDING expected");
-        if (pendingEffectiveTime == 0) return (NODE_NONE, 0, 0);
-        if (pendingActionType & mask == 0) return (NODE_NONE, 0, 0);
-        return (1, pendingActionType, pendingEffectiveTime);
-    }
-
-    function latestActionOfType(uint256 mask, CompletionFilter filter)
-        external
-        view
-        override
-        returns (uint256, uint256, uint64)
-    {
-        if (filter != CompletionFilter.COMPLETED) revert("mock: only COMPLETED expected");
-        if (completedEffectiveTime == 0) return (NODE_NONE, 0, 0);
-        if (completedActionType & mask == 0) return (NODE_NONE, 0, 0);
-        return (1, completedActionType, completedEffectiveTime);
-    }
-
-    function scheduleCorporateAction(bytes32, uint64, bytes calldata) external pure override returns (uint256) {
-        revert("mock: not implemented");
-    }
-
-    function cancelCorporateAction(uint256) external pure override {
-        revert("mock: not implemented");
-    }
-
-    function completedActionCount() external pure override returns (uint256) {
-        revert("mock: not implemented");
-    }
-
-    function nextOfType(uint256, uint256, CompletionFilter) external pure override returns (uint256, uint256, uint64) {
-        revert("mock: not implemented");
-    }
-
-    function prevOfType(uint256, uint256, CompletionFilter) external pure override returns (uint256, uint256, uint64) {
-        revert("mock: not implemented");
-    }
-
-    function getActionParameters(uint256) external pure override returns (bytes memory) {
-        revert("mock: not implemented");
-    }
-}
 
 /// @title AutoPausePropagationTest
 /// @notice End-to-end check that an auto-pause revert from the oracle layer
@@ -211,7 +144,7 @@ contract AutoPausePropagationTest is Test {
     /// selector unchanged.
     function testPassthroughPropagatesAutoPauseRevert() external {
         uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
-        corporateActions.setEarliestPending(ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        corporateActions.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
         vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
         passthroughAdapter.latestAnswer();
         vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
@@ -222,7 +155,7 @@ contract AutoPausePropagationTest is Test {
     /// distinct selector still propagates.
     function testMorphoPropagatesAutoPauseRevert() external {
         uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
-        corporateActions.setEarliestPending(ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        corporateActions.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
         vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
         morphoAdapter.price();
     }
@@ -230,7 +163,7 @@ contract AutoPausePropagationTest is Test {
     /// @notice Manual pause precedence is preserved through the protocol
     /// adapter chain — even with an auto-pause condition also armed.
     function testManualPausePropagatesThroughChain() external {
-        corporateActions.setEarliestPending(ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + PAUSE_BEFORE / 2));
+        corporateActions.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + PAUSE_BEFORE / 2));
         oracle.setPaused(true);
         vm.expectRevert(abi.encodeWithSelector(OraclePausedManual.selector));
         passthroughAdapter.latestAnswer();

--- a/test/src/lib/LibCorporateActionsPause.t.sol
+++ b/test/src/lib/LibCorporateActionsPause.t.sol
@@ -3,85 +3,10 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std/Test.sol";
-import {ICorporateActionsV1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
-import {CompletionFilter, NODE_NONE} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
+import {NODE_NONE} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
 import {LibCorporateActionsPause} from "src/lib/LibCorporateActionsPause.sol";
 import {ACTION_TYPE_STOCK_SPLIT_V1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
-
-/// @dev Minimal mock of `ICorporateActionsV1` exposing only the two read paths
-/// `LibCorporateActionsPause` consumes. Other interface methods revert so a
-/// regression that calls them is caught loudly.
-contract MockCorporateActions is ICorporateActionsV1 {
-    struct StubAction {
-        bool exists;
-        uint256 cursor;
-        uint256 actionType;
-        uint64 effectiveTime;
-    }
-
-    StubAction private _earliestPending;
-    StubAction private _latestCompleted;
-
-    function setEarliestPending(uint256 cursor, uint256 actionType, uint64 effectiveTime) external {
-        _earliestPending = StubAction({
-            exists: cursor != NODE_NONE, cursor: cursor, actionType: actionType, effectiveTime: effectiveTime
-        });
-    }
-
-    function setLatestCompleted(uint256 cursor, uint256 actionType, uint64 effectiveTime) external {
-        _latestCompleted = StubAction({
-            exists: cursor != NODE_NONE, cursor: cursor, actionType: actionType, effectiveTime: effectiveTime
-        });
-    }
-
-    function earliestActionOfType(uint256 mask, CompletionFilter filter)
-        external
-        view
-        override
-        returns (uint256, uint256, uint64)
-    {
-        if (filter != CompletionFilter.PENDING) revert("mock: only PENDING supported");
-        if (!_earliestPending.exists) return (NODE_NONE, 0, 0);
-        if (_earliestPending.actionType & mask == 0) return (NODE_NONE, 0, 0);
-        return (_earliestPending.cursor, _earliestPending.actionType, _earliestPending.effectiveTime);
-    }
-
-    function latestActionOfType(uint256 mask, CompletionFilter filter)
-        external
-        view
-        override
-        returns (uint256, uint256, uint64)
-    {
-        if (filter != CompletionFilter.COMPLETED) revert("mock: only COMPLETED supported");
-        if (!_latestCompleted.exists) return (NODE_NONE, 0, 0);
-        if (_latestCompleted.actionType & mask == 0) return (NODE_NONE, 0, 0);
-        return (_latestCompleted.cursor, _latestCompleted.actionType, _latestCompleted.effectiveTime);
-    }
-
-    function scheduleCorporateAction(bytes32, uint64, bytes calldata) external pure override returns (uint256) {
-        revert("mock: not implemented");
-    }
-
-    function cancelCorporateAction(uint256) external pure override {
-        revert("mock: not implemented");
-    }
-
-    function completedActionCount() external pure override returns (uint256) {
-        revert("mock: not implemented");
-    }
-
-    function nextOfType(uint256, uint256, CompletionFilter) external pure override returns (uint256, uint256, uint64) {
-        revert("mock: not implemented");
-    }
-
-    function prevOfType(uint256, uint256, CompletionFilter) external pure override returns (uint256, uint256, uint64) {
-        revert("mock: not implemented");
-    }
-
-    function getActionParameters(uint256) external pure override returns (bytes memory) {
-        revert("mock: not implemented");
-    }
-}
+import {MockCorporateActions} from "test/mocks/MockCorporateActions.sol";
 
 contract LibCorporateActionsPauseTest is Test {
     MockCorporateActions internal mock;


### PR DESCRIPTION
Three separate test files each defined their own MockCorporateActions
mock of ICorporateActionsV1, with subtly different setter signatures.
Drift across these copies has already burned us — PR #221 had to
update the no-match sentinel in all three; a future ICorporateActionsV1
interface change risks updating only two of three.

Extracts the mock to `test/mocks/MockCorporateActions.sol` using the
most expressive of the three signatures (3-arg setters with
caller-supplied cursor). All three call sites now import the shared
mock. Behaviour unchanged: NODE_NONE no-match sentinel preserved from
PR #221; existing test assertions still pass.

Closes #207.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>