### PR TITLE
fix(audit-low): code-correctness sweep — 10 LOW findings in one pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,16 @@ nix develop -c rainix-sol-legal
 
 If any of these fail locally, CI will fail too. Do NOT push without running all three.
 
-At minimum:
-1. `forge fmt` — auto-format all Solidity files
-2. `forge build` — compile everything
-3. `forge test` — run unit + fuzz tests
+During iteration (not as a substitute for the three CI tasks above), the
+inner-loop commands are:
+
+1. `forge fmt` — auto-format Solidity sources
+2. `forge build` — compile
+3. `forge test` — unit + fuzz tests
+
+These are NOT a sufficient pre-push gate. `rainix-sol-test`,
+`rainix-sol-static`, and `rainix-sol-legal` are mandatory before every push;
+CI runs the same checks and will reject otherwise.
 
 For fork tests (ProdFork.t.sol):
 ```bash
@@ -130,10 +136,16 @@ Workflow secrets follow the `CI_DEPLOY_<NETWORK>_<SUFFIX>` pattern:
 - **PassthroughProtocolAdapter** — passes oracle price through unchanged (AggregatorV3Interface)
 - **OracleRegistry** — maps vault → oracle adapter. Protocol adapters look up their oracle from the registry at runtime.
 - **OracleUnifiedDeployer** — deploys all three adapters for a vault in one call. Takes registry address as parameter.
-- **Beacon pattern** — all contracts use UpgradeableBeacon proxies. `BEACON_INITIAL_OWNER` is `rainlang.eth` (`0x8E4bdeec7CEB9570D440676345dA1dCe10329f5b`).
+- **Beacon pattern** — all contracts use UpgradeableBeacon proxies.
+  `BEACON_INITIAL_OWNER` is `rainlang.eth`; see
+  `src/lib/LibProdDeploy.sol#BEACON_INITIAL_OWNER` for the authoritative
+  address.
 
 ## Key Constants
 
