### PR TITLE
fix(oracle): narrow MultiPyth cascade to StalePrice-only fallthrough (audit #34 #176 #177)

### DIFF
--- a/src/concrete/oracle/MultiPythOracleAdapter.sol
+++ b/src/concrete/oracle/MultiPythOracleAdapter.sol
@@ -3,6 +3,7 @@
 pragma solidity =0.8.25;
 
 import {IPyth} from "pyth-sdk/IPyth.sol";
+import {PythErrors} from "pyth-sdk/PythErrors.sol";
 import {PythStructs} from "pyth-sdk/PythStructs.sol";
 import {LibPyth} from "rain.pyth/src/lib/pyth/LibPyth.sol";
 import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain.factory/interface/ICloneableV2.sol";
@@ -172,10 +173,19 @@ contract MultiPythOracleAdapter is BasePythOracleAdapter, ICloneableV2, Initiali
         revert AllFeedsStale();
     }
 
-    /// @dev Attempts to get a price from Pyth, returning success flag.
-    /// Extracted to avoid slither's pyth-unchecked-confidence detector
-    /// crashing on try/catch with Pyth calls (slither bug).
-    /// Confidence IS checked downstream in _conservativePriceFloat.
+    /// @dev Attempts to get a price from Pyth.
+    /// Returns `success = true` when Pyth returns a price. Returns
+    /// `success = false` **only** for `PythErrors.StalePrice()` — the
+    /// signal to try the next session feed. All other reverts
+    /// (e.g. `PriceFeedNotFound` for a misconfigured priceId, OOG, governance
+    /// guards) propagate so configuration errors fail loudly instead of
+    /// being silently absorbed into the cascade. Confidence is checked
+    /// downstream in `_conservativePriceFloat`.
+    ///
+    /// Slither suppression notes:
+    /// - `pyth-unchecked-confidence`: confidence IS checked downstream.
+    /// - `calls-loop`: intentional cascading design — max 8 iterations,
+    ///   each calling the immutable Pyth contract. Not a reentrancy risk.
     // slither-disable-next-line pyth-unchecked-confidence,calls-loop
     function _tryGetPrice(IPyth pyth, bytes32 feedPriceId, uint256 feedMaxAge)
         internal
@@ -184,8 +194,16 @@ contract MultiPythOracleAdapter is BasePythOracleAdapter, ICloneableV2, Initiali
     {
         try pyth.getPriceNoOlderThan(feedPriceId, feedMaxAge) returns (PythStructs.Price memory p) {
             return (true, p);
-        } catch {
-            return (false, price);
+        } catch (bytes memory reason) {
+            // Only StalePrice falls through to the next session feed.
+            // Anything else (PriceFeedNotFound, OOG, etc.) bubbles up.
+            if (reason.length == 4 && bytes4(reason) == PythErrors.StalePrice.selector) {
+                return (false, price);
+            }
+            // Re-raise the original revert preserving its selector + data.
+            assembly ("memory-safe") {
+                revert(add(reason, 0x20), mload(reason))
+            }
         }
     }
 

--- a/test/src/concrete/oracle/MultiPythOracleAdapter.fuzz.t.sol
+++ b/test/src/concrete/oracle/MultiPythOracleAdapter.fuzz.t.sol
@@ -6,6 +6,7 @@ import {Test} from "forge-std/Test.sol";
 import {IERC4626} from "openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {IPyth} from "pyth-sdk/IPyth.sol";
+import {PythErrors} from "pyth-sdk/PythErrors.sol";
 import {PythStructs} from "pyth-sdk/PythStructs.sol";
 import {
     ZeroVaultSupply,
@@ -73,10 +74,15 @@ contract MultiPythOracleAdapterFuzzTest is Test {
         );
     }
 
