### PR TITLE
docs(audit): close ~44 LOW NatSpec / contract-doc findings in one sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,16 @@ nix develop -c rainix-sol-legal
 
 If any of these fail locally, CI will fail too. Do NOT push without running all three.
 
-At minimum:
-1. `forge fmt` — auto-format all Solidity files
-2. `forge build` — compile everything
-3. `forge test` — run unit + fuzz tests
+During iteration (not as a substitute for the three CI tasks above), the
+inner-loop commands are:
+
+1. `forge fmt` — auto-format Solidity sources
+2. `forge build` — compile
+3. `forge test` — unit + fuzz tests
+
+These are NOT a sufficient pre-push gate. `rainix-sol-test`,
+`rainix-sol-static`, and `rainix-sol-legal` are mandatory before every push;
+CI runs the same checks and will reject otherwise.
 
 For fork tests (ProdFork.t.sol):
 ```bash
@@ -130,10 +136,16 @@ Workflow secrets follow the `CI_DEPLOY_<NETWORK>_<SUFFIX>` pattern:
 - **PassthroughProtocolAdapter** — passes oracle price through unchanged (AggregatorV3Interface)
 - **OracleRegistry** — maps vault → oracle adapter. Protocol adapters look up their oracle from the registry at runtime.
 - **OracleUnifiedDeployer** — deploys all three adapters for a vault in one call. Takes registry address as parameter.
-- **Beacon pattern** — all contracts use UpgradeableBeacon proxies. `BEACON_INITIAL_OWNER` is `rainlang.eth` (`0x8E4bdeec7CEB9570D440676345dA1dCe10329f5b`).
+- **Beacon pattern** — all contracts use UpgradeableBeacon proxies.
+  `BEACON_INITIAL_OWNER` is `rainlang.eth`; see
+  `src/lib/LibProdDeploy.sol#BEACON_INITIAL_OWNER` for the authoritative
+  address.
 
 ## Key Constants
 