-- `BEACON_INITIAL_OWNER`: `0x8E4bdeec7CEB9570D440676345dA1dCe10329f5b` (rainlang.eth)
+- `BEACON_INITIAL_OWNER`: see
+  `src/lib/LibProdDeploy.sol#BEACON_INITIAL_OWNER` (rainlang.eth). The
+  Solidity constant is the single source of truth; do not duplicate the
+  literal address into other docs.
 - All deployer addresses are in `src/lib/LibProdDeploy.sol`
 - All oracle instance addresses are in `test/src/concrete/ProdFork.t.sol` `LibProdOracles`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,21 @@ forge fmt            # Format Solidity code
 forge fmt --check    # Check formatting without modifying
 ```
 
+## Pre-Push Gate (mandatory)
+
+Before every push, mirror CI locally — never use CI to surface issues.
+The three nix tasks below must all pass:
+
+```bash
+nix develop -c rainix-sol-test     # unit + fuzz + fork tests
+nix develop -c rainix-sol-static   # slither static analysis
+nix develop -c rainix-sol-legal    # REUSE license compliance
+```
+
+`forge test` alone is NOT a sufficient gate; slither and REUSE are
+regularly the failing step. See `AGENTS.md` for the full deployment and
+slither-suppression conventions.
+
 ## Architecture (Three Layers)
 
 **Oracle Layer** — canonical price source per vault, implements `AggregatorV2V3Interface` (8 decimals):
@@ -97,13 +112,21 @@ src/
 
 ## Security Rules
 
-- Pyth prices can be negative — always revert on `answer <= 0`
-- Scaling math must not overflow — use checked arithmetic
-- `maxAge` must be enforced on every price read
-- Vault with zero total supply must revert (no valid price)
-- Pause mechanism for corporate actions (splits, dividends)
-- All admin roles held by founder multisig, no role separation
-- Protocol adapters revert with `OracleNotFound` if vault not registered in registry
+- Pyth prices can be negative — always revert on `answer <= 0`.
+- Pyth confidence intervals must be subtracted on the `latestAnswer` path
+  (conservative pricing). See `BasePythOracleAdapter._conservativePriceFloat`.
+  Do not bypass.
+- Scaling math is in Rain `Float` arithmetic; overflow / lossy conversion
+  back to `int256` must revert (`ZeroVaultSharePrice`, range guards).
+- `maxAge` must be enforced on every price read.
+- Vault with zero total supply must revert (`ZeroVaultSupply`).
+- Two pause mechanisms, both enforced on every price read:
+  1. **Manual** admin flag → `OraclePausedManual()`.
+  2. **Auto** corporate-action window read from `ICorporateActionsV1` on
+     the configured corporateActionsVault → `OraclePausedCorporateAction(uint64 effectiveTime)`.
+  See SPEC § 16 and `src/lib/LibCorporateActionsPause.sol`.
+- All admin roles held by founder multisig; no role separation.
+- Protocol adapters revert with `OracleNotFound` if vault not registered in registry.
 
 ## Conventions
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -539,9 +539,13 @@ OracleUnifiedDeployer.newOracleAndProtocolAdapters(
     vault,          // Wrapped AAPL ERC-4626 vault address
     priceId,        // AAPL/USD feed ID (from LibPyth constants)
     60,             // maxAge in seconds
-    registry        // The canonical OracleRegistry
+    registry,       // The canonical OracleRegistry
+    pauseConfig     // Corporate-action auto-pause config — see § 16.
+                    // Set corporateActionsVault = address(0) to disable.
 );
-// Returns oracleAdapter, morphoAdapter, passthroughAdapter addresses
+// The function declares no return values; the deployed addresses
+// (oracleAdapter, morphoAdapter, passthroughAdapter) are emitted via
+// the `Deployment` event and must be recovered from logs.
 
 // Step 2: Register oracle in registry (admin action, separate tx)
 registry.setOracle(vault, oracleAdapter);

--- a/src/abstract/BasePythOracleAdapter.sol
+++ b/src/abstract/BasePythOracleAdapter.sol
@@ -47,6 +47,12 @@ error VaultSharePriceOverflow(uint256 price8);
 /// source (Pyth's own getPriceAtPublishTime, an indexer, etc.).
 error HistoricalRoundDataUnsupported(uint80 roundId);
 
+/// @dev Error raised when `_setCorporateActionPauseConfig` is called more than
+/// once. Enforces the SPEC §16.2 "immutable after initialize" invariant on the
+/// four corporate-action pause storage slots so subclass discipline cannot
+/// silently break it.
+error CorporateActionConfigAlreadyInitialized();
+
 /// @title CorporateActionPauseConfig
 /// @notice Configuration for the corporate-action-aware auto-pause feature.
 /// All fields are immutable after initialize — see SPEC § 16.2.
@@ -113,6 +119,14 @@ abstract contract BasePythOracleAdapter is AggregatorV2V3Interface {
     /// pausing. Immutable.
     uint64 public pauseTimeAfter;
 
+    /// @dev True once `_setCorporateActionPauseConfig` has run. The four
+    /// corporate-action pause slots become immutable thereafter — any second
+    /// call reverts with `CorporateActionConfigAlreadyInitialized`. Subclass
+    /// initializers MUST call the helper exactly once. Packed alongside
+    /// `pauseTimeBefore` and `pauseTimeAfter` in the same storage slot
+    /// (8 + 8 + 1 bytes ≪ 32), so the new invariant costs no extra slot.
+    bool internal _corporateActionConfigInitialized;
+
     /// @dev Reserved storage to avoid shifting subclass slot positions when
     /// new base-class state is introduced in future versions. Decrement
     /// `__gap.length` by 1 for each `uint256`-equivalent slot added above.
@@ -125,6 +139,20 @@ abstract contract BasePythOracleAdapter is AggregatorV2V3Interface {
     /// @param oldAdmin The previous admin address.
     /// @param newAdmin The new admin address.
     event AdminSet(address indexed oldAdmin, address indexed newAdmin);
+    /// @notice Emitted exactly once on initialize to record the corporate-action
+    /// auto-pause config. Lets off-chain indexers reconstruct an oracle's
+    /// full governance state from event logs alone, without per-oracle storage
+    /// reads.
+    /// @param corporateActionsVault Address implementing `ICorporateActionsV1`,
+    /// or `address(0)` to disable auto-pause.
+    /// @param actionTypeMask Bitmap of action types that trigger an auto-pause.
+    /// @param pauseTimeBefore Seconds before a pending action's `effectiveTime`
+    /// to start pausing.
+    /// @param pauseTimeAfter Seconds after a completed action's `effectiveTime`
+    /// to keep pausing.
+    event CorporateActionPauseConfigSet(
+        address corporateActionsVault, uint256 actionTypeMask, uint64 pauseTimeBefore, uint64 pauseTimeAfter
+    );
 
     modifier onlyAdmin() {
         if (msg.sender != admin) revert OnlyAdmin();
@@ -156,6 +184,13 @@ abstract contract BasePythOracleAdapter is AggregatorV2V3Interface {
     }
 
     /// @inheritdoc AggregatorV2V3Interface
+    /// @dev `roundId` and `answeredInRound` are derived from the Pyth
+    /// `publishTime` (truncated to `uint80`) so they advance monotonically per
+    /// Chainlink convention without adding storage. Integrators that diff
+    /// `roundId` between calls to detect a fresh update will see a different
+    /// value whenever Pyth has produced a new price. The truncation collision
+    /// is far in the future — `uint80` covers more seconds than any plausible
+    /// deployment lifetime.
     // slither-disable-next-line pyth-unchecked-confidence
     function latestRoundData()
         external
@@ -168,7 +203,14 @@ abstract contract BasePythOracleAdapter is AggregatorV2V3Interface {
         PythStructs.Price memory priceData = _getPriceData();
         int256 scaledPrice = _vaultSharePrice(priceData);
 
-        return (1, scaledPrice, uint256(uint64(priceData.publishTime)), uint256(uint64(priceData.publishTime)), 1);
+        uint80 publishRoundId = uint80(uint64(priceData.publishTime));
+        return (
+            publishRoundId,
+            scaledPrice,
+            uint256(uint64(priceData.publishTime)),
+            uint256(uint64(priceData.publishTime)),
+            publishRoundId
+        );
     }
 
     /// @inheritdoc AggregatorV2V3Interface
@@ -225,12 +267,21 @@ abstract contract BasePythOracleAdapter is AggregatorV2V3Interface {
     /// `corporateActionsVault == address(0)` disables auto-pause for the
     /// life of the proxy and is the right choice when an oracle is
     /// redeployed against a vault that hasn't yet been upgraded to expose
-    /// `ICorporateActionsV1`.
+    /// `ICorporateActionsV1`. Reverts with
+    /// `CorporateActionConfigAlreadyInitialized` if called a second time —
+    /// the four corporate-action pause slots are SPEC §16.2 immutable.
+    /// Emits `CorporateActionPauseConfigSet` so off-chain indexers can
+    /// reconstruct the config from logs alone.
     function _setCorporateActionPauseConfig(CorporateActionPauseConfig memory config) internal {
+        if (_corporateActionConfigInitialized) revert CorporateActionConfigAlreadyInitialized();
+        _corporateActionConfigInitialized = true;
         corporateActionsVault = config.corporateActionsVault;
         actionTypeMask = config.actionTypeMask;
         pauseTimeBefore = config.pauseTimeBefore;
         pauseTimeAfter = config.pauseTimeAfter;
+        emit CorporateActionPauseConfigSet(
+            config.corporateActionsVault, config.actionTypeMask, config.pauseTimeBefore, config.pauseTimeAfter
+        );
     }
 
     /// @dev Computes conservative price (price - confidence) as a Rain Float.

--- a/src/abstract/BasePythOracleAdapter.sol
+++ b/src/abstract/BasePythOracleAdapter.sol
@@ -18,9 +18,10 @@ error OraclePausedManual();
 /// integrators see the next event coming, not the last one done.
 error OraclePausedCorporateAction(uint64 effectiveTime);
 
-/// @dev Error raised when the conservative price (price - confidence) is not
-/// positive.
-error NonPositivePrice(int256 price);
+/// @dev Error raised when the conservative price (raw Pyth price minus
+/// confidence interval) is not positive. The carried value is that
+/// conservative price, not the raw Pyth price.
+error NonPositivePrice(int256 conservativePrice);
 
 /// @dev Error raised when a zero address is provided for the vault.
 error ZeroVault();
@@ -117,9 +118,12 @@ abstract contract BasePythOracleAdapter is AggregatorV2V3Interface {
     /// `__gap.length` by 1 for each `uint256`-equivalent slot added above.
     uint256[50] private __gap;
 
-    /// @dev Emitted when the manual pause state changes.
+    /// @notice Emitted when the manual pause state changes.
+    /// @param isPaused The new pause state.
     event PauseSet(bool isPaused);
-    /// @dev Emitted when the admin is changed.
+    /// @notice Emitted when the admin is changed.
+    /// @param oldAdmin The previous admin address.
+    /// @param newAdmin The new admin address.
     event AdminSet(address indexed oldAdmin, address indexed newAdmin);
 
     modifier onlyAdmin() {
@@ -179,12 +183,19 @@ abstract contract BasePythOracleAdapter is AggregatorV2V3Interface {
     /// @notice Pause or unpause the oracle's manual flag. Admin only.
     /// @dev Independent of the corporate-action auto-pause; either condition
     /// causes price reads to revert.
+    /// @param isPaused True to pause, false to unpause.
     function setPaused(bool isPaused) external onlyAdmin {
         paused = isPaused;
         emit PauseSet(isPaused);
     }
 
     /// @notice Update the admin address. Admin only.
+    /// @dev One-step transfer — the new admin takes effect immediately. A
+    /// wrong `newAdmin` will lock the adapter's governance permanently:
+    /// `setPaused` will become uncallable. The only recovery is to redeploy
+    /// the oracle and `OracleRegistry.setOracle(vault, newOracle)` to
+    /// redirect downstream protocols. Use a multisig that cannot be
+    /// misaddressed.
     /// @param newAdmin The new admin address.
     function setAdmin(address newAdmin) external onlyAdmin {
         if (newAdmin == address(0)) revert ZeroAdmin();

--- a/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
@@ -13,7 +13,8 @@ import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 error ZeroImplementation();
 
 /// @dev Error raised when a zero address is provided for the initial beacon
-/// owner.
+/// owner. Only constrains construction-time ownership; subsequent owner
+/// rotations are the beacon's concern.
 error ZeroBeaconOwner();
 
 /// @dev Error raised when initialization of the protocol adapter fails.
@@ -30,8 +31,11 @@ struct MorphoProtocolAdapterBeaconSetDeployerConfig {
 }
 
 /// @title MorphoProtocolAdapterBeaconSetDeployer
-/// @notice Deploys and manages a beacon set for MorphoProtocolAdapter
-/// contracts. Used for Morpho Blue protocol integration.
+/// @notice Deploys a beacon and the proxies that share it for
+/// MorphoProtocolAdapter contracts. Beacon management (upgrades, ownership
+/// transfer) is performed externally by the beacon owner; this contract
+/// retains no authority over the beacon after construction. Used for Morpho
+/// Blue protocol integration.
 contract MorphoProtocolAdapterBeaconSetDeployer {
     /// Emitted when a new MorphoProtocolAdapter is deployed.
     event Deployment(address sender, address morphoProtocolAdapter);
@@ -54,7 +58,12 @@ contract MorphoProtocolAdapterBeaconSetDeployer {
     /// @notice Deploys and initializes a new MorphoProtocolAdapter proxy.
     /// @param registry The oracle registry address.
     /// @param vault The vault address this adapter serves.
-    /// @param admin The admin address.
+    /// @param admin Sole governance principal of the deployed adapter:
+    /// can call `setRegistry(newRegistry)` to swap the registry pointer
+    /// and `setAdmin(newAdmin)` to rotate this role. Distinct from the
+    /// `OracleRegistry` admin, which is not affected by this argument.
+    /// One-step transfer model — pass an address that cannot be
+    /// misaddressed (typically a multisig).
     /// @return adapter The deployed MorphoProtocolAdapter proxy.
     // slither-disable-next-line reentrancy-events
     function newMorphoProtocolAdapter(OracleRegistry registry, address vault, address admin)

--- a/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
@@ -37,8 +37,14 @@ struct MorphoProtocolAdapterBeaconSetDeployerConfig {
 /// retains no authority over the beacon after construction. Used for Morpho
 /// Blue protocol integration.
 contract MorphoProtocolAdapterBeaconSetDeployer {
-    /// Emitted when a new MorphoProtocolAdapter is deployed.
-    event Deployment(address sender, address morphoProtocolAdapter);
+    /// @notice Emitted when a new MorphoProtocolAdapter is deployed.
+    /// @param caller The direct on-chain caller of `newMorphoProtocolAdapter`.
+    /// For adapters created via `OracleUnifiedDeployer` /
+    /// `MultiOracleUnifiedDeployer` this is the unified-deployer contract, not
+    /// the originating EOA. Indexed so monitoring can filter by deployer.
+    /// @param morphoProtocolAdapter The address of the new proxy. Indexed so
+    /// monitoring can filter by adapter.
+    event Deployment(address indexed caller, address indexed morphoProtocolAdapter);
 
     /// The beacon for the MorphoProtocolAdapter implementation contracts.
     IBeacon public immutable I_MORPHO_PROTOCOL_ADAPTER_BEACON;

--- a/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
+++ b/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
@@ -12,7 +12,8 @@ import {OracleRegistry, OracleRegistryConfig} from "src/concrete/registry/Oracle
 error ZeroImplementation();
 
 /// @dev Error raised when a zero address is provided for the initial beacon
-/// owner.
+/// owner. Only constrains construction-time ownership; subsequent owner
+/// rotations are the beacon's concern.
 error ZeroBeaconOwner();
 
 /// @dev Error raised when initialization of the oracle registry fails.
@@ -28,8 +29,12 @@ struct OracleRegistryBeaconSetDeployerConfig {
 }
 
 /// @title OracleRegistryBeaconSetDeployer
-/// @notice Deploys and manages a beacon set for OracleRegistry contracts.
-/// Follows the st0x.deploy BeaconSetDeployer pattern.
+/// @notice Deploys a beacon (constructed once at deploy-time) and the
+/// proxies that share it for OracleRegistry contracts. Beacon authority
+/// — including upgrade and ownership transfer — lives entirely with the
+/// `initialOwner` supplied at construction; this contract retains no
+/// post-construction authority over the beacon. Follows the st0x.deploy
+/// BeaconSetDeployer pattern.
 contract OracleRegistryBeaconSetDeployer {
     /// Emitted when a new OracleRegistry is deployed.
     event Deployment(address sender, address oracleRegistry);
@@ -50,8 +55,10 @@ contract OracleRegistryBeaconSetDeployer {
     }
 
     /// @notice Deploys and initializes a new OracleRegistry proxy.
-    /// The caller (msg.sender) becomes the registry admin, consistent with
-    /// OracleUnifiedDeployer which sets msg.sender as admin for all adapters.
+    /// @dev `msg.sender` becomes the registry admin. SPEC §13 states the
+    /// registry admin is the founder multisig, so this function MUST be
+    /// called from that multisig (or, after deployment, transfer admin to
+    /// the multisig via `OracleRegistry.setAdmin`).
     /// @return registry The deployed OracleRegistry proxy.
     // slither-disable-next-line reentrancy-events
     function newOracleRegistry() external returns (OracleRegistry) {

--- a/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
+++ b/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
@@ -36,8 +36,13 @@ struct OracleRegistryBeaconSetDeployerConfig {
 /// post-construction authority over the beacon. Follows the st0x.deploy
 /// BeaconSetDeployer pattern.
 contract OracleRegistryBeaconSetDeployer {
-    /// Emitted when a new OracleRegistry is deployed.
-    event Deployment(address sender, address oracleRegistry);
+    /// @notice Emitted when a new OracleRegistry is deployed.
+    /// @param caller The direct on-chain caller of `newOracleRegistry`. Also
+    /// becomes the registry admin per SPEC §13. Indexed so monitoring can
+    /// filter by deployer.
+    /// @param oracleRegistry The address of the new proxy. Indexed so
+    /// monitoring can filter by registry.
+    event Deployment(address indexed caller, address indexed oracleRegistry);
 
     /// The beacon for the OracleRegistry implementation contracts.
     IBeacon public immutable I_ORACLE_REGISTRY_BEACON;

--- a/src/concrete/deploy/OracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/OracleUnifiedDeployer.sol
@@ -27,7 +27,11 @@ import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
 /// otherwise calls route to the old sub-deployer until this bytecode is
 /// replaced. There is no on-chain pointer to chase. Tracked at #209.
 contract OracleUnifiedDeployer {
-    /// Emitted when a new oracle and protocol adapter set is deployed.
+    /// @notice Emitted when a new oracle and protocol adapter set is deployed.
+    /// @param sender The caller that triggered the deployment.
+    /// @param pythOracleAdapter The address of the new PythOracleAdapter proxy.
+    /// @param morphoProtocolAdapter The address of the new MorphoProtocolAdapter proxy.
+    /// @param passthroughProtocolAdapter The address of the new PassthroughProtocolAdapter proxy.
     event Deployment(
         address sender, address pythOracleAdapter, address morphoProtocolAdapter, address passthroughProtocolAdapter
     );
@@ -38,8 +42,10 @@ contract OracleUnifiedDeployer {
     /// @param maxAge Maximum acceptable price age in seconds.
     /// @param registry The oracle registry. Admin must call registry.setOracle() separately.
     /// @param pauseConfig Corporate-action auto-pause configuration — see
-    /// SPEC § 16. Pass an all-zero struct to disable auto-pause (legacy /
-    /// manual-only mode).
+    /// SPEC § 16. To disable auto-pause entirely, set
+    /// `pauseConfig.corporateActionsVault = address(0)` (other fields ignored).
+    /// Setting only `actionTypeMask = 0` while keeping a non-zero
+    /// corporateActionsVault costs gas on every read but never pauses.
     // slither-disable-next-line reentrancy-events
     function newOracleAndProtocolAdapters(
         address vault,

--- a/src/concrete/deploy/OracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/OracleUnifiedDeployer.sol
@@ -14,6 +14,18 @@ import {MorphoProtocolAdapter} from "src/concrete/protocol/MorphoProtocolAdapter
 import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
 
+/// @dev Error raised when the `PythOracleAdapterBeaconSetDeployer` address in
+/// `LibProdDeploy` is unset (zero) on the current chain.
+error PythBeaconSetDeployerNotSet();
+
+/// @dev Error raised when the `MorphoProtocolAdapterBeaconSetDeployer` address
+/// in `LibProdDeploy` is unset (zero) on the current chain.
+error MorphoBeaconSetDeployerNotSet();
+
+/// @dev Error raised when the `PassthroughProtocolAdapterBeaconSetDeployer`
+/// address in `LibProdDeploy` is unset (zero) on the current chain.
+error PassthroughBeaconSetDeployerNotSet();
+
 /// @title OracleUnifiedDeployer
 /// @notice Atomically deploys a PythOracleAdapter and all protocol adapters
 /// (Morpho, Passthrough for Aave/Compound) for a new vault. The beacon set
@@ -28,12 +40,18 @@ import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
 /// replaced. There is no on-chain pointer to chase. Tracked at #209.
 contract OracleUnifiedDeployer {
     /// @notice Emitted when a new oracle and protocol adapter set is deployed.
-    /// @param sender The caller that triggered the deployment.
+    /// @param caller The direct on-chain caller of `newOracleAndProtocolAdapters`
+    /// — typically the originating EOA, but if this contract is itself wrapped
+    /// behind another deployer it will be that intermediate contract, not the
+    /// EOA. Indexed so monitoring can filter by deployer.
     /// @param pythOracleAdapter The address of the new PythOracleAdapter proxy.
     /// @param morphoProtocolAdapter The address of the new MorphoProtocolAdapter proxy.
     /// @param passthroughProtocolAdapter The address of the new PassthroughProtocolAdapter proxy.
     event Deployment(
-        address sender, address pythOracleAdapter, address morphoProtocolAdapter, address passthroughProtocolAdapter
+        address indexed caller,
+        address indexed pythOracleAdapter,
+        address indexed morphoProtocolAdapter,
+        address passthroughProtocolAdapter
     );
 
     /// @notice Deploy oracle + all protocol adapters for a new vault.
@@ -54,6 +72,20 @@ contract OracleUnifiedDeployer {
         OracleRegistry registry,
         CorporateActionPauseConfig calldata pauseConfig
     ) external {
+        // Pre-flight: every LibProdDeploy sub-deployer address must be set on
+        // the current chain. Surface a typed error so a partial deployment or
+        // wrong-chain invocation fails loudly rather than reverting deep
+        // inside an ABI decode of an empty extcall return.
+        if (LibProdDeploy.PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER == address(0)) {
+            revert PythBeaconSetDeployerNotSet();
+        }
+        if (LibProdDeploy.MORPHO_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER == address(0)) {
+            revert MorphoBeaconSetDeployerNotSet();
+        }
+        if (LibProdDeploy.PASSTHROUGH_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER == address(0)) {
+            revert PassthroughBeaconSetDeployerNotSet();
+        }
+
         // 1. Deploy oracle adapter
         PythOracleAdapter oracleAdapter = PythOracleAdapterBeaconSetDeployer(
                 LibProdDeploy.PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER

--- a/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
@@ -16,7 +16,8 @@ import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 error ZeroImplementation();
 
 /// @dev Error raised when a zero address is provided for the initial beacon
-/// owner.
+/// owner. Only constrains construction-time ownership; subsequent owner
+/// rotations are the beacon's concern.
 error ZeroBeaconOwner();
 
 /// @dev Error raised when initialization of the protocol adapter fails.
@@ -34,9 +35,11 @@ struct PassthroughProtocolAdapterBeaconSetDeployerConfig {
 }
 
 /// @title PassthroughProtocolAdapterBeaconSetDeployer
-/// @notice Deploys and manages a beacon set for PassthroughProtocolAdapter
-/// contracts. Used for Aave V3, Compound V3, and any future
-/// Chainlink-compatible protocol.
+/// @notice Deploys a beacon and the proxies that share it for
+/// PassthroughProtocolAdapter contracts. Beacon management (upgrades,
+/// ownership transfer) is performed externally by the beacon owner; this
+/// contract retains no authority over the beacon after construction. Used
+/// for Aave V3, Compound V3, and any future Chainlink-compatible protocol.
 contract PassthroughProtocolAdapterBeaconSetDeployer {
     /// Emitted when a new PassthroughProtocolAdapter is deployed.
     event Deployment(address sender, address passthroughProtocolAdapter);
@@ -59,7 +62,12 @@ contract PassthroughProtocolAdapterBeaconSetDeployer {
     /// @notice Deploys and initializes a new PassthroughProtocolAdapter proxy.
     /// @param registry The oracle registry address.
     /// @param vault The vault address this adapter serves.
-    /// @param admin The admin address.
+    /// @param admin Sole governance principal of the deployed adapter:
+    /// can call `setRegistry(newRegistry)` to swap the registry pointer
+    /// and `setAdmin(newAdmin)` to rotate this role. Distinct from the
+    /// `OracleRegistry` admin, which is not affected by this argument.
+    /// One-step transfer model — pass an address that cannot be
+    /// misaddressed (typically a multisig).
     /// @return adapter The deployed PassthroughProtocolAdapter proxy.
     // slither-disable-next-line reentrancy-events
     function newPassthroughProtocolAdapter(OracleRegistry registry, address vault, address admin)

--- a/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
@@ -41,8 +41,15 @@ struct PassthroughProtocolAdapterBeaconSetDeployerConfig {
 /// contract retains no authority over the beacon after construction. Used
 /// for Aave V3, Compound V3, and any future Chainlink-compatible protocol.
 contract PassthroughProtocolAdapterBeaconSetDeployer {
-    /// Emitted when a new PassthroughProtocolAdapter is deployed.
-    event Deployment(address sender, address passthroughProtocolAdapter);
+    /// @notice Emitted when a new PassthroughProtocolAdapter is deployed.
+    /// @param caller The direct on-chain caller of
+    /// `newPassthroughProtocolAdapter`. For adapters created via
+    /// `OracleUnifiedDeployer` / `MultiOracleUnifiedDeployer` this is the
+    /// unified-deployer contract, not the originating EOA. Indexed so
+    /// monitoring can filter by deployer.
+    /// @param passthroughProtocolAdapter The address of the new proxy. Indexed
+    /// so monitoring can filter by adapter.
+    event Deployment(address indexed caller, address indexed passthroughProtocolAdapter);
 
     /// The beacon for the PassthroughProtocolAdapter implementation contracts.
     IBeacon public immutable I_PASSTHROUGH_PROTOCOL_ADAPTER_BEACON;

--- a/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol
@@ -12,7 +12,8 @@ import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/Py
 error ZeroImplementation();
 
 /// @dev Error raised when a zero address is provided for the initial beacon
-/// owner.
+/// owner. Only constrains construction-time ownership; subsequent owner
+/// rotations are the beacon's concern.
 error ZeroBeaconOwner();
 
 /// @dev Error raised when initialization of the oracle adapter fails.
@@ -29,8 +30,11 @@ struct PythOracleAdapterBeaconSetDeployerConfig {
 }
 
 /// @title PythOracleAdapterBeaconSetDeployer
-/// @notice Deploys and manages a beacon set for PythOracleAdapter contracts.
-/// Follows the st0x.deploy BeaconSetDeployer pattern.
+/// @notice Deploys a beacon and the proxies that share it for
+/// PythOracleAdapter contracts. Beacon management (upgrades, ownership
+/// transfer) is performed externally by the beacon owner; this contract
+/// retains no authority over the beacon after construction. Follows the
+/// st0x.deploy BeaconSetDeployer pattern.
 contract PythOracleAdapterBeaconSetDeployer {
     /// Emitted when a new PythOracleAdapter is deployed.
     event Deployment(address sender, address pythOracleAdapter);

--- a/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol
@@ -36,8 +36,14 @@ struct PythOracleAdapterBeaconSetDeployerConfig {
 /// retains no authority over the beacon after construction. Follows the
 /// st0x.deploy BeaconSetDeployer pattern.
 contract PythOracleAdapterBeaconSetDeployer {
-    /// Emitted when a new PythOracleAdapter is deployed.
-    event Deployment(address sender, address pythOracleAdapter);
+    /// @notice Emitted when a new PythOracleAdapter is deployed.
+    /// @param caller The direct on-chain caller of `newPythOracleAdapter`. For
+    /// adapters created via `OracleUnifiedDeployer` /
+    /// `MultiOracleUnifiedDeployer` this is the unified-deployer contract, not
+    /// the originating EOA. Indexed so monitoring can filter by deployer.
+    /// @param pythOracleAdapter The address of the new proxy. Indexed so
+    /// monitoring can filter by adapter.
+    event Deployment(address indexed caller, address indexed pythOracleAdapter);
 
     /// The beacon for the PythOracleAdapter implementation contracts.
     IBeacon public immutable I_PYTH_ORACLE_ADAPTER_BEACON;

--- a/src/concrete/oracle/PythOracleAdapter.sol
+++ b/src/concrete/oracle/PythOracleAdapter.sol
@@ -50,23 +50,30 @@ struct PythOracleAdapterConfig {
 /// Uses conservative pricing (price - confidence interval) per rain.pyth
 /// patterns. Scaling uses LibDecimalFloat for audited precision.
 ///
-/// Price formula: vaultSharePrice = pythPrice * totalAssets / totalSupply
+/// Price formula: vaultSharePrice = (pythPrice - pythConfidence) * totalAssets / totalSupply
+/// — i.e. the conservative price is used. See SPEC §15.2 and
+/// `BasePythOracleAdapter._conservativePriceFloat`.
 contract PythOracleAdapter is BasePythOracleAdapter, ICloneableV2, Initializable {
     /// @dev The Pyth price feed ID for the underlying asset.
     bytes32 public priceId;
     /// @dev Maximum acceptable price age in seconds.
     uint256 public maxAge;
 
-    /// @dev Emitted when the oracle is initialized.
+    /// @notice Emitted when the oracle is initialized.
+    /// @param sender The caller that initialized the proxy.
+    /// @param config The initialization configuration.
     event PythOracleAdapterInitialized(address indexed sender, PythOracleAdapterConfig config);
 
     constructor() {
         _disableInitializers();
     }
 
-    /// As per ICloneableV2, this overload MUST always revert. Documents the
-    /// signature of the initialize function.
-    /// @param config The initialization configuration.
+    /// @notice Documents the typed signature of the initialize function. Per
+    /// ICloneableV2 this overload MUST always revert; callers should use the
+    /// `bytes calldata` overload instead.
+    /// @dev Always reverts with `InitializeSignatureFn`.
+    /// @param config The initialization configuration. Ignored.
+    /// @return Never returns; included only for the function signature.
     function initialize(PythOracleAdapterConfig memory config) external pure returns (bytes32) {
         (config);
         revert InitializeSignatureFn();

--- a/src/concrete/protocol/MorphoProtocolAdapter.sol
+++ b/src/concrete/protocol/MorphoProtocolAdapter.sol
@@ -22,7 +22,10 @@ error ZeroVault();
 /// @dev Error raised when the price is not positive.
 error NonPositivePrice();
 
-/// @dev Error raised when no oracle is found for the vault in the registry.
+/// @dev Error raised when the currently-pointed registry has no entry for
+/// `vault`. This includes both the canonical-registry-never-registered case
+/// AND the `setRegistry`-pointed-elsewhere case (where the admin swapped
+/// the registry to one that doesn't know about this vault).
 error OracleNotFound();
 
 /// @dev Error raised when the registered oracle reports decimals other than 8.
@@ -32,8 +35,11 @@ error OracleNotFound();
 /// Morpho borrow against a 10^N×-wrong price.
 error UnexpectedOracleDecimals(uint8 actual, uint8 expected);
 
-/// @dev Morpho Blue's IOracle interface.
+/// @notice Morpho Blue's IOracle interface — the minimum surface a Morpho
+/// market expects from its oracle.
 interface IOracle {
+    /// @notice Returns the price scaled to 1e36 as required by Morpho Blue.
+    /// @return The price as uint256 scaled to 1e36.
     function price() external view returns (uint256);
 }
 
@@ -62,20 +68,29 @@ contract MorphoProtocolAdapter is IOracle, ICloneableV2, Initializable {
     /// @dev Admin address for governance actions.
     address public admin;
 
-    /// @dev Emitted when the adapter is initialized.
+    /// @notice Emitted when the adapter is initialized.
+    /// @param sender The caller that initialized the proxy.
+    /// @param config The initialization configuration.
     event MorphoProtocolAdapterInitialized(address indexed sender, MorphoProtocolAdapterConfig config);
-    /// @dev Emitted when the registry reference is updated.
+    /// @notice Emitted when the registry reference is updated.
+    /// @param oldRegistry The previous registry address.
+    /// @param newRegistry The new registry address.
     event RegistrySet(address indexed oldRegistry, address indexed newRegistry);
-    /// @dev Emitted when the admin is changed.
+    /// @notice Emitted when the admin is changed.
+    /// @param oldAdmin The previous admin address.
+    /// @param newAdmin The new admin address.
     event AdminSet(address indexed oldAdmin, address indexed newAdmin);
 
     constructor() {
         _disableInitializers();
     }
 
-    /// As per ICloneableV2, this overload MUST always revert. Documents the
-    /// signature of the initialize function.
-    /// @param config The initialization configuration.
+    /// @notice Documents the typed signature of the initialize function. Per
+    /// ICloneableV2 this overload MUST always revert; callers should use the
+    /// `bytes calldata` overload instead.
+    /// @dev Always reverts with `InitializeSignatureFn`.
+    /// @param config The initialization configuration. Ignored.
+    /// @return Never returns; included only for the function signature.
     function initialize(MorphoProtocolAdapterConfig memory config) external pure returns (bytes32) {
         (config);
         revert InitializeSignatureFn();
@@ -104,6 +119,7 @@ contract MorphoProtocolAdapter is IOracle, ICloneableV2, Initializable {
     }
 
     /// @notice Update the registry reference. Admin only.
+    /// @param newRegistry The new oracle registry address.
     function setRegistry(OracleRegistry newRegistry) external onlyAdmin {
         if (address(newRegistry) == address(0)) revert ZeroRegistry();
         emit RegistrySet(address(registry), address(newRegistry));
@@ -111,6 +127,12 @@ contract MorphoProtocolAdapter is IOracle, ICloneableV2, Initializable {
     }
 
     /// @notice Update the admin address. Admin only.
+    /// @dev One-step transfer — the new admin takes effect immediately. A
+    /// wrong `newAdmin` will lock the adapter's governance permanently:
+    /// `setRegistry` will become uncallable by the intended principal. The
+    /// only recovery is `OracleRegistry.setOracle(vault, newOracle)` to
+    /// redirect downstream protocols to a different `MorphoProtocolAdapter`
+    /// proxy. Use a multisig that cannot be misaddressed.
     /// @param newAdmin The new admin address.
     function setAdmin(address newAdmin) external onlyAdmin {
         if (newAdmin == address(0)) revert ZeroAdmin();

--- a/src/concrete/protocol/PassthroughProtocolAdapter.sol
+++ b/src/concrete/protocol/PassthroughProtocolAdapter.sol
@@ -19,7 +19,10 @@ error ZeroRegistry();
 /// @dev Error raised when a zero address is provided for the vault.
 error ZeroVault();
 
-/// @dev Error raised when no oracle is found for the vault in the registry.
+/// @dev Error raised when the currently-pointed registry has no entry for
+/// `vault`. This includes both the canonical-registry-never-registered case
+/// AND the `setRegistry`-pointed-elsewhere case (where the admin swapped
+/// the registry to one that doesn't know about this vault).
 error OracleNotFound();
 
 /// @title PassthroughProtocolAdapterConfig
@@ -38,6 +41,13 @@ struct PassthroughProtocolAdapterConfig {
 /// Chainlink-compatible protocol. Passes through all AggregatorV2V3Interface
 /// calls to the underlying oracle adapter. The registry reference is updatable
 /// by the admin, allowing oracle swaps without protocol governance.
+///
+/// PRECONDITION: All oracles registered for vaults consumed by this adapter
+/// MUST report `decimals() == 8`. Aave V3 and Compound V3 cache `decimals()`
+/// at registration time and hard-code the 8-decimal expectation; pointing
+/// the registry to an oracle with a different precision will silently scale
+/// prices wrong (e.g. an 18-decimal oracle yields 1e10× prices on Aave).
+/// SPEC §15's registry-admin-trust assumption applies.
 /// Deploy multiple proxy instances from the same beacon for different protocols.
 contract PassthroughProtocolAdapter is AggregatorV2V3Interface, ICloneableV2, Initializable {
     /// @dev The oracle registry for looking up the oracle adapter.
@@ -47,20 +57,29 @@ contract PassthroughProtocolAdapter is AggregatorV2V3Interface, ICloneableV2, In
     /// @dev Admin address for governance actions.
     address public admin;
 
-    /// @dev Emitted when the adapter is initialized.
+    /// @notice Emitted when the adapter is initialized.
+    /// @param sender The caller that initialized the proxy.
+    /// @param config The initialization configuration.
     event PassthroughProtocolAdapterInitialized(address indexed sender, PassthroughProtocolAdapterConfig config);
-    /// @dev Emitted when the registry reference is updated.
+    /// @notice Emitted when the registry reference is updated.
+    /// @param oldRegistry The previous registry address.
+    /// @param newRegistry The new registry address.
     event RegistrySet(address indexed oldRegistry, address indexed newRegistry);
-    /// @dev Emitted when the admin is changed.
+    /// @notice Emitted when the admin is changed.
+    /// @param oldAdmin The previous admin address.
+    /// @param newAdmin The new admin address.
     event AdminSet(address indexed oldAdmin, address indexed newAdmin);
 
     constructor() {
         _disableInitializers();
     }
 
-    /// As per ICloneableV2, this overload MUST always revert. Documents the
-    /// signature of the initialize function.
-    /// @param config The initialization configuration.
+    /// @notice Documents the typed signature of the initialize function. Per
+    /// ICloneableV2 this overload MUST always revert; callers should use the
+    /// `bytes calldata` overload instead.
+    /// @dev Always reverts with `InitializeSignatureFn`.
+    /// @param config The initialization configuration. Ignored.
+    /// @return Never returns; included only for the function signature.
     function initialize(PassthroughProtocolAdapterConfig memory config) external pure returns (bytes32) {
         (config);
         revert InitializeSignatureFn();
@@ -89,6 +108,7 @@ contract PassthroughProtocolAdapter is AggregatorV2V3Interface, ICloneableV2, In
     }
 
     /// @notice Update the registry reference. Admin only.
+    /// @param newRegistry The new oracle registry address.
     function setRegistry(OracleRegistry newRegistry) external onlyAdmin {
         if (address(newRegistry) == address(0)) revert ZeroRegistry();
         emit RegistrySet(address(registry), address(newRegistry));
@@ -96,6 +116,12 @@ contract PassthroughProtocolAdapter is AggregatorV2V3Interface, ICloneableV2, In
     }
 
     /// @notice Update the admin address. Admin only.
+    /// @dev One-step transfer — the new admin takes effect immediately. A
+    /// wrong `newAdmin` will lock the adapter's governance permanently:
+    /// `setRegistry` will become uncallable. The only recovery is
+    /// `OracleRegistry.setOracle(vault, newOracle)` to redirect downstream
+    /// protocols to a different `PassthroughProtocolAdapter` proxy. Use a
+    /// multisig that cannot be misaddressed.
     /// @param newAdmin The new admin address.
     function setAdmin(address newAdmin) external onlyAdmin {
         if (newAdmin == address(0)) revert ZeroAdmin();
@@ -131,6 +157,12 @@ contract PassthroughProtocolAdapter is AggregatorV2V3Interface, ICloneableV2, In
     }
 
     /// @inheritdoc AggregatorV2V3Interface
+    /// @dev `roundId` and `answeredInRound` are forwarded verbatim from the
+    /// registered upstream oracle. They are NOT normalized across
+    /// `OracleRegistry.setOracle` swaps; integrators that rely on Chainlink's
+    /// monotonically-increasing-roundId guarantee should not register this
+    /// adapter unless the registry's oracle is locked or the integrator's
+    /// staleness check tolerates discontinuities.
     // slither-disable-next-line unused-return
     function latestRoundData()
         external

--- a/src/concrete/registry/OracleRegistry.sol
+++ b/src/concrete/registry/OracleRegistry.sol
@@ -21,6 +21,16 @@ error ZeroOracle();
 /// @dev Error raised when array lengths do not match in bulk operations.
 error ArrayLengthMismatch();
 
+/// @dev Error raised when a bulk operation's input arrays exceed
+/// `MAX_BULK_LENGTH`. Includes the offending length and the cap so a
+/// multisig signer reviewing the revert can confirm the bound at a glance.
+error BulkLengthExceeded(uint256 length, uint256 maxLength);
+
+/// @dev Maximum number of (vault, oracle) pairs accepted in a single
+/// `setOracleBulk` call. Sized to fit comfortably under any current EVM
+/// L1/L2 block gas limit while leaving margin for log and call overhead.
+uint256 constant MAX_BULK_LENGTH = 256;
+
 /// @title OracleRegistryConfig
 /// @notice Single-field config struct kept to mirror the BeaconSetDeployer
 /// pattern used by sibling adapters; future fields can be added without an
@@ -120,6 +130,7 @@ contract OracleRegistry is ICloneableV2, Initializable {
     /// @param oracles The oracle adapter addresses.
     function setOracleBulk(address[] calldata vaults, AggregatorV2V3Interface[] calldata oracles) external onlyAdmin {
         if (vaults.length != oracles.length) revert ArrayLengthMismatch();
+        if (vaults.length > MAX_BULK_LENGTH) revert BulkLengthExceeded(vaults.length, MAX_BULK_LENGTH);
 
         for (uint256 i = 0; i < vaults.length; i++) {
             if (vaults[i] == address(0)) revert ZeroVault();

--- a/src/concrete/registry/OracleRegistry.sol
+++ b/src/concrete/registry/OracleRegistry.sol
@@ -22,7 +22,9 @@ error ZeroOracle();
 error ArrayLengthMismatch();
 
 /// @title OracleRegistryConfig
-/// @notice Configuration for OracleRegistry initialization.
+/// @notice Single-field config struct kept to mirror the BeaconSetDeployer
+/// pattern used by sibling adapters; future fields can be added without an
+/// ABI break for the initializer.
 /// @param admin The admin address.
 struct OracleRegistryConfig {
     address admin;
@@ -39,20 +41,30 @@ contract OracleRegistry is ICloneableV2, Initializable {
     /// @dev Mapping from vault address to oracle adapter.
     mapping(address vault => AggregatorV2V3Interface oracle) internal _oracles;
 
-    /// @dev Emitted when the registry is initialized.
+    /// @notice Emitted when the registry is initialized.
+    /// @param sender The caller that initialized the proxy.
+    /// @param config The initialization configuration.
     event OracleRegistryInitialized(address indexed sender, OracleRegistryConfig config);
-    /// @dev Emitted when an oracle is set for a vault.
+    /// @notice Emitted when an oracle is set for a vault.
+    /// @param vault The vault address.
+    /// @param oldOracle The previous oracle adapter address (zero if none).
+    /// @param newOracle The new oracle adapter address.
     event OracleSet(address indexed vault, address indexed oldOracle, address indexed newOracle);
-    /// @dev Emitted when the admin is changed.
+    /// @notice Emitted when the admin is changed.
+    /// @param oldAdmin The previous admin address.
+    /// @param newAdmin The new admin address.
     event AdminSet(address indexed oldAdmin, address indexed newAdmin);
 
     constructor() {
         _disableInitializers();
     }
 
-    /// As per ICloneableV2, this overload MUST always revert. Documents the
-    /// signature of the initialize function.
-    /// @param config The initialization configuration.
+    /// @notice Documents the typed signature of the initialize function. Per
+    /// ICloneableV2 this overload MUST always revert; callers should use the
+    /// `bytes calldata` overload instead.
+    /// @dev Always reverts with `InitializeSignatureFn`.
+    /// @param config The initialization configuration. Ignored.
+    /// @return Never returns; included only for the function signature.
     function initialize(OracleRegistryConfig memory config) external pure returns (bytes32) {
         (config);
         revert InitializeSignatureFn();
@@ -77,6 +89,12 @@ contract OracleRegistry is ICloneableV2, Initializable {
     }
 
     /// @notice Update the admin address. Admin only.
+    /// @dev One-step transfer — the new admin takes effect immediately. A
+    /// wrong `newAdmin` will lock the registry's governance permanently:
+    /// `setOracle` / `setOracleBulk` will become uncallable. There is no
+    /// in-band recovery — downstream protocol adapters that look up via this
+    /// registry will be stuck on their current oracle. Use a multisig that
+    /// cannot be misaddressed.
     /// @param newAdmin The new admin address.
     function setAdmin(address newAdmin) external onlyAdmin {
         if (newAdmin == address(0)) revert ZeroAdmin();

--- a/src/lib/LibProdDeploy.sol
+++ b/src/lib/LibProdDeploy.sol
@@ -5,25 +5,41 @@ pragma solidity ^0.8.25;
 /// @title LibProdDeploy
 /// @notice Hardcoded production deployment addresses. Provides an audit trail
 /// in git of any address modifications.
+/// @dev Per-address "Deployed to … Run: …" comments are hand-curated by the
+/// operator after each workflow run (see `AGENTS.md` § Deployment). On a
+/// re-deploy the operator MUST append a new line of the form
+/// `Re-deployed to <network> <yyyy-mm-dd> with <reason>. Run: <runId>.`
+/// rather than rewriting the existing line — losing prior provenance breaks
+/// the audit trail. Tracked at #217 (Pass 6 hazard); future work moves this
+/// metadata into a workflow-generated JSON artifact consumed by a codegen
+/// step so the comments stop drifting from reality.
 library LibProdDeploy {
-    /// rainlang.eth founder multisig.
+    /// rainlang.eth founder multisig. Used as the `initialOwner` of every
+    /// `UpgradeableBeacon` constructed by every `*BeaconSetDeployer` in
+    /// `script/Deploy.sol`; per SPEC §13 this is the beacon upgrade authority.
     address constant BEACON_INITIAL_OWNER = 0x8E4bdeec7CEB9570D440676345dA1dCe10329f5b;
 
-    /// Deployed to Base 2026-02-13. Run: 21981134736.
+    /// Address of a deployed `PythOracleAdapterBeaconSetDeployer`. Deployed
+    /// to Base 2026-02-13. Run: 21981134736.
     address constant PYTH_ORACLE_ADAPTER_BEACON_SET_DEPLOYER = 0x29295438119dA1E773f6A103cC935c89BfdEbc4A;
 
+    /// Address of a deployed `MorphoProtocolAdapterBeaconSetDeployer`.
     /// Deployed to Base 2026-02-13. Run: 21981948500.
     address constant MORPHO_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER = 0x5022bb2ecB539Ad54E49871389E134fb2c9fE9a5;
 
+    /// Address of a deployed `PassthroughProtocolAdapterBeaconSetDeployer`.
     /// Deployed to Base 2026-02-13. Run: 21982188432.
     address constant PASSTHROUGH_PROTOCOL_ADAPTER_BEACON_SET_DEPLOYER = 0x62bb7076075a78dEc0e888668C44482235B93CD0;
 
-    /// Deployed to Base 2026-02-13. Run: 21982788744.
+    /// Address of a deployed `OracleUnifiedDeployer`. Deployed to Base
+    /// 2026-02-13. Run: 21982788744.
     address constant ORACLE_UNIFIED_DEPLOYER = 0x377c9657D1827b6bcd1e4B6d0a714815D5F2C615;
 
-    /// Deployed to Base 2026-02-13. Run: 21984615902.
+    /// Address of a deployed `OracleRegistryBeaconSetDeployer`. Deployed to
+    /// Base 2026-02-13. Run: 21984615902.
     address constant ORACLE_REGISTRY_BEACON_SET_DEPLOYER = 0x3B8E2056Dce6E6847e853c3FEdda379802cD07d3;
 
-    /// Deployed to Base 2026-02-13.
+    /// Address of the canonical `OracleRegistry` proxy. Deployed to Base
+    /// 2026-02-13.
     address constant ORACLE_REGISTRY = 0x36a14d00a8597731fb6dB1e0e7EeA0BB81ffD156;
 }

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -19,7 +19,7 @@ dataSources:
         - name: OracleRegistryBeaconSetDeployer
           file: ../out/OracleRegistryBeaconSetDeployer.sol/OracleRegistryBeaconSetDeployer.json
       eventHandlers:
-        - event: Deployment(address,address)
+        - event: Deployment(indexed address,indexed address)
           handler: handleRegistryDeployment
       file: ./src/deployer.ts
 
@@ -40,7 +40,7 @@ dataSources:
         - name: PythOracleAdapterBeaconSetDeployer
           file: ../out/PythOracleAdapterBeaconSetDeployer.sol/PythOracleAdapterBeaconSetDeployer.json
       eventHandlers:
-        - event: Deployment(address,address)
+        - event: Deployment(indexed address,indexed address)
           handler: handlePythAdapterDeployment
       file: ./src/deployer.ts
 
@@ -61,7 +61,7 @@ dataSources:
         - name: MorphoProtocolAdapterBeaconSetDeployer
           file: ../out/MorphoProtocolAdapterBeaconSetDeployer.sol/MorphoProtocolAdapterBeaconSetDeployer.json
       eventHandlers:
-        - event: Deployment(address,address)
+        - event: Deployment(indexed address,indexed address)
           handler: handleMorphoAdapterDeployment
       file: ./src/deployer.ts
 
@@ -82,7 +82,7 @@ dataSources:
         - name: PassthroughProtocolAdapterBeaconSetDeployer
           file: ../out/PassthroughProtocolAdapterBeaconSetDeployer.sol/PassthroughProtocolAdapterBeaconSetDeployer.json
       eventHandlers:
-        - event: Deployment(address,address)
+        - event: Deployment(indexed address,indexed address)
           handler: handlePassthroughAdapterDeployment
       file: ./src/deployer.ts
 
@@ -104,7 +104,7 @@ dataSources:
         - name: OracleUnifiedDeployer
           file: ../out/OracleUnifiedDeployer.sol/OracleUnifiedDeployer.json
       eventHandlers:
-        - event: Deployment(address,address,address,address)
+        - event: Deployment(indexed address,indexed address,indexed address,address)
           handler: handleSingleDeployment
       file: ./src/deployer.ts
 

--- a/test/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.construct.t.sol
@@ -114,8 +114,10 @@ contract MorphoProtocolAdapterBeaconSetDeployerConstructTest is Test {
         bool found;
         for (uint256 i = 0; i < logs.length; i++) {
             if (logs[i].topics[0] == keccak256("Deployment(address,address)")) {
-                (address sender, address adapterAddr) = abi.decode(logs[i].data, (address, address));
-                assertEq(sender, address(this));
+                // Both fields are indexed — decode from topics, not data.
+                address caller = address(uint160(uint256(logs[i].topics[1])));
+                address adapterAddr = address(uint160(uint256(logs[i].topics[2])));
+                assertEq(caller, address(this));
                 assertEq(adapterAddr, address(adapter));
                 found = true;
             }

--- a/test/src/concrete/deploy/OracleRegistryBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/OracleRegistryBeaconSetDeployer.construct.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test, Vm} from "forge-std-1.16.1/src/Test.sol";
 import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
@@ -47,5 +47,37 @@ contract OracleRegistryBeaconSetDeployerConstructTest is Test {
         );
 
         assertTrue(address(deployer.I_ORACLE_REGISTRY_BEACON()) != address(0));
+    }
+
+    /// `Deployment` must carry both `caller` and `oracleRegistry` as indexed
+    /// topics so indexers can filter by either field. Closes audit #40 / #173.
+    function testDeploymentEventIsIndexed(address caller) external {
+        vm.assume(caller != address(0));
+
+        OracleRegistry implementation = new OracleRegistry();
+        OracleRegistryBeaconSetDeployer deployer = new OracleRegistryBeaconSetDeployer(
+            OracleRegistryBeaconSetDeployerConfig({
+                initialOwner: address(this), initialOracleRegistryImplementation: address(implementation)
+            })
+        );
+
+        vm.recordLogs();
+        vm.prank(caller);
+        OracleRegistry registry = deployer.newOracleRegistry();
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bool found;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == keccak256("Deployment(address,address)")) {
+                assertEq(logs[i].topics.length, 3, "expected 3 topics (signature + 2 indexed)");
+                assertEq(logs[i].data.length, 0, "expected empty data (all args indexed)");
+                address evCaller = address(uint160(uint256(logs[i].topics[1])));
+                address evRegistry = address(uint160(uint256(logs[i].topics[2])));
+                assertEq(evCaller, caller);
+                assertEq(evRegistry, address(registry));
+                found = true;
+            }
+        }
+        assertTrue(found, "Deployment event missing");
     }
 }

--- a/test/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.construct.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test, Vm} from "forge-std-1.16.1/src/Test.sol";
 import {
     PassthroughProtocolAdapterBeaconSetDeployer,
     PassthroughProtocolAdapterBeaconSetDeployerConfig,
@@ -10,6 +10,11 @@ import {
     ZeroBeaconOwner
 } from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
 import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
+import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+import {
+    OracleRegistryBeaconSetDeployer,
+    OracleRegistryBeaconSetDeployerConfig
+} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
 
 contract PassthroughProtocolAdapterBeaconSetDeployerConstructTest is Test {
     function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroImplementation(address initialOwner) external {
@@ -46,5 +51,46 @@ contract PassthroughProtocolAdapterBeaconSetDeployerConstructTest is Test {
         );
 
         assertEq(address(deployer.I_PASSTHROUGH_PROTOCOL_ADAPTER_BEACON().implementation()), address(implementation));
+    }
+
+    /// `Deployment` must carry both `caller` and `passthroughProtocolAdapter`
+    /// as indexed topics so indexers can filter by either field. Closes audit
+    /// #40 / #173.
+    function testDeploymentEventIsIndexed(address vault, address admin) external {
+        vm.assume(vault != address(0));
+        vm.assume(admin != address(0));
+
+        PassthroughProtocolAdapter implementation = new PassthroughProtocolAdapter();
+        PassthroughProtocolAdapterBeaconSetDeployer deployer = new PassthroughProtocolAdapterBeaconSetDeployer(
+            PassthroughProtocolAdapterBeaconSetDeployerConfig({
+                initialOwner: address(this), initialPassthroughProtocolAdapterImplementation: address(implementation)
+            })
+        );
+
+        OracleRegistry registryImpl = new OracleRegistry();
+        OracleRegistryBeaconSetDeployer registryDeployer = new OracleRegistryBeaconSetDeployer(
+            OracleRegistryBeaconSetDeployerConfig({
+                initialOwner: address(this), initialOracleRegistryImplementation: address(registryImpl)
+            })
+        );
+        OracleRegistry registry = registryDeployer.newOracleRegistry();
+
+        vm.recordLogs();
+        PassthroughProtocolAdapter adapter = deployer.newPassthroughProtocolAdapter(registry, vault, admin);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bool found;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == keccak256("Deployment(address,address)")) {
+                assertEq(logs[i].topics.length, 3, "expected 3 topics (signature + 2 indexed)");
+                assertEq(logs[i].data.length, 0, "expected empty data (all args indexed)");
+                address caller = address(uint160(uint256(logs[i].topics[1])));
+                address adapterAddr = address(uint160(uint256(logs[i].topics[2])));
+                assertEq(caller, address(this));
+                assertEq(adapterAddr, address(adapter));
+                found = true;
+            }
+        }
+        assertTrue(found, "Deployment event missing");
     }
 }

--- a/test/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.construct.t.sol
@@ -2,14 +2,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test, Vm} from "forge-std-1.16.1/src/Test.sol";
 import {
     PythOracleAdapterBeaconSetDeployer,
     PythOracleAdapterBeaconSetDeployerConfig,
     ZeroImplementation,
     ZeroBeaconOwner
 } from "src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
-import {PythOracleAdapter} from "src/concrete/oracle/PythOracleAdapter.sol";
+import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
+import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
 
 contract PythOracleAdapterBeaconSetDeployerConstructTest is Test {
     function testPythOracleAdapterBeaconSetDeployerConstructZeroImplementation(address initialOwner) external {
@@ -45,5 +46,52 @@ contract PythOracleAdapterBeaconSetDeployerConstructTest is Test {
         );
 
         assertEq(address(deployer.I_PYTH_ORACLE_ADAPTER_BEACON().implementation()), address(implementation));
+    }
+
+    /// `Deployment` must carry both `caller` and `pythOracleAdapter` as
+    /// indexed topics so indexers can filter by either field. Decoding from
+    /// `topics[1..2]` (not from `data`) is the assertion that locks the
+    /// indexed-ness in. Closes audit #40 / #173.
+    function testDeploymentEventIsIndexed(address vault, bytes32 priceId, uint256 maxAge, address admin) external {
+        vm.assume(vault != address(0));
+        vm.assume(priceId != bytes32(0));
+        vm.assume(maxAge > 0);
+        vm.assume(admin != address(0));
+
+        PythOracleAdapter implementation = new PythOracleAdapter();
+        PythOracleAdapterBeaconSetDeployer deployer = new PythOracleAdapterBeaconSetDeployer(
+            PythOracleAdapterBeaconSetDeployerConfig({
+                initialOwner: address(this), initialPythOracleAdapterImplementation: address(implementation)
+            })
+        );
+
+        vm.recordLogs();
+        PythOracleAdapter adapter = deployer.newPythOracleAdapter(
+            PythOracleAdapterConfig({
+                vault: vault,
+                priceId: priceId,
+                maxAge: maxAge,
+                admin: admin,
+                pauseConfig: CorporateActionPauseConfig({
+                    corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+                })
+            })
+        );
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bool found;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == keccak256("Deployment(address,address)")) {
+                // 3 topics = signature + 2 indexed args. data must be empty.
+                assertEq(logs[i].topics.length, 3, "expected 3 topics (signature + 2 indexed)");
+                assertEq(logs[i].data.length, 0, "expected empty data (all args indexed)");
+                address caller = address(uint160(uint256(logs[i].topics[1])));
+                address adapterAddr = address(uint160(uint256(logs[i].topics[2])));
+                assertEq(caller, address(this));
+                assertEq(adapterAddr, address(adapter));
+                found = true;
+            }
+        }
+        assertTrue(found, "Deployment event missing");
     }
 }

--- a/test/src/concrete/oracle/BasePythOracleAdapter.corporateActionConfig.t.sol
+++ b/test/src/concrete/oracle/BasePythOracleAdapter.corporateActionConfig.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test, Vm} from "forge-std-1.16.1/src/Test.sol";
+import {PythStructs} from "pyth-sdk/PythStructs.sol";
+import {
+    BasePythOracleAdapter,
+    CorporateActionPauseConfig,
+    CorporateActionConfigAlreadyInitialized
+} from "src/abstract/BasePythOracleAdapter.sol";
+
+/// @dev Minimal harness exposing `_setCorporateActionPauseConfig` for direct
+/// invocation. The base adapter's helper is `internal`; we override the
+/// abstract `_getPriceData` with a no-op since no price reads happen here.
+contract CorporateActionConfigHarness is BasePythOracleAdapter {
+    function setConfig(CorporateActionPauseConfig memory config) external {
+        _setCorporateActionPauseConfig(config);
+    }
+
+    function _getPriceData() internal pure override returns (PythStructs.Price memory p) {
+        return p;
+    }
+}
+
+/// @title BasePythOracleAdapterCorporateActionConfigTest
+/// @notice Tests the SPEC §16.2 immutable-after-initialize invariant on the
+/// four corporate-action pause storage slots, plus the new install-time event.
+/// Closes audits #148 and #149.
+contract BasePythOracleAdapterCorporateActionConfigTest is Test {
+    function _cfg(address vault) internal pure returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: vault, actionTypeMask: 0x1, pauseTimeBefore: 60, pauseTimeAfter: 120
+        });
+    }
+
+    /// First call to `_setCorporateActionPauseConfig` populates the four
+    /// governance slots; a second call reverts with
+    /// `CorporateActionConfigAlreadyInitialized`. The internal `bool` flag
+    /// codifies the invariant rather than relying on subclass discipline.
+    /// Closes audit #148.
+    function testCorporateActionConfigImmutableAfterInitialize(address vault) external {
+        CorporateActionConfigHarness h = new CorporateActionConfigHarness();
+        h.setConfig(_cfg(vault));
+
+        assertEq(h.corporateActionsVault(), vault);
+        assertEq(h.actionTypeMask(), 0x1);
+        assertEq(h.pauseTimeBefore(), 60);
+        assertEq(h.pauseTimeAfter(), 120);
+
+        vm.expectRevert(CorporateActionConfigAlreadyInitialized.selector);
+        h.setConfig(_cfg(address(0)));
+    }
+
+    /// `CorporateActionConfigAlreadyInitialized` selector also fires when the
+    /// second call's payload happens to be identical to the first — the guard
+    /// is positional, not content-aware. Closes audit #148.
+    function testCorporateActionConfigRevertsOnIdenticalReinit(address vault) external {
+        CorporateActionConfigHarness h = new CorporateActionConfigHarness();
+        h.setConfig(_cfg(vault));
+        vm.expectRevert(CorporateActionConfigAlreadyInitialized.selector);
+        h.setConfig(_cfg(vault));
+    }
+
+    /// `_setCorporateActionPauseConfig` must emit
+    /// `CorporateActionPauseConfigSet` with every installed field so off-chain
+    /// indexers can reconstruct the four governance slots from logs alone.
+    /// Closes audit #149.
+    function testCorporateActionConfigEmitsInstallEvent(address vault, uint256 mask, uint64 before_, uint64 after_)
+        external
+    {
+        CorporateActionConfigHarness h = new CorporateActionConfigHarness();
+        CorporateActionPauseConfig memory cfg = CorporateActionPauseConfig({
+            corporateActionsVault: vault, actionTypeMask: mask, pauseTimeBefore: before_, pauseTimeAfter: after_
+        });
+
+        vm.expectEmit();
+        emit BasePythOracleAdapter.CorporateActionPauseConfigSet(vault, mask, before_, after_);
+        h.setConfig(cfg);
+    }
+}

--- a/test/src/concrete/oracle/PythOracleAdapter.autoPause.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.autoPause.t.sol
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
+import {Vm} from "forge-std-1.16.1/src/Test.sol";
 import {PythOracleAdapterTest} from "test/abstract/PythOracleAdapterTest.sol";
 import {MockCorporateActions} from "test/mocks/MockCorporateActions.sol";
 import {IERC4626} from "@openzeppelin-contracts-5.6.1/interfaces/IERC4626.sol";
@@ -158,5 +159,87 @@ contract PythOracleAdapterAutoPauseTest is PythOracleAdapterTest {
         );
         vm.expectRevert(abi.encodeWithSelector(HistoricalRoundDataUnsupported.selector, requestedRound));
         oracle.getRoundData(requestedRound);
+    }
+
+    /// `latestRoundData` MUST encode `uint80(uint64(publishTime))` into both
+    /// `roundId` and `answeredInRound` so Chainlink consumers that diff round
+    /// ids across blocks see a fresh round whenever Pyth has produced one.
+    /// Pre-fix the values were hardcoded to `1`. Closes audit #43.
+    function testLatestRoundDataIdIsPublishTime() external {
+        // Re-mock Pyth so publishTime is a fixed sentinel, not block.timestamp.
+        uint256 sentinel = 1_234_567_890;
+        PythStructs.Price memory p = PythStructs.Price({price: 100e8, conf: 1e6, expo: -8, publishTime: sentinel});
+        vm.mockCall(PYTH_BASE, abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector), abi.encode(p));
+
+        PythOracleAdapter oracle = _config(
+            CorporateActionPauseConfig({
+                corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+            })
+        );
+        (uint80 roundId,, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = oracle.latestRoundData();
+
+        assertEq(roundId, uint80(uint64(sentinel)), "roundId should be uint80(uint64(publishTime))");
+        assertEq(answeredInRound, uint80(uint64(sentinel)), "answeredInRound should equal roundId");
+        assertEq(startedAt, sentinel);
+        assertEq(updatedAt, sentinel);
+        assertEq(roundId, answeredInRound, "Chainlink: a fresh round is answered in itself");
+    }
+
+    /// Calling `latestRoundData` twice with two different Pyth publishTimes
+    /// must return two different roundIds — proving the metadata advances
+    /// monotonically across reads, not stuck at the pre-fix constant `1`.
+    /// Closes audit #43.
+    function testLatestRoundDataIdAdvancesAcrossUpdates() external {
+        PythOracleAdapter oracle = _config(
+            CorporateActionPauseConfig({
+                corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+            })
+        );
+
+        uint256 t1 = 1_000_000_000;
+        vm.mockCall(
+            PYTH_BASE,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector),
+            abi.encode(PythStructs.Price({price: 100e8, conf: 1e6, expo: -8, publishTime: t1}))
+        );
+        (uint80 round1,,,,) = oracle.latestRoundData();
+
+        uint256 t2 = 1_000_000_777;
+        vm.mockCall(
+            PYTH_BASE,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector),
+            abi.encode(PythStructs.Price({price: 101e8, conf: 1e6, expo: -8, publishTime: t2}))
+        );
+        (uint80 round2,,,,) = oracle.latestRoundData();
+
+        assertGt(round2, round1, "roundId must advance when publishTime advances");
+        assertEq(round1, uint80(uint64(t1)));
+        assertEq(round2, uint80(uint64(t2)));
+    }
+
+    /// `_setCorporateActionPauseConfig` is called by every subclass initializer
+    /// and must emit `CorporateActionPauseConfigSet` so off-chain indexers can
+    /// reconstruct the four corporate-action governance slots from logs alone.
+    /// Closes audit #149.
+    function testInitializeEmitsCorporateActionPauseConfigSet() external {
+        CorporateActionPauseConfig memory cfg = _stockSplitConfig();
+
+        vm.recordLogs();
+        _config(cfg);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bool found;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == keccak256("CorporateActionPauseConfigSet(address,uint256,uint64,uint64)")) {
+                (address evVault, uint256 evMask, uint64 evBefore, uint64 evAfter) =
+                    abi.decode(logs[i].data, (address, uint256, uint64, uint64));
+                assertEq(evVault, cfg.corporateActionsVault);
+                assertEq(evMask, cfg.actionTypeMask);
+                assertEq(evBefore, cfg.pauseTimeBefore);
+                assertEq(evAfter, cfg.pauseTimeAfter);
+                found = true;
+            }
+        }
+        assertTrue(found, "CorporateActionPauseConfigSet event missing");
     }
 }

--- a/test/src/concrete/oracle/PythOracleAdapter.latestAnswer.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.latestAnswer.t.sol
@@ -153,11 +153,15 @@ contract PythOracleAdapterLatestAnswerTest is Test {
         (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
             oracle.latestRoundData();
 
-        assertEq(roundId, 1);
-        assertEq(answeredInRound, 1);
+        // Per audit #43, roundId / answeredInRound now encode the Pyth
+        // publishTime (truncated to uint80) so consumers can diff fresh
+        // rounds. publishTime > 0 on a live feed.
+        assertTrue(roundId > 0, "roundId should be derived from publishTime > 0");
+        assertEq(answeredInRound, roundId, "answeredInRound should equal roundId");
         assertTrue(answer > 0, "Price should be positive");
         assertTrue(startedAt > 0, "startedAt should be nonzero");
         assertEq(startedAt, updatedAt);
+        assertEq(uint256(roundId), startedAt, "roundId should equal startedAt for uint80-fitting publishTimes");
 
         assertEq(answer, oracle.latestAnswer());
     }

--- a/test/src/concrete/registry/OracleRegistry.t.sol
+++ b/test/src/concrete/registry/OracleRegistry.t.sol
@@ -10,7 +10,9 @@ import {
     ZeroAdmin,
     ZeroVault,
     ZeroOracle,
-    ArrayLengthMismatch
+    ArrayLengthMismatch,
+    BulkLengthExceeded,
+    MAX_BULK_LENGTH
 } from "src/concrete/registry/OracleRegistry.sol";
 import {ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
 import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
@@ -208,6 +210,51 @@ contract OracleRegistrySetOracleBulkTest is OracleRegistryTest {
         vm.prank(admin);
         vm.expectRevert(abi.encodeWithSelector(ZeroOracle.selector));
         registry.setOracleBulk(vaults, oracles);
+    }
+
+    /// `setOracleBulk` must revert `BulkLengthExceeded(length, max)` when the
+    /// input arrays are strictly longer than `MAX_BULK_LENGTH`. The cap exists
+    /// so a multisig signer can confirm the bound from the calldata alone —
+    /// the function must surface the cap, not silently consume gas. Closes
+    /// audit #36.
+    function testSetOracleBulkRevertsAboveMaxLength(address admin) external {
+        vm.assume(admin != address(0));
+
+        OracleRegistry registry = createRegistry(admin);
+
+        address[] memory vaults = new address[](MAX_BULK_LENGTH + 1);
+        AggregatorV2V3Interface[] memory oracles = new AggregatorV2V3Interface[](MAX_BULK_LENGTH + 1);
+        for (uint256 i = 0; i < vaults.length; i++) {
+            vaults[i] = address(uint160(i + 1));
+            oracles[i] = AggregatorV2V3Interface(address(uint160(i + 1 + 1e6)));
+        }
+
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(BulkLengthExceeded.selector, MAX_BULK_LENGTH + 1, MAX_BULK_LENGTH));
+        registry.setOracleBulk(vaults, oracles);
+    }
+
+    /// `setOracleBulk` must succeed at exactly `MAX_BULK_LENGTH` entries — the
+    /// cap is inclusive. Catches an off-by-one regression (`>=`) that would
+    /// silently reject the largest valid bulk call. Closes audit #36.
+    function testSetOracleBulkSucceedsAtExactlyMaxLength(address admin) external {
+        vm.assume(admin != address(0));
+
+        OracleRegistry registry = createRegistry(admin);
+
+        address[] memory vaults = new address[](MAX_BULK_LENGTH);
+        AggregatorV2V3Interface[] memory oracles = new AggregatorV2V3Interface[](MAX_BULK_LENGTH);
+        for (uint256 i = 0; i < vaults.length; i++) {
+            vaults[i] = address(uint160(i + 1));
+            oracles[i] = AggregatorV2V3Interface(address(uint160(i + 1 + 1e6)));
+        }
+
+        vm.prank(admin);
+        registry.setOracleBulk(vaults, oracles);
+
+        for (uint256 i = 0; i < vaults.length; i++) {
+            assertEq(address(registry.getOracle(vaults[i])), address(oracles[i]));
+        }
     }
 
     /// Test successful bulk registration.


### PR DESCRIPTION
- #36: OracleRegistry.setOracleBulk gains MAX_BULK_LENGTH = 256 cap +
  BulkLengthExceeded(length, max) error.
- #37 / #38 / #155: OracleUnifiedDeployer + MultiOracleUnifiedDeployer
  gain symmetric zero-address guards on every LibProdDeploy
  sub-deployer constant with typed errors (Pyth/Morpho/Passthrough on
  the single-feed deployer; Morpho/Passthrough extended onto the
  multi-feed deployer alongside the existing MultiPyth guard).
- #40: Deployment(...) event params indexed across all 5
  *BeaconSetDeployer + both *UnifiedDeployer.
- #41 / #179 / #180: MultiPythOracleAdapter._setFeeds validates all
  entries before mutating, writes feedCount last, and internalises
  MAX_FEEDS / non-empty checks so initialize and setFeeds become
  thin wrappers.
- #43: BasePythOracleAdapter.latestRoundData encodes
  uint80(uint64(publishTime)) into roundId and answeredInRound
  for Chainlink monotonic-id convention.
- #148: BasePythOracleAdapter enforces the "immutable after
  initialize" invariant on CorporateActionPauseConfig with a
  one-shot flag + CorporateActionConfigAlreadyInitialized error.
- #149: CorporateActionPauseConfigSet event emitted from
  _setCorporateActionPauseConfig so indexers observe the install.
- #173: Deployment event param renamed `sender` → `caller` across
  all 5 BeaconSetDeployer + both UnifiedDeployer (NatSpec @param
  describes it as the direct on-chain caller).

All behaviour changes have a test that fails against pre-fix and
passes after. forge build / fmt / slither / REUSE green. Test count
delta: 214 → 231 (+17).

Closes #36, #37, #38, #40, #41, #43, #148, #149, #155, #173, #179, #180.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>