-    /// @dev Mock Pyth to revert (stale) for the given feed.
+    /// @dev Mock Pyth to revert with the canonical `StalePrice()` custom
+    /// error for the given feed — matches what the real Pyth contract
+    /// emits when a price is older than `maxAge`. The cascade catches
+    /// this selector specifically and falls through to the next feed.
     function _mockStaleFeed(bytes32 feedId, uint256 maxAge) internal {
         vm.mockCallRevert(
-            PYTH_BASE, abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, feedId, maxAge), "stale"
+            PYTH_BASE,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, feedId, maxAge),
+            abi.encodeWithSelector(PythErrors.StalePrice.selector)
         );
     }
 
@@ -178,5 +184,39 @@ contract MultiPythOracleAdapterFuzzTest is Test {
             int256 answer = adapter.latestAnswer();
             assertEq(answer, firstFreshExpectedPrice, "Should use first non-stale feed");
         }
+    }
+
+    /// @notice A non-stale Pyth revert (e.g. `PriceFeedNotFound` for a
+    /// misconfigured priceId) must propagate, not be absorbed into the
+    /// `AllFeedsStale` cascade. Pre-fix the bare `catch` swallowed all
+    /// reverts identically; misconfig was indistinguishable from "all
+    /// session feeds stale" once you reached the end of the cascade.
+    function testFirstFeedPriceFeedNotFoundPropagates() external {
+        address mockVault = address(uint160(uint256(keccak256("v.notfound"))));
+        _mockVault(mockVault, 1000e18, 1000e18);
+
+        bytes32 feedId = keccak256("feed.0");
+        FeedConfig[] memory feeds = new FeedConfig[](2);
+        feeds[0] = FeedConfig({priceId: feedId, maxAge: 300});
+        feeds[1] = FeedConfig({priceId: keccak256("feed.1"), maxAge: 300});
+
+        MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
+            MultiPythOracleAdapterConfig({
+                vault: mockVault, feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()
+            })
+        );
+
+        // First feed reverts with PriceFeedNotFound — must propagate, not
+        // fall through to the second feed.
+        vm.mockCallRevert(
+            PYTH_BASE,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, feedId, 300),
+            abi.encodeWithSelector(PythErrors.PriceFeedNotFound.selector)
+        );
+        // Second feed would succeed if reached — must NOT be reached.
+        _mockFreshFeed(keccak256("feed.1"), 300, 999e8, 1);
+
+        vm.expectRevert(abi.encodeWithSelector(PythErrors.PriceFeedNotFound.selector));
+        adapter.latestAnswer();
     }
 }


### PR DESCRIPTION
`MultiPythOracleAdapter._tryGetPrice` used a bare `catch {}` that
absorbed every Pyth revert into "stale, try next feed". A misconfigured
priceId, an OOG, or any future Pyth error was indistinguishable from
session staleness — operators got `AllFeedsStale` for any failure mode.

Three related findings:
- #34 / Pass 1: cascade swallows real errors as stale
- #176 / Pass 5: NatSpec "first non-stale price" is false (impl was
  "first non-reverting price")
- #177 / Pass 5: `AllFeedsStale` name conflates stale with misconfig

Fix: catch the typed `PythErrors.StalePrice()` selector only. Other
reverts propagate (preserving their original selector + data via
`memory-safe` assembly re-revert). After this change:
- NatSpec "first non-stale price" is accurate.
- `AllFeedsStale` is accurate — it only fires when every configured
  feed returned `StalePrice()`.
- A misconfigured priceId surfaces as `PriceFeedNotFound` instead of
  `AllFeedsStale`.

Test updates:
- `_mockStaleFeed` now reverts with `PythErrors.StalePrice.selector`
  instead of the string `"stale"` — matches what the real Pyth
  contract emits.
- New regression test `testFirstFeedPriceFeedNotFoundPropagates`
  arms feed 0 with `PriceFeedNotFound`, feed 1 with a fresh price,
  and asserts the cascade propagates the original revert instead of
  reaching feed 1.

Existing fuzz `testFuzzStalenessPatterns` continues to pass with 256
runs of the staleness bitmap.

Closes #34, #176, #177.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>