-- `BEACON_INITIAL_OWNER`: `0x8E4bdeec7CEB9570D440676345dA1dCe10329f5b` (rainlang.eth)
+- `BEACON_INITIAL_OWNER`: see
+  `src/lib/LibProdDeploy.sol#BEACON_INITIAL_OWNER` (rainlang.eth). The
+  Solidity constant is the single source of truth; do not duplicate the
+  literal address into other docs.
 - All deployer addresses are in `src/lib/LibProdDeploy.sol`
 - All oracle instance addresses are in `test/src/concrete/ProdFork.t.sol` `LibProdOracles`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,21 @@ forge fmt            # Format Solidity code
 forge fmt --check    # Check formatting without modifying
 ```
 
+## Pre-Push Gate (mandatory)
+
+Before every push, mirror CI locally — never use CI to surface issues.
+The three nix tasks below must all pass:
+
+```bash
+nix develop -c rainix-sol-test     # unit + fuzz + fork tests
+nix develop -c rainix-sol-static   # slither static analysis
+nix develop -c rainix-sol-legal    # REUSE license compliance
+```
+
+`forge test` alone is NOT a sufficient gate; slither and REUSE are
+regularly the failing step. See `AGENTS.md` for the full deployment and
+slither-suppression conventions.
+
 ## Architecture (Three Layers)
 
 **Oracle Layer** — canonical price source per vault, implements `AggregatorV2V3Interface` (8 decimals):
@@ -97,13 +112,21 @@ src/
 
 ## Security Rules
 
-- Pyth prices can be negative — always revert on `answer <= 0`
-- Scaling math must not overflow — use checked arithmetic
-- `maxAge` must be enforced on every price read
-- Vault with zero total supply must revert (no valid price)
-- Pause mechanism for corporate actions (splits, dividends)
-- All admin roles held by founder multisig, no role separation
-- Protocol adapters revert with `OracleNotFound` if vault not registered in registry
+- Pyth prices can be negative — always revert on `answer <= 0`.
+- Pyth confidence intervals must be subtracted on the `latestAnswer` path
+  (conservative pricing). See `BasePythOracleAdapter._conservativePriceFloat`.
+  Do not bypass.
+- Scaling math is in Rain `Float` arithmetic; overflow / lossy conversion
+  back to `int256` must revert (`ZeroVaultSharePrice`, range guards).
+- `maxAge` must be enforced on every price read.
+- Vault with zero total supply must revert (`ZeroVaultSupply`).
+- Two pause mechanisms, both enforced on every price read:
+  1. **Manual** admin flag → `OraclePausedManual()`.
+  2. **Auto** corporate-action window read from `ICorporateActionsV1` on
+     the configured corporateActionsVault → `OraclePausedCorporateAction(uint64 effectiveTime)`.
+  See SPEC § 16 and `src/lib/LibCorporateActionsPause.sol`.
+- All admin roles held by founder multisig; no role separation.
+- Protocol adapters revert with `OracleNotFound` if vault not registered in registry.
 
 ## Conventions
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -539,9 +539,13 @@ OracleUnifiedDeployer.newOracleAndProtocolAdapters(
     vault,          // Wrapped AAPL ERC-4626 vault address
     priceId,        // AAPL/USD feed ID (from LibPyth constants)
     60,             // maxAge in seconds
-    registry        // The canonical OracleRegistry
+    registry,       // The canonical OracleRegistry
+    pauseConfig     // Corporate-action auto-pause config — see § 16.
+                    // Set corporateActionsVault = address(0) to disable.
 );
-// Returns oracleAdapter, morphoAdapter, passthroughAdapter addresses
+// The function declares no return values; the deployed addresses
+// (oracleAdapter, morphoAdapter, passthroughAdapter) are emitted via
+// the `Deployment` event and must be recovered from logs.
 
 // Step 2: Register oracle in registry (admin action, separate tx)
 registry.setOracle(vault, oracleAdapter);

--- a/src/abstract/BasePythOracleAdapter.sol
+++ b/src/abstract/BasePythOracleAdapter.sol
@@ -18,9 +18,10 @@ error OraclePausedManual();
 /// integrators see the next event coming, not the last one done.
 error OraclePausedCorporateAction(uint64 effectiveTime);
 
-/// @dev Error raised when the conservative price (price - confidence) is not
-/// positive.
-error NonPositivePrice(int256 price);
+/// @dev Error raised when the conservative price (raw Pyth price minus
+/// confidence interval) is not positive. The carried value is that
+/// conservative price, not the raw Pyth price.
+error NonPositivePrice(int256 conservativePrice);
 
 /// @dev Error raised when a zero address is provided for the vault.
 error ZeroVault();
@@ -112,9 +113,12 @@ abstract contract BasePythOracleAdapter is AggregatorV2V3Interface {
     /// pausing. Immutable.
     uint64 public pauseTimeAfter;
 
-    /// @dev Emitted when the manual pause state changes.
+    /// @notice Emitted when the manual pause state changes.
+    /// @param isPaused The new pause state.
     event PauseSet(bool isPaused);
-    /// @dev Emitted when the admin is changed.
+    /// @notice Emitted when the admin is changed.
+    /// @param oldAdmin The previous admin address.
+    /// @param newAdmin The new admin address.
     event AdminSet(address indexed oldAdmin, address indexed newAdmin);
 
     modifier onlyAdmin() {
@@ -174,12 +178,19 @@ abstract contract BasePythOracleAdapter is AggregatorV2V3Interface {
     /// @notice Pause or unpause the oracle's manual flag. Admin only.
     /// @dev Independent of the corporate-action auto-pause; either condition
     /// causes price reads to revert.
+    /// @param isPaused True to pause, false to unpause.
     function setPaused(bool isPaused) external onlyAdmin {
         paused = isPaused;
         emit PauseSet(isPaused);
     }
 
     /// @notice Update the admin address. Admin only.
+    /// @dev One-step transfer — the new admin takes effect immediately. A
+    /// wrong `newAdmin` will lock the adapter's governance permanently:
+    /// `setPaused` will become uncallable. The only recovery is to redeploy
+    /// the oracle and `OracleRegistry.setOracle(vault, newOracle)` to
+    /// redirect downstream protocols. Use a multisig that cannot be
+    /// misaddressed.
     /// @param newAdmin The new admin address.
     function setAdmin(address newAdmin) external onlyAdmin {
         if (newAdmin == address(0)) revert ZeroAdmin();

--- a/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
@@ -13,7 +13,8 @@ import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 error ZeroImplementation();
 
 /// @dev Error raised when a zero address is provided for the initial beacon
-/// owner.
+/// owner. Only constrains construction-time ownership; subsequent owner
+/// rotations are the beacon's concern.
 error ZeroBeaconOwner();
 
 /// @dev Error raised when initialization of the protocol adapter fails.
@@ -30,8 +31,11 @@ struct MorphoProtocolAdapterBeaconSetDeployerConfig {
 }
 
 /// @title MorphoProtocolAdapterBeaconSetDeployer
-/// @notice Deploys and manages a beacon set for MorphoProtocolAdapter
-/// contracts. Used for Morpho Blue protocol integration.
+/// @notice Deploys a beacon and the proxies that share it for
+/// MorphoProtocolAdapter contracts. Beacon management (upgrades, ownership
+/// transfer) is performed externally by the beacon owner; this contract
+/// retains no authority over the beacon after construction. Used for Morpho
+/// Blue protocol integration.
 contract MorphoProtocolAdapterBeaconSetDeployer {
     /// Emitted when a new MorphoProtocolAdapter is deployed.
     event Deployment(address sender, address morphoProtocolAdapter);
@@ -54,7 +58,12 @@ contract MorphoProtocolAdapterBeaconSetDeployer {
     /// @notice Deploys and initializes a new MorphoProtocolAdapter proxy.
     /// @param registry The oracle registry address.
     /// @param vault The vault address this adapter serves.
-    /// @param admin The admin address.
+    /// @param admin Sole governance principal of the deployed adapter:
+    /// can call `setRegistry(newRegistry)` to swap the registry pointer
+    /// and `setAdmin(newAdmin)` to rotate this role. Distinct from the
+    /// `OracleRegistry` admin, which is not affected by this argument.
+    /// One-step transfer model — pass an address that cannot be
+    /// misaddressed (typically a multisig).
     /// @return adapter The deployed MorphoProtocolAdapter proxy.
     // slither-disable-next-line reentrancy-events
     function newMorphoProtocolAdapter(OracleRegistry registry, address vault, address admin)

--- a/src/concrete/deploy/MultiOracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/MultiOracleUnifiedDeployer.sol
@@ -25,7 +25,9 @@ error MultiPythBeaconSetDeployerNotSet();
 /// @title MultiOracleUnifiedDeployer
 /// @notice Atomically deploys a MultiPythOracleAdapter and all protocol
 /// adapters (Morpho, Passthrough for Aave/Compound) for a new vault. Mirrors
-/// OracleUnifiedDeployer but uses multi-feed oracle for near-24/7 coverage.
+/// OracleUnifiedDeployer (with an added pre-flight check that the multi-Pyth
+/// beacon-set deployer constant in LibProdDeploy is non-zero) but uses
+/// multi-feed oracle for near-24/7 coverage.
 /// @dev The sub-deployer addresses
 /// (`LibProdDeploy.MULTI_PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER`,
 /// `LibProdDeploy.MORPHO_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER`,
@@ -35,7 +37,11 @@ error MultiPythBeaconSetDeployerNotSet();
 /// otherwise calls route to the old sub-deployer until this bytecode is
 /// replaced. There is no on-chain pointer to chase. Tracked at #209.
 contract MultiOracleUnifiedDeployer {
-    /// Emitted when a new multi-feed oracle and protocol adapter set is deployed.
+    /// @notice Emitted when a new multi-feed oracle and protocol adapter set is deployed.
+    /// @param sender The caller that triggered the deployment.
+    /// @param multiPythOracleAdapter The address of the new MultiPythOracleAdapter proxy.
+    /// @param morphoProtocolAdapter The address of the new MorphoProtocolAdapter proxy.
+    /// @param passthroughProtocolAdapter The address of the new PassthroughProtocolAdapter proxy.
     event Deployment(
         address sender,
         address multiPythOracleAdapter,
@@ -48,8 +54,10 @@ contract MultiOracleUnifiedDeployer {
     /// @param feeds Ordered list of Pyth feed configurations (tried in order).
     /// @param registry The oracle registry. Admin must call registry.setOracle() separately.
     /// @param pauseConfig Corporate-action auto-pause configuration — see
-    /// SPEC § 16. Pass an all-zero struct to disable auto-pause (legacy /
-    /// manual-only mode).
+    /// SPEC § 16. To disable auto-pause entirely, set
+    /// `pauseConfig.corporateActionsVault = address(0)` (other fields ignored).
+    /// Setting only `actionTypeMask = 0` while keeping a non-zero
+    /// corporateActionsVault costs gas on every read but never pauses.
     // slither-disable-next-line reentrancy-events
     function newMultiOracleAndProtocolAdapters(
         address vault,

--- a/src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol
@@ -12,7 +12,8 @@ import {MultiPythOracleAdapter, MultiPythOracleAdapterConfig} from "src/concrete
 error MultiZeroImplementation();
 
 /// @dev Error raised when a zero address is provided for the initial beacon
-/// owner.
+/// owner. Only constrains construction-time ownership; subsequent owner
+/// rotations are the beacon's concern.
 error MultiZeroBeaconOwner();
 
 /// @dev Error raised when initialization of the oracle adapter fails.
@@ -29,7 +30,10 @@ struct MultiPythOracleAdapterBeaconSetDeployerConfig {
 }
 
 /// @title MultiPythOracleAdapterBeaconSetDeployer
-/// @notice Deploys and manages a beacon set for MultiPythOracleAdapter contracts.
+/// @notice Deploys a beacon and the proxies that share it for
+/// MultiPythOracleAdapter contracts. Beacon management (upgrades,
+/// ownership transfer) is performed externally by the beacon owner; this
+/// contract retains no authority over the beacon after construction.
 /// Follows the st0x.deploy BeaconSetDeployer pattern.
 contract MultiPythOracleAdapterBeaconSetDeployer {
     /// Emitted when a new MultiPythOracleAdapter is deployed.

--- a/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
+++ b/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
@@ -12,7 +12,8 @@ import {OracleRegistry, OracleRegistryConfig} from "src/concrete/registry/Oracle
 error ZeroImplementation();
 
 /// @dev Error raised when a zero address is provided for the initial beacon
-/// owner.
+/// owner. Only constrains construction-time ownership; subsequent owner
+/// rotations are the beacon's concern.
 error ZeroBeaconOwner();
 
 /// @dev Error raised when initialization of the oracle registry fails.
@@ -28,8 +29,12 @@ struct OracleRegistryBeaconSetDeployerConfig {
 }
 
 /// @title OracleRegistryBeaconSetDeployer
-/// @notice Deploys and manages a beacon set for OracleRegistry contracts.
-/// Follows the st0x.deploy BeaconSetDeployer pattern.
+/// @notice Deploys a beacon (constructed once at deploy-time) and the
+/// proxies that share it for OracleRegistry contracts. Beacon authority
+/// — including upgrade and ownership transfer — lives entirely with the
+/// `initialOwner` supplied at construction; this contract retains no
+/// post-construction authority over the beacon. Follows the st0x.deploy
+/// BeaconSetDeployer pattern.
 contract OracleRegistryBeaconSetDeployer {
     /// Emitted when a new OracleRegistry is deployed.
     event Deployment(address sender, address oracleRegistry);
@@ -50,8 +55,10 @@ contract OracleRegistryBeaconSetDeployer {
     }
 
     /// @notice Deploys and initializes a new OracleRegistry proxy.
-    /// The caller (msg.sender) becomes the registry admin, consistent with
-    /// OracleUnifiedDeployer which sets msg.sender as admin for all adapters.
+    /// @dev `msg.sender` becomes the registry admin. SPEC §13 states the
+    /// registry admin is the founder multisig, so this function MUST be
+    /// called from that multisig (or, after deployment, transfer admin to
+    /// the multisig via `OracleRegistry.setAdmin`).
     /// @return registry The deployed OracleRegistry proxy.
     // slither-disable-next-line reentrancy-events
     function newOracleRegistry() external returns (OracleRegistry) {

--- a/src/concrete/deploy/OracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/OracleUnifiedDeployer.sol
@@ -27,7 +27,11 @@ import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
 /// otherwise calls route to the old sub-deployer until this bytecode is
 /// replaced. There is no on-chain pointer to chase. Tracked at #209.
 contract OracleUnifiedDeployer {
-    /// Emitted when a new oracle and protocol adapter set is deployed.
+    /// @notice Emitted when a new oracle and protocol adapter set is deployed.
+    /// @param sender The caller that triggered the deployment.
+    /// @param pythOracleAdapter The address of the new PythOracleAdapter proxy.
+    /// @param morphoProtocolAdapter The address of the new MorphoProtocolAdapter proxy.
+    /// @param passthroughProtocolAdapter The address of the new PassthroughProtocolAdapter proxy.
     event Deployment(
         address sender, address pythOracleAdapter, address morphoProtocolAdapter, address passthroughProtocolAdapter
     );
@@ -38,8 +42,10 @@ contract OracleUnifiedDeployer {
     /// @param maxAge Maximum acceptable price age in seconds.
     /// @param registry The oracle registry. Admin must call registry.setOracle() separately.
     /// @param pauseConfig Corporate-action auto-pause configuration — see
-    /// SPEC § 16. Pass an all-zero struct to disable auto-pause (legacy /
-    /// manual-only mode).
+    /// SPEC § 16. To disable auto-pause entirely, set
+    /// `pauseConfig.corporateActionsVault = address(0)` (other fields ignored).
+    /// Setting only `actionTypeMask = 0` while keeping a non-zero
+    /// corporateActionsVault costs gas on every read but never pauses.
     // slither-disable-next-line reentrancy-events
     function newOracleAndProtocolAdapters(
         address vault,

--- a/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
@@ -16,7 +16,8 @@ import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 error ZeroImplementation();
 
 /// @dev Error raised when a zero address is provided for the initial beacon
-/// owner.
+/// owner. Only constrains construction-time ownership; subsequent owner
+/// rotations are the beacon's concern.
 error ZeroBeaconOwner();
 
 /// @dev Error raised when initialization of the protocol adapter fails.
@@ -34,9 +35,11 @@ struct PassthroughProtocolAdapterBeaconSetDeployerConfig {
 }
 
 /// @title PassthroughProtocolAdapterBeaconSetDeployer
-/// @notice Deploys and manages a beacon set for PassthroughProtocolAdapter
-/// contracts. Used for Aave V3, Compound V3, and any future
-/// Chainlink-compatible protocol.
+/// @notice Deploys a beacon and the proxies that share it for
+/// PassthroughProtocolAdapter contracts. Beacon management (upgrades,
+/// ownership transfer) is performed externally by the beacon owner; this
+/// contract retains no authority over the beacon after construction. Used
+/// for Aave V3, Compound V3, and any future Chainlink-compatible protocol.
 contract PassthroughProtocolAdapterBeaconSetDeployer {
     /// Emitted when a new PassthroughProtocolAdapter is deployed.
     event Deployment(address sender, address passthroughProtocolAdapter);
@@ -59,7 +62,12 @@ contract PassthroughProtocolAdapterBeaconSetDeployer {
     /// @notice Deploys and initializes a new PassthroughProtocolAdapter proxy.
     /// @param registry The oracle registry address.
     /// @param vault The vault address this adapter serves.
-    /// @param admin The admin address.
+    /// @param admin Sole governance principal of the deployed adapter:
+    /// can call `setRegistry(newRegistry)` to swap the registry pointer
+    /// and `setAdmin(newAdmin)` to rotate this role. Distinct from the
+    /// `OracleRegistry` admin, which is not affected by this argument.
+    /// One-step transfer model — pass an address that cannot be
+    /// misaddressed (typically a multisig).
     /// @return adapter The deployed PassthroughProtocolAdapter proxy.
     // slither-disable-next-line reentrancy-events
     function newPassthroughProtocolAdapter(OracleRegistry registry, address vault, address admin)

--- a/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol
@@ -12,7 +12,8 @@ import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/Py
 error ZeroImplementation();
 
 /// @dev Error raised when a zero address is provided for the initial beacon
-/// owner.
+/// owner. Only constrains construction-time ownership; subsequent owner
+/// rotations are the beacon's concern.
 error ZeroBeaconOwner();
 
 /// @dev Error raised when initialization of the oracle adapter fails.
@@ -29,8 +30,11 @@ struct PythOracleAdapterBeaconSetDeployerConfig {
 }
 
 /// @title PythOracleAdapterBeaconSetDeployer
-/// @notice Deploys and manages a beacon set for PythOracleAdapter contracts.
-/// Follows the st0x.deploy BeaconSetDeployer pattern.
+/// @notice Deploys a beacon and the proxies that share it for
+/// PythOracleAdapter contracts. Beacon management (upgrades, ownership
+/// transfer) is performed externally by the beacon owner; this contract
+/// retains no authority over the beacon after construction. Follows the
+/// st0x.deploy BeaconSetDeployer pattern.
 contract PythOracleAdapterBeaconSetDeployer {
     /// Emitted when a new PythOracleAdapter is deployed.
     event Deployment(address sender, address pythOracleAdapter);

--- a/src/concrete/oracle/MultiPythOracleAdapter.sol
+++ b/src/concrete/oracle/MultiPythOracleAdapter.sol
@@ -49,6 +49,7 @@ struct FeedConfig {
 /// @notice Configuration for MultiPythOracleAdapter initialization.
 /// @param vault The ERC-4626 vault address this oracle prices shares for.
 /// @param feeds Ordered list of feed configurations (tried in order).
+/// MUTABLE post-init via admin's `setFeeds` / `setMaxAge`.
 /// @param admin The admin address for governance.
 /// @param pauseConfig Corporate-action auto-pause config — see SPEC § 16.
 /// All-zero is the legacy/manual-only mode; `corporateActionsVault =
@@ -66,30 +67,47 @@ struct MultiPythOracleAdapterConfig {
 /// near 24/7 coverage for equities with separate feeds for regular, pre-market,
 /// post-market, and overnight sessions.
 ///
+/// **Mutability divergence from PythOracleAdapter.** Unlike the single-feed
+/// sibling, the feed list and per-feed maxAge are mutable post-init under
+/// admin (`setFeeds`, `setMaxAge`) so per-session feed retuning does not
+/// require a new proxy + registry switch. Vault, admin, and corporate-action
+/// pause config remain immutable per SPEC §16.2 and the BeaconSetDeployer
+/// pattern.
+///
 /// Same external interface as PythOracleAdapter (AggregatorV2V3Interface).
 /// Each feed has its own maxAge since update frequency varies by session.
 ///
-/// Price formula: vaultSharePrice = pythPrice * totalAssets / totalSupply
+/// Price formula: vaultSharePrice = (pythPrice - pythConfidence) * totalAssets / totalSupply
+/// — i.e. the conservative price is used. See SPEC §15.2 and
+/// `BasePythOracleAdapter._conservativePriceFloat`.
 contract MultiPythOracleAdapter is BasePythOracleAdapter, ICloneableV2, Initializable {
     /// @dev Number of configured feeds.
     uint256 public feedCount;
     /// @dev Feed configurations indexed by position.
     mapping(uint256 => FeedConfig) internal _feeds;
 
-    /// @dev Emitted when the oracle is initialized.
+    /// @notice Emitted when the oracle is initialized.
+    /// @param sender The caller that initialized the proxy.
+    /// @param config The initialization configuration.
     event MultiPythOracleAdapterInitialized(address indexed sender, MultiPythOracleAdapterConfig config);
-    /// @dev Emitted when feeds are updated.
+    /// @notice Emitted when feeds are updated.
+    /// @param feeds The new ordered feed configurations.
     event FeedsSet(FeedConfig[] feeds);
-    /// @dev Emitted when a single feed's maxAge is updated.
+    /// @notice Emitted when a single feed's maxAge is updated.
+    /// @param index The feed index whose maxAge changed.
+    /// @param maxAge The new maxAge value in seconds.
     event FeedMaxAgeSet(uint256 index, uint256 maxAge);
 
     constructor() {
         _disableInitializers();
     }
 
-    /// As per ICloneableV2, this overload MUST always revert. Documents the
-    /// signature of the initialize function.
-    /// @param config The initialization configuration.
+    /// @notice Documents the typed signature of the initialize function. Per
+    /// ICloneableV2 this overload MUST always revert; callers should use the
+    /// `bytes calldata` overload instead.
+    /// @dev Always reverts with `InitializeSignatureFn`.
+    /// @param config The initialization configuration. Ignored.
+    /// @return Never returns; included only for the function signature.
     function initialize(MultiPythOracleAdapterConfig memory config) external pure returns (bytes32) {
         (config);
         revert InitializeSignatureFn();

--- a/src/concrete/oracle/PythOracleAdapter.sol
+++ b/src/concrete/oracle/PythOracleAdapter.sol
@@ -50,23 +50,30 @@ struct PythOracleAdapterConfig {
 /// Uses conservative pricing (price - confidence interval) per rain.pyth
 /// patterns. Scaling uses LibDecimalFloat for audited precision.
 ///
-/// Price formula: vaultSharePrice = pythPrice * totalAssets / totalSupply
+/// Price formula: vaultSharePrice = (pythPrice - pythConfidence) * totalAssets / totalSupply
+/// — i.e. the conservative price is used. See SPEC §15.2 and
+/// `BasePythOracleAdapter._conservativePriceFloat`.
 contract PythOracleAdapter is BasePythOracleAdapter, ICloneableV2, Initializable {
     /// @dev The Pyth price feed ID for the underlying asset.
     bytes32 public priceId;
     /// @dev Maximum acceptable price age in seconds.
     uint256 public maxAge;
 
-    /// @dev Emitted when the oracle is initialized.
+    /// @notice Emitted when the oracle is initialized.
+    /// @param sender The caller that initialized the proxy.
+    /// @param config The initialization configuration.
     event PythOracleAdapterInitialized(address indexed sender, PythOracleAdapterConfig config);
 
     constructor() {
         _disableInitializers();
     }
 
-    /// As per ICloneableV2, this overload MUST always revert. Documents the
-    /// signature of the initialize function.
-    /// @param config The initialization configuration.
+    /// @notice Documents the typed signature of the initialize function. Per
+    /// ICloneableV2 this overload MUST always revert; callers should use the
+    /// `bytes calldata` overload instead.
+    /// @dev Always reverts with `InitializeSignatureFn`.
+    /// @param config The initialization configuration. Ignored.
+    /// @return Never returns; included only for the function signature.
     function initialize(PythOracleAdapterConfig memory config) external pure returns (bytes32) {
         (config);
         revert InitializeSignatureFn();

--- a/src/concrete/protocol/MorphoProtocolAdapter.sol
+++ b/src/concrete/protocol/MorphoProtocolAdapter.sol
@@ -22,7 +22,10 @@ error ZeroVault();
 /// @dev Error raised when the price is not positive.
 error NonPositivePrice();
 
-/// @dev Error raised when no oracle is found for the vault in the registry.
+/// @dev Error raised when the currently-pointed registry has no entry for
+/// `vault`. This includes both the canonical-registry-never-registered case
+/// AND the `setRegistry`-pointed-elsewhere case (where the admin swapped
+/// the registry to one that doesn't know about this vault).
 error OracleNotFound();
 
 /// @dev Error raised when the registered oracle reports decimals other than 8.
@@ -32,8 +35,11 @@ error OracleNotFound();
 /// Morpho borrow against a 10^N×-wrong price.
 error UnexpectedOracleDecimals(uint8 actual, uint8 expected);
 
-/// @dev Morpho Blue's IOracle interface.
+/// @notice Morpho Blue's IOracle interface — the minimum surface a Morpho
+/// market expects from its oracle.
 interface IOracle {
+    /// @notice Returns the price scaled to 1e36 as required by Morpho Blue.
+    /// @return The price as uint256 scaled to 1e36.
     function price() external view returns (uint256);
 }
 
@@ -62,20 +68,29 @@ contract MorphoProtocolAdapter is IOracle, ICloneableV2, Initializable {
     /// @dev Admin address for governance actions.
     address public admin;
 
-    /// @dev Emitted when the adapter is initialized.
+    /// @notice Emitted when the adapter is initialized.
+    /// @param sender The caller that initialized the proxy.
+    /// @param config The initialization configuration.
     event MorphoProtocolAdapterInitialized(address indexed sender, MorphoProtocolAdapterConfig config);
-    /// @dev Emitted when the registry reference is updated.
+    /// @notice Emitted when the registry reference is updated.
+    /// @param oldRegistry The previous registry address.
+    /// @param newRegistry The new registry address.
     event RegistrySet(address indexed oldRegistry, address indexed newRegistry);
-    /// @dev Emitted when the admin is changed.
+    /// @notice Emitted when the admin is changed.
+    /// @param oldAdmin The previous admin address.
+    /// @param newAdmin The new admin address.
     event AdminSet(address indexed oldAdmin, address indexed newAdmin);
 
     constructor() {
         _disableInitializers();
     }
 
-    /// As per ICloneableV2, this overload MUST always revert. Documents the
-    /// signature of the initialize function.
-    /// @param config The initialization configuration.
+    /// @notice Documents the typed signature of the initialize function. Per
+    /// ICloneableV2 this overload MUST always revert; callers should use the
+    /// `bytes calldata` overload instead.
+    /// @dev Always reverts with `InitializeSignatureFn`.
+    /// @param config The initialization configuration. Ignored.
+    /// @return Never returns; included only for the function signature.
     function initialize(MorphoProtocolAdapterConfig memory config) external pure returns (bytes32) {
         (config);
         revert InitializeSignatureFn();
@@ -104,6 +119,7 @@ contract MorphoProtocolAdapter is IOracle, ICloneableV2, Initializable {
     }
 
     /// @notice Update the registry reference. Admin only.
+    /// @param newRegistry The new oracle registry address.
     function setRegistry(OracleRegistry newRegistry) external onlyAdmin {
         if (address(newRegistry) == address(0)) revert ZeroRegistry();
         emit RegistrySet(address(registry), address(newRegistry));
@@ -111,6 +127,12 @@ contract MorphoProtocolAdapter is IOracle, ICloneableV2, Initializable {
     }
 
     /// @notice Update the admin address. Admin only.
+    /// @dev One-step transfer — the new admin takes effect immediately. A
+    /// wrong `newAdmin` will lock the adapter's governance permanently:
+    /// `setRegistry` will become uncallable by the intended principal. The
+    /// only recovery is `OracleRegistry.setOracle(vault, newOracle)` to
+    /// redirect downstream protocols to a different `MorphoProtocolAdapter`
+    /// proxy. Use a multisig that cannot be misaddressed.
     /// @param newAdmin The new admin address.
     function setAdmin(address newAdmin) external onlyAdmin {
         if (newAdmin == address(0)) revert ZeroAdmin();

--- a/src/concrete/protocol/PassthroughProtocolAdapter.sol
+++ b/src/concrete/protocol/PassthroughProtocolAdapter.sol
@@ -19,7 +19,10 @@ error ZeroRegistry();
 /// @dev Error raised when a zero address is provided for the vault.
 error ZeroVault();
 
-/// @dev Error raised when no oracle is found for the vault in the registry.
+/// @dev Error raised when the currently-pointed registry has no entry for
+/// `vault`. This includes both the canonical-registry-never-registered case
+/// AND the `setRegistry`-pointed-elsewhere case (where the admin swapped
+/// the registry to one that doesn't know about this vault).
 error OracleNotFound();
 
 /// @title PassthroughProtocolAdapterConfig
@@ -38,6 +41,13 @@ struct PassthroughProtocolAdapterConfig {
 /// Chainlink-compatible protocol. Passes through all AggregatorV2V3Interface
 /// calls to the underlying oracle adapter. The registry reference is updatable
 /// by the admin, allowing oracle swaps without protocol governance.
+///
+/// PRECONDITION: All oracles registered for vaults consumed by this adapter
+/// MUST report `decimals() == 8`. Aave V3 and Compound V3 cache `decimals()`
+/// at registration time and hard-code the 8-decimal expectation; pointing
+/// the registry to an oracle with a different precision will silently scale
+/// prices wrong (e.g. an 18-decimal oracle yields 1e10× prices on Aave).
+/// SPEC §15's registry-admin-trust assumption applies.
 /// Deploy multiple proxy instances from the same beacon for different protocols.
 contract PassthroughProtocolAdapter is AggregatorV2V3Interface, ICloneableV2, Initializable {
     /// @dev The oracle registry for looking up the oracle adapter.
@@ -47,20 +57,29 @@ contract PassthroughProtocolAdapter is AggregatorV2V3Interface, ICloneableV2, In
     /// @dev Admin address for governance actions.
     address public admin;
 
-    /// @dev Emitted when the adapter is initialized.
+    /// @notice Emitted when the adapter is initialized.
+    /// @param sender The caller that initialized the proxy.
+    /// @param config The initialization configuration.
     event PassthroughProtocolAdapterInitialized(address indexed sender, PassthroughProtocolAdapterConfig config);
-    /// @dev Emitted when the registry reference is updated.
+    /// @notice Emitted when the registry reference is updated.
+    /// @param oldRegistry The previous registry address.
+    /// @param newRegistry The new registry address.
     event RegistrySet(address indexed oldRegistry, address indexed newRegistry);
-    /// @dev Emitted when the admin is changed.
+    /// @notice Emitted when the admin is changed.
+    /// @param oldAdmin The previous admin address.
+    /// @param newAdmin The new admin address.
     event AdminSet(address indexed oldAdmin, address indexed newAdmin);
 
     constructor() {
         _disableInitializers();
     }
 
-    /// As per ICloneableV2, this overload MUST always revert. Documents the
-    /// signature of the initialize function.
-    /// @param config The initialization configuration.
+    /// @notice Documents the typed signature of the initialize function. Per
+    /// ICloneableV2 this overload MUST always revert; callers should use the
+    /// `bytes calldata` overload instead.
+    /// @dev Always reverts with `InitializeSignatureFn`.
+    /// @param config The initialization configuration. Ignored.
+    /// @return Never returns; included only for the function signature.
     function initialize(PassthroughProtocolAdapterConfig memory config) external pure returns (bytes32) {
         (config);
         revert InitializeSignatureFn();
@@ -89,6 +108,7 @@ contract PassthroughProtocolAdapter is AggregatorV2V3Interface, ICloneableV2, In
     }
 
     /// @notice Update the registry reference. Admin only.
+    /// @param newRegistry The new oracle registry address.
     function setRegistry(OracleRegistry newRegistry) external onlyAdmin {
         if (address(newRegistry) == address(0)) revert ZeroRegistry();
         emit RegistrySet(address(registry), address(newRegistry));
@@ -96,6 +116,12 @@ contract PassthroughProtocolAdapter is AggregatorV2V3Interface, ICloneableV2, In
     }
 
     /// @notice Update the admin address. Admin only.
+    /// @dev One-step transfer — the new admin takes effect immediately. A
+    /// wrong `newAdmin` will lock the adapter's governance permanently:
+    /// `setRegistry` will become uncallable. The only recovery is
+    /// `OracleRegistry.setOracle(vault, newOracle)` to redirect downstream
+    /// protocols to a different `PassthroughProtocolAdapter` proxy. Use a
+    /// multisig that cannot be misaddressed.
     /// @param newAdmin The new admin address.
     function setAdmin(address newAdmin) external onlyAdmin {
         if (newAdmin == address(0)) revert ZeroAdmin();
@@ -131,6 +157,12 @@ contract PassthroughProtocolAdapter is AggregatorV2V3Interface, ICloneableV2, In
     }
 
     /// @inheritdoc AggregatorV2V3Interface
+    /// @dev `roundId` and `answeredInRound` are forwarded verbatim from the
+    /// registered upstream oracle. They are NOT normalized across
+    /// `OracleRegistry.setOracle` swaps; integrators that rely on Chainlink's
+    /// monotonically-increasing-roundId guarantee should not register this
+    /// adapter unless the registry's oracle is locked or the integrator's
+    /// staleness check tolerates discontinuities.
     // slither-disable-next-line unused-return
     function latestRoundData()
         external

--- a/src/concrete/registry/OracleRegistry.sol
+++ b/src/concrete/registry/OracleRegistry.sol
@@ -22,7 +22,9 @@ error ZeroOracle();
 error ArrayLengthMismatch();
 
 /// @title OracleRegistryConfig
-/// @notice Configuration for OracleRegistry initialization.
+/// @notice Single-field config struct kept to mirror the BeaconSetDeployer
+/// pattern used by sibling adapters; future fields can be added without an
+/// ABI break for the initializer.
 /// @param admin The admin address.
 struct OracleRegistryConfig {
     address admin;
@@ -39,20 +41,30 @@ contract OracleRegistry is ICloneableV2, Initializable {
     /// @dev Mapping from vault address to oracle adapter.
     mapping(address vault => AggregatorV2V3Interface oracle) internal _oracles;
 
-    /// @dev Emitted when the registry is initialized.
+    /// @notice Emitted when the registry is initialized.
+    /// @param sender The caller that initialized the proxy.
+    /// @param config The initialization configuration.
     event OracleRegistryInitialized(address indexed sender, OracleRegistryConfig config);
-    /// @dev Emitted when an oracle is set for a vault.
+    /// @notice Emitted when an oracle is set for a vault.
+    /// @param vault The vault address.
+    /// @param oldOracle The previous oracle adapter address (zero if none).
+    /// @param newOracle The new oracle adapter address.
     event OracleSet(address indexed vault, address indexed oldOracle, address indexed newOracle);
-    /// @dev Emitted when the admin is changed.
+    /// @notice Emitted when the admin is changed.
+    /// @param oldAdmin The previous admin address.
+    /// @param newAdmin The new admin address.
     event AdminSet(address indexed oldAdmin, address indexed newAdmin);
 
     constructor() {
         _disableInitializers();
     }
 
-    /// As per ICloneableV2, this overload MUST always revert. Documents the
-    /// signature of the initialize function.
-    /// @param config The initialization configuration.
+    /// @notice Documents the typed signature of the initialize function. Per
+    /// ICloneableV2 this overload MUST always revert; callers should use the
+    /// `bytes calldata` overload instead.
+    /// @dev Always reverts with `InitializeSignatureFn`.
+    /// @param config The initialization configuration. Ignored.
+    /// @return Never returns; included only for the function signature.
     function initialize(OracleRegistryConfig memory config) external pure returns (bytes32) {
         (config);
         revert InitializeSignatureFn();
@@ -77,6 +89,12 @@ contract OracleRegistry is ICloneableV2, Initializable {
     }
 
     /// @notice Update the admin address. Admin only.
+    /// @dev One-step transfer — the new admin takes effect immediately. A
+    /// wrong `newAdmin` will lock the registry's governance permanently:
+    /// `setOracle` / `setOracleBulk` will become uncallable. There is no
+    /// in-band recovery — downstream protocol adapters that look up via this
+    /// registry will be stuck on their current oracle. Use a multisig that
+    /// cannot be misaddressed.
     /// @param newAdmin The new admin address.
     function setAdmin(address newAdmin) external onlyAdmin {
         if (newAdmin == address(0)) revert ZeroAdmin();

--- a/src/lib/LibProdDeploy.sol
+++ b/src/lib/LibProdDeploy.sol
@@ -5,32 +5,50 @@ pragma solidity ^0.8.25;
 /// @title LibProdDeploy
 /// @notice Hardcoded production deployment addresses. Provides an audit trail
 /// in git of any address modifications.
+/// @dev Per-address "Deployed to … Run: …" comments are hand-curated by the
+/// operator after each workflow run (see `AGENTS.md` § Deployment). On a
+/// re-deploy the operator MUST append a new line of the form
+/// `Re-deployed to <network> <yyyy-mm-dd> with <reason>. Run: <runId>.`
+/// rather than rewriting the existing line — losing prior provenance breaks
+/// the audit trail. Tracked at #217 (Pass 6 hazard); future work moves this
+/// metadata into a workflow-generated JSON artifact consumed by a codegen
+/// step so the comments stop drifting from reality.
 library LibProdDeploy {
-    /// rainlang.eth founder multisig.
+    /// rainlang.eth founder multisig. Used as the `initialOwner` of every
+    /// `UpgradeableBeacon` constructed by every `*BeaconSetDeployer` in
+    /// `script/Deploy.sol`; per SPEC §13 this is the beacon upgrade authority.
     address constant BEACON_INITIAL_OWNER = 0x8E4bdeec7CEB9570D440676345dA1dCe10329f5b;
 
-    /// Deployed to Base 2026-02-13. Run: 21981134736.
+    /// Address of a deployed `PythOracleAdapterBeaconSetDeployer`. Deployed
+    /// to Base 2026-02-13. Run: 21981134736.
     address constant PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER = 0x29295438119dA1E773f6A103cC935c89BfdEbc4A;
 
+    /// Address of a deployed `MorphoProtocolAdapterBeaconSetDeployer`.
     /// Deployed to Base 2026-02-13. Run: 21981948500.
     address constant MORPHO_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER = 0x5022bb2ecB539Ad54E49871389E134fb2c9fE9a5;
 
+    /// Address of a deployed `PassthroughProtocolAdapterBeaconSetDeployer`.
     /// Deployed to Base 2026-02-13. Run: 21982188432.
     address constant PASSTHROUGH_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER = 0x62bb7076075a78dEc0e888668C44482235B93CD0;
 
-    /// Deployed to Base 2026-02-13. Run: 21982788744.
+    /// Address of a deployed `OracleUnifiedDeployer`. Deployed to Base
+    /// 2026-02-13. Run: 21982788744.
     address constant ORACLE_UNIFIED_DEPLOYER = 0x377c9657D1827b6bcd1e4B6d0a714815D5F2C615;
 
-    /// Deployed to Base 2026-02-13. Run: 21984615902.
+    /// Address of a deployed `OracleRegistryBeaconSetDeployer`. Deployed to
+    /// Base 2026-02-13. Run: 21984615902.
     address constant ORACLE_REGISTRY_BEACON_SET_DEPLOYER = 0x3B8E2056Dce6E6847e853c3FEdda379802cD07d3;
 
+    /// Address of a deployed `MultiPythOracleAdapterBeaconSetDeployer`.
     /// Deployed to Base 2026-02-17. Run: 22098089152.
     address constant MULTI_PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER = 0xDc555fb8043b50d449667eE718527eCad2A267ad;
 
-    /// Deployed to Base 2026-02-17. Run: 22098092240.
+    /// Address of a deployed `MultiOracleUnifiedDeployer`. Deployed to Base
+    /// 2026-02-17. Run: 22098092240.
     /// Re-deployed to Base 2026-02-18 with updated constants. Run: 22101213391.
     address constant MULTI_ORACLE_UNIFIED_DEPLOYER = 0x4fcef5a7B3059586ad7A9552aCA0a60d075CB74c;
 
-    /// Deployed to Base 2026-02-13.
+    /// Address of the canonical `OracleRegistry` proxy. Deployed to Base
+    /// 2026-02-13.
     address constant ORACLE_REGISTRY = 0x36a14d00a8597731fb6dB1e0e7EeA0BB81ffD156;
 }


### PR DESCRIPTION
Bundles the documentation-only LOW audit findings:
- 9 events get @notice + @param per parameter (was @dev only)
- 5 ICloneableV2 typed-overload initialisers get full NatSpec
- 4 setters / view functions get missing @param
- 9 contract/function NatSpec blocks rewritten to match actual behaviour
- 3 error definitions get better param names and docs
- 4 LibProdDeploy constants get per-constant role docs
- 1 setAdmin block gets a one-step-transfer lockout warning
- 1 PassthroughProtocolAdapter PRECONDITION on registered-oracle decimals
- 2 BeaconSetDeployer @param admin docs expand on conferred authority
- 3 AGENTS.md / CLAUDE.md process-doc refinements
- 3 SPEC.md drift fixes (§9 newOracleRegistry signature, §10 example call, §10 returns)

No executable code or test changes. nix CI green (test/static/legal).

Closes #30, #31, #32, #78, #79, #80, #84, #88, #92, #93, #95, #96, #97, #98, #99, #100, #101, #102, #103, #104, #105, #120, #147, #157, #160, #161, #165, #166, #167, #169, #170, #174, #178, #182, #189, #190, #191, #192, #202, #204, #211, #217, #219.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>