### PR TITLE
refactor(audit-low): style + refactor sweep — ~22 LOW findings

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -19,6 +19,7 @@ remappings = [
     "rain.factory/=lib/st0x.deploy/lib/rain.vats/lib/rain.factory/src/",
     "st0x.deploy/=lib/st0x.deploy/",
     "src/=src/",
+    "st0x.oracle/=src/",
     # Transitive deps (forge doesn't use each lib's own remappings)
     "rain.math.float/=lib/rain.pyth/lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float/src/",
     "rain.intorastring/=lib/rain.pyth/lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.intorastring/src/",

--- a/src/abstract/BasePythOracleAdapter.sol
+++ b/src/abstract/BasePythOracleAdapter.sol
@@ -5,8 +5,9 @@ pragma solidity =0.8.25;
 import {PythStructs} from "pyth-sdk/PythStructs.sol";
 import {LibDecimalFloat, Float} from "rain.math.float/lib/LibDecimalFloat.sol";
 import {IERC4626} from "openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
-import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
-import {LibCorporateActionsPause} from "src/lib/LibCorporateActionsPause.sol";
+import {AggregatorV2V3Interface} from "st0x.oracle/interface/IAggregatorV2V3.sol";
+import {LibCorporateActionsPause} from "st0x.oracle/lib/LibCorporateActionsPause.sol";
+import {OnlyAdmin, ZeroAdmin, ZeroVault} from "st0x.oracle/lib/LibOracleErrors.sol";
 
 /// @dev Error raised when the manual admin pause is active.
 error OraclePausedManual();
@@ -22,15 +23,6 @@ error OraclePausedCorporateAction(uint64 effectiveTime);
 /// confidence interval) is not positive. The carried value is that
 /// conservative price, not the raw Pyth price.
 error NonPositivePrice(int256 conservativePrice);
-
-/// @dev Error raised when a zero address is provided for the vault.
-error ZeroVault();
-
-/// @dev Error raised when the caller is not the admin.
-error OnlyAdmin();
-
-/// @dev Error raised when a zero address is provided for the admin.
-error ZeroAdmin();
 
 /// @dev Error raised when the vault has zero total supply (no shares minted).
 error ZeroVaultSupply();
@@ -97,6 +89,11 @@ struct CorporateActionPauseConfig {
 /// or simulation. Auto-pause configuration is set once at initialize and is
 /// immutable thereafter; manual pause stays as the operational escape hatch.
 abstract contract BasePythOracleAdapter is AggregatorV2V3Interface {
+    // --------------------------------------------------------------------- //
+    // Mutable governance state.                                             //
+    // Slots 0–1. Updated by `setPaused` / `setAdmin` after initialize.       //
+    // --------------------------------------------------------------------- //
+
     /// @dev The ERC-4626 vault this oracle prices shares for.
     address public vault;
     /// @dev Manual emergency pause flag. Independent of the corporate-action
@@ -104,6 +101,13 @@ abstract contract BasePythOracleAdapter is AggregatorV2V3Interface {
     bool public paused;
     /// @dev Admin address for governance actions.
     address public admin;
+
+    // --------------------------------------------------------------------- //
+    // Immutable-after-init corporate-action auto-pause config.              //
+    // Slots 2–4. Set exactly once by `_setCorporateActionPauseConfig`; any  //
+    // second call reverts with `CorporateActionConfigAlreadyInitialized`.   //
+    // SPEC §16.2.                                                            //
+    // --------------------------------------------------------------------- //
 
     /// @dev Address implementing `ICorporateActionsV1` consulted on every price
     /// read for auto-pause. Zero address disables auto-pause. Immutable after
@@ -126,6 +130,18 @@ abstract contract BasePythOracleAdapter is AggregatorV2V3Interface {
     /// `pauseTimeBefore` and `pauseTimeAfter` in the same storage slot
     /// (8 + 8 + 1 bytes ≪ 32), so the new invariant costs no extra slot.
     bool internal _corporateActionConfigInitialized;
+
+    // --------------------------------------------------------------------- //
+    // Reserved slots.                                                        //
+    // 50-slot gap so future base-class additions do not shift subclass slot //
+    // positions. New state added BEFORE the gap; subclasses keep their      //
+    // post-gap offsets stable across upgrades.                              //
+    // --------------------------------------------------------------------- //
+
+    /// @dev Reserved storage to avoid shifting subclass slot positions when
+    /// new base-class state is introduced in future versions. Decrement
+    /// `__gap.length` by 1 for each `uint256`-equivalent slot added above.
+    uint256[50] private __gap;
 
     /// @notice Emitted when the manual pause state changes.
     /// @param isPaused The new pause state.
@@ -322,6 +338,9 @@ abstract contract BasePythOracleAdapter is AggregatorV2V3Interface {
         if (price8 == 0) revert ZeroVaultSharePrice();
         if (price8 > uint256(type(int256).max)) revert VaultSharePriceOverflow(price8);
 
+        // The preceding `VaultSharePriceOverflow` guard rejects any `price8`
+        // exceeding `type(int256).max`, so this cast cannot truncate.
+        // forge-lint: disable-next-line(unsafe-typecast)
         return int256(price8);
     }
 }

--- a/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol
@@ -6,8 +6,11 @@ import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol
 import {UpgradeableBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import {BeaconProxy} from "openzeppelin-contracts/contracts/proxy/beacon/BeaconProxy.sol";
 import {ICLONEABLE_V2_SUCCESS} from "rain.factory/interface/ICloneableV2.sol";
-import {MorphoProtocolAdapter, MorphoProtocolAdapterConfig} from "src/concrete/protocol/MorphoProtocolAdapter.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+import {
+    MorphoProtocolAdapter,
+    MorphoProtocolAdapterConfig
+} from "st0x.oracle/concrete/protocol/MorphoProtocolAdapter.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
 
 /// @dev Error raised when a zero address is provided for the implementation.
 error ZeroImplementation();

--- a/src/concrete/deploy/MultiOracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/MultiOracleUnifiedDeployer.sol
@@ -2,21 +2,25 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {MultiPythOracleAdapterBeaconSetDeployer} from "src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
+import {
+    MultiPythOracleAdapterBeaconSetDeployer
+} from "st0x.oracle/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
 import {
     PassthroughProtocolAdapterBeaconSetDeployer
-} from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
-import {MorphoProtocolAdapterBeaconSetDeployer} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
+import {
+    MorphoProtocolAdapterBeaconSetDeployer
+} from "st0x.oracle/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
 import {
     MultiPythOracleAdapter,
     MultiPythOracleAdapterConfig,
     FeedConfig
-} from "src/concrete/oracle/MultiPythOracleAdapter.sol";
-import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
-import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
-import {MorphoProtocolAdapter} from "src/concrete/protocol/MorphoProtocolAdapter.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
-import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
+} from "st0x.oracle/concrete/oracle/MultiPythOracleAdapter.sol";
+import {CorporateActionPauseConfig} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
+import {PassthroughProtocolAdapter} from "st0x.oracle/concrete/protocol/PassthroughProtocolAdapter.sol";
+import {MorphoProtocolAdapter} from "st0x.oracle/concrete/protocol/MorphoProtocolAdapter.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
+import {LibProdDeploy} from "st0x.oracle/lib/LibProdDeploy.sol";
 
 /// @dev Error raised when the MultiPythOracleAdapterBeaconSetDeployer is not
 /// set in LibProdDeploy.

--- a/src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol
@@ -6,18 +6,21 @@ import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol
 import {UpgradeableBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import {BeaconProxy} from "openzeppelin-contracts/contracts/proxy/beacon/BeaconProxy.sol";
 import {ICLONEABLE_V2_SUCCESS} from "rain.factory/interface/ICloneableV2.sol";
-import {MultiPythOracleAdapter, MultiPythOracleAdapterConfig} from "src/concrete/oracle/MultiPythOracleAdapter.sol";
+import {
+    MultiPythOracleAdapter,
+    MultiPythOracleAdapterConfig
+} from "st0x.oracle/concrete/oracle/MultiPythOracleAdapter.sol";
 
 /// @dev Error raised when a zero address is provided for the implementation.
-error MultiZeroImplementation();
+error ZeroImplementation();
 
 /// @dev Error raised when a zero address is provided for the initial beacon
 /// owner. Only constrains construction-time ownership; subsequent owner
 /// rotations are the beacon's concern.
-error MultiZeroBeaconOwner();
+error ZeroBeaconOwner();
 
 /// @dev Error raised when initialization of the oracle adapter fails.
-error InitializeMultiOracleFailed();
+error InitializeAdapterFailed();
 
 /// @title MultiPythOracleAdapterBeaconSetDeployerConfig
 /// @notice Configuration for the MultiPythOracleAdapterBeaconSetDeployer
@@ -50,10 +53,10 @@ contract MultiPythOracleAdapterBeaconSetDeployer {
 
     constructor(MultiPythOracleAdapterBeaconSetDeployerConfig memory config) {
         if (config.initialMultiPythOracleAdapterImplementation == address(0)) {
-            revert MultiZeroImplementation();
+            revert ZeroImplementation();
         }
         if (config.initialOwner == address(0)) {
-            revert MultiZeroBeaconOwner();
+            revert ZeroBeaconOwner();
         }
 
         I_MULTI_PYTH_ORACLE_ADAPTER_BEACON =
@@ -72,7 +75,7 @@ contract MultiPythOracleAdapterBeaconSetDeployer {
             MultiPythOracleAdapter(address(new BeaconProxy(address(I_MULTI_PYTH_ORACLE_ADAPTER_BEACON), "")));
 
         if (adapter.initialize(abi.encode(config)) != ICLONEABLE_V2_SUCCESS) {
-            revert InitializeMultiOracleFailed();
+            revert InitializeAdapterFailed();
         }
 
         emit Deployment(msg.sender, address(adapter));

--- a/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
+++ b/src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol
@@ -6,7 +6,7 @@ import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol
 import {UpgradeableBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import {BeaconProxy} from "openzeppelin-contracts/contracts/proxy/beacon/BeaconProxy.sol";
 import {ICLONEABLE_V2_SUCCESS} from "rain.factory/interface/ICloneableV2.sol";
-import {OracleRegistry, OracleRegistryConfig} from "src/concrete/registry/OracleRegistry.sol";
+import {OracleRegistry, OracleRegistryConfig} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
 
 /// @dev Error raised when a zero address is provided for the implementation.
 error ZeroImplementation();

--- a/src/concrete/deploy/OracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/OracleUnifiedDeployer.sol
@@ -2,17 +2,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {PythOracleAdapterBeaconSetDeployer} from "src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
+import {PythOracleAdapterBeaconSetDeployer} from "st0x.oracle/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
 import {
     PassthroughProtocolAdapterBeaconSetDeployer
-} from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
-import {MorphoProtocolAdapterBeaconSetDeployer} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
-import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
-import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
-import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
-import {MorphoProtocolAdapter} from "src/concrete/protocol/MorphoProtocolAdapter.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
-import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
+} from "st0x.oracle/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
+import {
+    MorphoProtocolAdapterBeaconSetDeployer
+} from "st0x.oracle/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
+import {PythOracleAdapter, PythOracleAdapterConfig} from "st0x.oracle/concrete/oracle/PythOracleAdapter.sol";
+import {CorporateActionPauseConfig} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
+import {PassthroughProtocolAdapter} from "st0x.oracle/concrete/protocol/PassthroughProtocolAdapter.sol";
+import {MorphoProtocolAdapter} from "st0x.oracle/concrete/protocol/MorphoProtocolAdapter.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
+import {LibProdDeploy} from "st0x.oracle/lib/LibProdDeploy.sol";
 
 /// @dev Error raised when the `PythOracleAdapterBeaconSetDeployer` address in
 /// `LibProdDeploy` is unset (zero) on the current chain.

--- a/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol
@@ -9,8 +9,8 @@ import {ICLONEABLE_V2_SUCCESS} from "rain.factory/interface/ICloneableV2.sol";
 import {
     PassthroughProtocolAdapter,
     PassthroughProtocolAdapterConfig
-} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+} from "st0x.oracle/concrete/protocol/PassthroughProtocolAdapter.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
 
 /// @dev Error raised when a zero address is provided for the implementation.
 error ZeroImplementation();

--- a/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol
@@ -6,7 +6,7 @@ import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol
 import {UpgradeableBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import {BeaconProxy} from "openzeppelin-contracts/contracts/proxy/beacon/BeaconProxy.sol";
 import {ICLONEABLE_V2_SUCCESS} from "rain.factory/interface/ICloneableV2.sol";
-import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
+import {PythOracleAdapter, PythOracleAdapterConfig} from "st0x.oracle/concrete/oracle/PythOracleAdapter.sol";
 
 /// @dev Error raised when a zero address is provided for the implementation.
 error ZeroImplementation();

--- a/src/concrete/oracle/MultiPythOracleAdapter.sol
+++ b/src/concrete/oracle/MultiPythOracleAdapter.sol
@@ -13,7 +13,7 @@ import {
     CorporateActionPauseConfig,
     ZeroVault,
     ZeroAdmin
-} from "src/abstract/BasePythOracleAdapter.sol";
+} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
 
 /// @dev Error raised when all feeds are stale.
 error AllFeedsStale();
@@ -206,8 +206,8 @@ contract MultiPythOracleAdapter is BasePythOracleAdapter, ICloneableV2, Initiali
         view
         returns (bool success, PythStructs.Price memory price)
     {
-        try pyth.getPriceNoOlderThan(feedPriceId, feedMaxAge) returns (PythStructs.Price memory p) {
-            return (true, p);
+        try pyth.getPriceNoOlderThan(feedPriceId, feedMaxAge) returns (PythStructs.Price memory fetchedPrice) {
+            return (true, fetchedPrice);
         } catch (bytes memory reason) {
             // Only StalePrice falls through to the next session feed.
             // Anything else (PriceFeedNotFound, OOG, etc.) bubbles up.

--- a/src/concrete/oracle/PythOracleAdapter.sol
+++ b/src/concrete/oracle/PythOracleAdapter.sol
@@ -12,7 +12,7 @@ import {
     CorporateActionPauseConfig,
     ZeroVault,
     ZeroAdmin
-} from "src/abstract/BasePythOracleAdapter.sol";
+} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
 
 /// @dev Error raised when a zero price ID is provided.
 error ZeroPriceId();

--- a/src/concrete/protocol/MorphoProtocolAdapter.sol
+++ b/src/concrete/protocol/MorphoProtocolAdapter.sol
@@ -4,29 +4,15 @@ pragma solidity =0.8.25;
 
 import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain.factory/interface/ICloneableV2.sol";
 import {Initializable} from "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
-import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+import {AggregatorV2V3Interface} from "st0x.oracle/interface/IAggregatorV2V3.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
+import {OnlyAdmin, ZeroAdmin, ZeroVault, ZeroRegistry, OracleNotFound} from "st0x.oracle/lib/LibOracleErrors.sol";
 
-/// @dev Error raised when the caller is not the admin.
-error OnlyAdmin();
-
-/// @dev Error raised when a zero address is provided for the admin.
-error ZeroAdmin();
-
-/// @dev Error raised when a zero address is provided for the registry.
-error ZeroRegistry();
-
-/// @dev Error raised when a zero address is provided for the vault.
-error ZeroVault();
-
-/// @dev Error raised when the price is not positive.
-error NonPositivePrice();
-
-/// @dev Error raised when the currently-pointed registry has no entry for
-/// `vault`. This includes both the canonical-registry-never-registered case
-/// AND the `setRegistry`-pointed-elsewhere case (where the admin swapped
-/// the registry to one that doesn't know about this vault).
-error OracleNotFound();
+/// @dev Error raised when the price is not positive. Carries the offending
+/// signed answer (`oracle.latestAnswer()`) so an off-chain observer can see
+/// exactly which value tripped the guard without having to re-call the
+/// upstream oracle. Shape mirrors `BasePythOracleAdapter.NonPositivePrice`.
+error NonPositivePrice(int256 price);
 
 /// @dev Error raised when the registered oracle reports decimals other than 8.
 /// The `* 1e28` scaling in `price()` assumes an 8-decimal upstream; any other
@@ -140,9 +126,19 @@ contract MorphoProtocolAdapter is IOracle, ICloneableV2, Initializable {
         admin = newAdmin;
     }
 
-    /// @dev Expected upstream oracle decimals. Hard-coded because the `* 1e28`
-    /// scaling factor below is derived from `36 - 8`.
+    /// @dev Expected upstream oracle decimals. Hard-coded because the scaling
+    /// factor below is derived from `MORPHO_PRICE_SCALE / 10**EXPECTED_ORACLE_DECIMALS`.
     uint8 internal constant EXPECTED_ORACLE_DECIMALS = 8;
+
+    /// @dev The fixed-point scale Morpho Blue's `IOracle.price()` is required
+    /// to return — see Morpho documentation. Encoded as a named constant so
+    /// the scaling derivation below is auditable without a calculator.
+    uint256 internal constant MORPHO_PRICE_SCALE = 1e36;
+
+    /// @dev Multiplier applied to the upstream 8-decimal answer to reach
+    /// `MORPHO_PRICE_SCALE` (1e36). Derived from
+    /// `MORPHO_PRICE_SCALE / 10**EXPECTED_ORACLE_DECIMALS` (= 1e28).
+    uint256 internal constant SCALE_MULTIPLIER = MORPHO_PRICE_SCALE / 10 ** uint256(EXPECTED_ORACLE_DECIMALS);
 
     /// @notice Returns the price scaled to 36 decimals as required by Morpho
     /// Blue.
@@ -161,9 +157,9 @@ contract MorphoProtocolAdapter is IOracle, ICloneableV2, Initializable {
         }
 
         int256 answer = oracle.latestAnswer();
-        if (answer <= 0) revert NonPositivePrice();
+        if (answer <= 0) revert NonPositivePrice(answer);
 
-        // Scale from 8 decimals to 36 decimals
-        return uint256(answer) * 1e28;
+        // Scale from EXPECTED_ORACLE_DECIMALS to MORPHO_PRICE_SCALE.
+        return uint256(answer) * SCALE_MULTIPLIER;
     }
 }

--- a/src/concrete/protocol/PassthroughProtocolAdapter.sol
+++ b/src/concrete/protocol/PassthroughProtocolAdapter.sol
@@ -4,26 +4,9 @@ pragma solidity =0.8.25;
 
 import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain.factory/interface/ICloneableV2.sol";
 import {Initializable} from "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
-import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
-
-/// @dev Error raised when the caller is not the admin.
-error OnlyAdmin();
-
-/// @dev Error raised when a zero address is provided for the admin.
-error ZeroAdmin();
-
-/// @dev Error raised when a zero address is provided for the registry.
-error ZeroRegistry();
-
-/// @dev Error raised when a zero address is provided for the vault.
-error ZeroVault();
-
-/// @dev Error raised when the currently-pointed registry has no entry for
-/// `vault`. This includes both the canonical-registry-never-registered case
-/// AND the `setRegistry`-pointed-elsewhere case (where the admin swapped
-/// the registry to one that doesn't know about this vault).
-error OracleNotFound();
+import {AggregatorV2V3Interface} from "st0x.oracle/interface/IAggregatorV2V3.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
+import {OnlyAdmin, ZeroAdmin, ZeroVault, ZeroRegistry, OracleNotFound} from "st0x.oracle/lib/LibOracleErrors.sol";
 
 /// @title PassthroughProtocolAdapterConfig
 /// @notice Configuration for PassthroughProtocolAdapter initialization.

--- a/src/concrete/registry/OracleRegistry.sol
+++ b/src/concrete/registry/OracleRegistry.sol
@@ -4,16 +4,8 @@ pragma solidity =0.8.25;
 
 import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain.factory/interface/ICloneableV2.sol";
 import {Initializable} from "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
-import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
-
-/// @dev Error raised when the caller is not the admin.
-error OnlyAdmin();
-
-/// @dev Error raised when a zero address is provided for the admin.
-error ZeroAdmin();
-
-/// @dev Error raised when a zero address is provided for the vault.
-error ZeroVault();
+import {AggregatorV2V3Interface} from "st0x.oracle/interface/IAggregatorV2V3.sol";
+import {OnlyAdmin, ZeroAdmin, ZeroVault} from "st0x.oracle/lib/LibOracleErrors.sol";
 
 /// @dev Error raised when a zero address is provided for the oracle.
 error ZeroOracle();
@@ -116,13 +108,7 @@ contract OracleRegistry is ICloneableV2, Initializable {
     /// @param vault The vault address.
     /// @param oracle The oracle adapter address.
     function setOracle(address vault, AggregatorV2V3Interface oracle) external onlyAdmin {
-        if (vault == address(0)) revert ZeroVault();
-        if (address(oracle) == address(0)) revert ZeroOracle();
-
-        address oldOracle = address(_oracles[vault]);
-        _oracles[vault] = oracle;
-
-        emit OracleSet(vault, oldOracle, address(oracle));
+        _setOracle(vault, oracle);
     }
 
     /// @notice Bulk set or update oracles for multiple vaults. Admin only.
@@ -133,14 +119,24 @@ contract OracleRegistry is ICloneableV2, Initializable {
         if (vaults.length > MAX_BULK_LENGTH) revert BulkLengthExceeded(vaults.length, MAX_BULK_LENGTH);
 
         for (uint256 i = 0; i < vaults.length; i++) {
-            if (vaults[i] == address(0)) revert ZeroVault();
-            if (address(oracles[i]) == address(0)) revert ZeroOracle();
-
-            address oldOracle = address(_oracles[vaults[i]]);
-            _oracles[vaults[i]] = oracles[i];
-
-            emit OracleSet(vaults[i], oldOracle, address(oracles[i]));
+            _setOracle(vaults[i], oracles[i]);
         }
+    }
+
+    /// @dev Shared implementation for `setOracle` and the body of the
+    /// `setOracleBulk` loop. Validates inputs, performs the storage write,
+    /// and emits `OracleSet` exactly once per (vault, oracle) pair so the
+    /// single-set and bulk-set paths produce identical event histories.
+    /// @param vault The vault address. Must be non-zero.
+    /// @param oracle The oracle adapter address. Must be non-zero.
+    function _setOracle(address vault, AggregatorV2V3Interface oracle) internal {
+        if (vault == address(0)) revert ZeroVault();
+        if (address(oracle) == address(0)) revert ZeroOracle();
+
+        address oldOracle = address(_oracles[vault]);
+        _oracles[vault] = oracle;
+
+        emit OracleSet(vault, oldOracle, address(oracle));
     }
 
     /// @notice Get the oracle for a vault.

--- a/src/lib/LibCorporateActionsPause.sol
+++ b/src/lib/LibCorporateActionsPause.sol
@@ -66,25 +66,44 @@ library LibCorporateActionsPause {
             return (false, 0);
         }
 
-        ICorporateActionsV1 vault = ICorporateActionsV1(corporateActionsVault);
+        // Local binding for the `ICorporateActionsV1` lookups below. Named
+        // `corporateActions` (not `vault`) to avoid shadowing the
+        // priced-vault meaning used by callers — the address pointed to here
+        // is the corporate-actions registry, which may or may not coincide
+        // with the priced ERC-4626 vault address.
+        ICorporateActionsV1 corporateActions = ICorporateActionsV1(corporateActionsVault);
 
-        (uint256 pendingCursor,, uint64 pendingEffective) = vault.earliestActionOfType(mask, CompletionFilter.PENDING);
+        // The unused middle return is the action's `actionType` — already
+        // filtered by `mask`, so the call-site has nothing to do with it.
+        (uint256 pendingCursor,, uint64 pendingEffective) =
+            corporateActions.earliestActionOfType(mask, CompletionFilter.PENDING);
         // `NODE_NONE = type(uint256).max` is the documented no-match sentinel
         // from `ICorporateActionsV1` — cursor `0` is a real bootstrap node and
         // must NOT be treated as "no match".
-        if (pendingCursor != NODE_NONE) {
+        if (pendingCursor != NODE_NONE && pendingEffective != 0) {
             // pendingEffective > now is guaranteed by the PENDING filter.
             // We compare via addition on uint256-promoted operands so neither
             // underflow nor overflow is possible for any realistic timestamp.
+            // The explicit `pendingEffective != 0` guard is belt-and-suspenders
+            // on top of the `NODE_NONE` cursor check: a regression that
+            // surfaced a real cursor with a zero `effectiveTime` would
+            // otherwise silently open a pause window starting at the unix
+            // epoch — defence-in-depth, no behaviour change for callers
+            // because the `NODE_NONE` check already handles every documented
+            // no-match case.
             if (block.timestamp + uint256(pauseTimeBefore) >= uint256(pendingEffective)) {
                 return (true, pendingEffective);
             }
         }
 
+        // The unused middle return is the action's `actionType` — already
+        // filtered by `mask`, so the call-site has nothing to do with it.
         (uint256 completedCursor,, uint64 completedEffective) =
-            vault.latestActionOfType(mask, CompletionFilter.COMPLETED);
-        if (completedCursor != NODE_NONE) {
+            corporateActions.latestActionOfType(mask, CompletionFilter.COMPLETED);
+        if (completedCursor != NODE_NONE && completedEffective != 0) {
             // completedEffective <= now is guaranteed by the COMPLETED filter.
+            // The explicit `completedEffective != 0` guard mirrors the
+            // pre-window branch above — see comment there for rationale.
             if (block.timestamp <= uint256(completedEffective) + uint256(pauseTimeAfter)) {
                 return (true, completedEffective);
             }

--- a/src/lib/LibOracleErrors.sol
+++ b/src/lib/LibOracleErrors.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @title LibOracleErrors
+/// @notice Shared error definitions used by multiple contracts in the
+/// st0x.oracle stack. Hoisting the file-level errors out of each consumer
+/// avoids accidental selector drift if one site is updated and another is
+/// missed, and gives a single canonical home for cross-cutting governance
+/// errors (`OnlyAdmin`, `ZeroAdmin`, `ZeroVault`, `ZeroRegistry`,
+/// `OracleNotFound`).
+///
+/// File-level errors in Solidity are namespaced by their declaring file, so
+/// importing them from a shared module yields the same selectors at every
+/// consumer.
+
+/// @dev Error raised when the caller is not the admin.
+error OnlyAdmin();
+
+/// @dev Error raised when a zero address is provided for the admin.
+error ZeroAdmin();
+
+/// @dev Error raised when a zero address is provided for the vault.
+error ZeroVault();
+
+/// @dev Error raised when a zero address is provided for the registry.
+error ZeroRegistry();
+
+/// @dev Error raised when the currently-pointed registry has no entry for
+/// `vault`. This includes both the canonical-registry-never-registered case
+/// AND the `setRegistry`-pointed-elsewhere case (where the admin swapped
+/// the registry to one that doesn't know about this vault).
+error OracleNotFound();

--- a/src/lib/LibProdDeploy.sol
+++ b/src/lib/LibProdDeploy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-DCL-1.0
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity ^0.8.25;
+pragma solidity =0.8.25;
 
 /// @title LibProdDeploy
 /// @notice Hardcoded production deployment addresses. Provides an audit trail

--- a/test/abstract/OracleRegistryTest.sol
+++ b/test/abstract/OracleRegistryTest.sol
@@ -3,11 +3,11 @@
 pragma solidity =0.8.25;
 
 import {Test, Vm} from "forge-std/Test.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig
-} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
 
 contract OracleRegistryTest is Test {
     OracleRegistry internal immutable I_IMPLEMENTATION;

--- a/test/abstract/PythOracleAdapterTest.sol
+++ b/test/abstract/PythOracleAdapterTest.sol
@@ -3,12 +3,12 @@
 pragma solidity =0.8.25;
 
 import {Test, Vm} from "forge-std/Test.sol";
-import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
-import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
+import {CorporateActionPauseConfig} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
+import {PythOracleAdapter, PythOracleAdapterConfig} from "st0x.oracle/concrete/oracle/PythOracleAdapter.sol";
 import {
     PythOracleAdapterBeaconSetDeployer,
     PythOracleAdapterBeaconSetDeployerConfig
-} from "src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
 
 contract PythOracleAdapterTest is Test {
     PythOracleAdapter internal immutable I_IMPLEMENTATION;

--- a/test/src/concrete/ProdFork.t.sol
+++ b/test/src/concrete/ProdFork.t.sol
@@ -3,13 +3,13 @@
 pragma solidity =0.8.25;
 
 import {Test, Vm} from "forge-std/Test.sol";
-import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
-import {PythOracleAdapter} from "src/concrete/oracle/PythOracleAdapter.sol";
-import {MultiPythOracleAdapter} from "src/concrete/oracle/MultiPythOracleAdapter.sol";
-import {MorphoProtocolAdapter} from "src/concrete/protocol/MorphoProtocolAdapter.sol";
-import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
-import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
+import {AggregatorV2V3Interface} from "st0x.oracle/interface/IAggregatorV2V3.sol";
+import {PythOracleAdapter} from "st0x.oracle/concrete/oracle/PythOracleAdapter.sol";
+import {MultiPythOracleAdapter} from "st0x.oracle/concrete/oracle/MultiPythOracleAdapter.sol";
+import {MorphoProtocolAdapter} from "st0x.oracle/concrete/protocol/MorphoProtocolAdapter.sol";
+import {PassthroughProtocolAdapter} from "st0x.oracle/concrete/protocol/PassthroughProtocolAdapter.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
+import {LibProdDeploy} from "st0x.oracle/lib/LibProdDeploy.sol";
 
 /// @title LibProdOracles
 /// @notice Hardcoded production oracle addresses deployed via

--- a/test/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.construct.t.sol
@@ -9,13 +9,13 @@ import {
     ZeroImplementation,
     ZeroBeaconOwner,
     InitializeAdapterFailed
-} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
-import {MorphoProtocolAdapter} from "src/concrete/protocol/MorphoProtocolAdapter.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+} from "st0x.oracle/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
+import {MorphoProtocolAdapter} from "st0x.oracle/concrete/protocol/MorphoProtocolAdapter.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig
-} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
 
 /// @dev Malicious adapter implementation whose `initialize` returns a non-
 /// success sentinel, exercising the `InitializeAdapterFailed` branch in

--- a/test/src/concrete/deploy/MultiOracleUnifiedDeployer.t.sol
+++ b/test/src/concrete/deploy/MultiOracleUnifiedDeployer.t.sol
@@ -6,20 +6,24 @@ import {Test} from "forge-std/Test.sol";
 import {
     MultiOracleUnifiedDeployer,
     MultiPythBeaconSetDeployerNotSet
-} from "src/concrete/deploy/MultiOracleUnifiedDeployer.sol";
-import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
-import {MultiPythOracleAdapterBeaconSetDeployer} from "src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/MultiOracleUnifiedDeployer.sol";
+import {LibProdDeploy} from "st0x.oracle/lib/LibProdDeploy.sol";
+import {
+    MultiPythOracleAdapterBeaconSetDeployer
+} from "st0x.oracle/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
 import {
     PassthroughProtocolAdapterBeaconSetDeployer
-} from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
-import {MorphoProtocolAdapterBeaconSetDeployer} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
-import {FeedConfig} from "src/concrete/oracle/MultiPythOracleAdapter.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+} from "st0x.oracle/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
+import {
+    MorphoProtocolAdapterBeaconSetDeployer
+} from "st0x.oracle/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
+import {FeedConfig} from "st0x.oracle/concrete/oracle/MultiPythOracleAdapter.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig
-} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
-import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
+} from "st0x.oracle/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
+import {CorporateActionPauseConfig} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
 
 /// @title MultiOracleUnifiedDeployerTest
 /// @notice Mirrors `OracleUnifiedDeployerTest` — etches the three sub-deployers

--- a/test/src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.construct.t.sol
@@ -6,19 +6,19 @@ import {Test, Vm} from "forge-std/Test.sol";
 import {
     MultiPythOracleAdapterBeaconSetDeployer,
     MultiPythOracleAdapterBeaconSetDeployerConfig,
-    MultiZeroImplementation,
-    MultiZeroBeaconOwner,
-    InitializeMultiOracleFailed
-} from "src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
+    ZeroImplementation,
+    ZeroBeaconOwner,
+    InitializeAdapterFailed
+} from "st0x.oracle/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
 import {
     MultiPythOracleAdapter,
     MultiPythOracleAdapterConfig,
     FeedConfig
-} from "src/concrete/oracle/MultiPythOracleAdapter.sol";
-import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
+} from "st0x.oracle/concrete/oracle/MultiPythOracleAdapter.sol";
+import {CorporateActionPauseConfig} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
 
 /// @dev Malicious implementation whose `initialize` returns a non-success
-/// sentinel, exercising the `InitializeMultiOracleFailed` branch in
+/// sentinel, exercising the `InitializeAdapterFailed` branch in
 /// `newMultiPythOracleAdapter`.
 contract BadMultiImpl {
     function initialize(bytes calldata) external pure returns (bytes32) {
@@ -37,11 +37,11 @@ contract MultiPythOracleAdapterBeaconSetDeployerConstructTest is Test {
         });
     }
 
-    /// Constructor must revert `MultiZeroImplementation` when the
+    /// Constructor must revert `ZeroImplementation` when the
     /// implementation address is zero.
     function testMultiPythOracleAdapterBeaconSetDeployerConstructZeroImplementation(address initialOwner) external {
         vm.assume(initialOwner != address(0));
-        vm.expectRevert(abi.encodeWithSelector(MultiZeroImplementation.selector));
+        vm.expectRevert(abi.encodeWithSelector(ZeroImplementation.selector));
         new MultiPythOracleAdapterBeaconSetDeployer(
             MultiPythOracleAdapterBeaconSetDeployerConfig({
                 initialOwner: initialOwner, initialMultiPythOracleAdapterImplementation: address(0)
@@ -49,13 +49,13 @@ contract MultiPythOracleAdapterBeaconSetDeployerConstructTest is Test {
         );
     }
 
-    /// Constructor must revert `MultiZeroBeaconOwner` when the initial owner
+    /// Constructor must revert `ZeroBeaconOwner` when the initial owner
     /// is zero (checked after implementation validation).
     function testMultiPythOracleAdapterBeaconSetDeployerConstructZeroBeaconOwner(address initialMultiPythOracleAdapterImplementation)
         external
     {
         vm.assume(initialMultiPythOracleAdapterImplementation != address(0));
-        vm.expectRevert(abi.encodeWithSelector(MultiZeroBeaconOwner.selector));
+        vm.expectRevert(abi.encodeWithSelector(ZeroBeaconOwner.selector));
         new MultiPythOracleAdapterBeaconSetDeployer(
             MultiPythOracleAdapterBeaconSetDeployerConfig({
                 initialOwner: address(0),
@@ -76,7 +76,7 @@ contract MultiPythOracleAdapterBeaconSetDeployerConstructTest is Test {
         assertEq(address(deployer.I_MULTI_PYTH_ORACLE_ADAPTER_BEACON().implementation()), address(implementation));
     }
 
-    /// `newMultiPythOracleAdapter` must revert `InitializeMultiOracleFailed`
+    /// `newMultiPythOracleAdapter` must revert `InitializeAdapterFailed`
     /// when the cloned proxy's `initialize` returns the wrong sentinel.
     function testNewMultiPythOracleAdapterRevertsInitFailure() external {
         BadMultiImpl bad = new BadMultiImpl();
@@ -89,7 +89,7 @@ contract MultiPythOracleAdapterBeaconSetDeployerConstructTest is Test {
         FeedConfig[] memory feeds = new FeedConfig[](1);
         feeds[0] = FeedConfig({priceId: bytes32(uint256(1)), maxAge: 300});
 
-        vm.expectRevert(abi.encodeWithSelector(InitializeMultiOracleFailed.selector));
+        vm.expectRevert(abi.encodeWithSelector(InitializeAdapterFailed.selector));
         deployer.newMultiPythOracleAdapter(
             MultiPythOracleAdapterConfig({
                 vault: address(0xBEEF), feeds: feeds, admin: address(this), pauseConfig: _emptyPauseConfig()

--- a/test/src/concrete/deploy/OracleRegistryBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/OracleRegistryBeaconSetDeployer.construct.t.sol
@@ -3,13 +3,13 @@
 pragma solidity =0.8.25;
 
 import {Test, Vm} from "forge-std/Test.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig,
     ZeroImplementation,
     ZeroBeaconOwner
-} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
 
 contract OracleRegistryBeaconSetDeployerConstructTest is Test {
     /// Test that zero implementation address reverts.

--- a/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
+++ b/test/src/concrete/deploy/OracleUnifiedDeployer.t.sol
@@ -3,20 +3,22 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std/Test.sol";
-import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
-import {OracleUnifiedDeployer} from "src/concrete/deploy/OracleUnifiedDeployer.sol";
-import {LibProdDeploy} from "src/lib/LibProdDeploy.sol";
-import {PythOracleAdapterBeaconSetDeployer} from "src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
+import {CorporateActionPauseConfig} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
+import {OracleUnifiedDeployer} from "st0x.oracle/concrete/deploy/OracleUnifiedDeployer.sol";
+import {LibProdDeploy} from "st0x.oracle/lib/LibProdDeploy.sol";
+import {PythOracleAdapterBeaconSetDeployer} from "st0x.oracle/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
 import {
     PassthroughProtocolAdapterBeaconSetDeployer
-} from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
-import {MorphoProtocolAdapterBeaconSetDeployer} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
-import {PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+} from "st0x.oracle/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
+import {
+    MorphoProtocolAdapterBeaconSetDeployer
+} from "st0x.oracle/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
+import {PythOracleAdapterConfig} from "st0x.oracle/concrete/oracle/PythOracleAdapter.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig
-} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
 
 contract OracleUnifiedDeployerTest is Test {
     OracleRegistry internal immutable I_REGISTRY_IMPLEMENTATION;

--- a/test/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.construct.t.sol
@@ -8,13 +8,13 @@ import {
     PassthroughProtocolAdapterBeaconSetDeployerConfig,
     ZeroImplementation,
     ZeroBeaconOwner
-} from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
-import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+} from "st0x.oracle/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
+import {PassthroughProtocolAdapter} from "st0x.oracle/concrete/protocol/PassthroughProtocolAdapter.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig
-} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
 
 contract PassthroughProtocolAdapterBeaconSetDeployerConstructTest is Test {
     function testPassthroughProtocolAdapterBeaconSetDeployerConstructZeroImplementation(address initialOwner) external {

--- a/test/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.construct.t.sol
@@ -8,9 +8,9 @@ import {
     PythOracleAdapterBeaconSetDeployerConfig,
     ZeroImplementation,
     ZeroBeaconOwner
-} from "src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
-import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
-import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
+} from "st0x.oracle/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
+import {PythOracleAdapter, PythOracleAdapterConfig} from "st0x.oracle/concrete/oracle/PythOracleAdapter.sol";
+import {CorporateActionPauseConfig} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
 
 contract PythOracleAdapterBeaconSetDeployerConstructTest is Test {
     function testPythOracleAdapterBeaconSetDeployerConstructZeroImplementation(address initialOwner) external {

--- a/test/src/concrete/oracle/BasePythOracleAdapter.corporateActionConfig.t.sol
+++ b/test/src/concrete/oracle/BasePythOracleAdapter.corporateActionConfig.t.sol
@@ -8,7 +8,7 @@ import {
     BasePythOracleAdapter,
     CorporateActionPauseConfig,
     CorporateActionConfigAlreadyInitialized
-} from "src/abstract/BasePythOracleAdapter.sol";
+} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
 
 /// @dev Minimal harness exposing `_setCorporateActionPauseConfig` for direct
 /// invocation. The base adapter's helper is `internal`; we override the

--- a/test/src/concrete/oracle/MultiPythOracleAdapter.admin.t.sol
+++ b/test/src/concrete/oracle/MultiPythOracleAdapter.admin.t.sol
@@ -12,7 +12,7 @@ import {
     ZeroAdmin,
     BasePythOracleAdapter,
     CorporateActionPauseConfig
-} from "src/abstract/BasePythOracleAdapter.sol";
+} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
 import {
     MultiPythOracleAdapter,
     MultiPythOracleAdapterConfig,
@@ -23,11 +23,11 @@ import {
     TooManyFeeds,
     FeedIndexOutOfBounds,
     MAX_FEEDS
-} from "src/concrete/oracle/MultiPythOracleAdapter.sol";
+} from "st0x.oracle/concrete/oracle/MultiPythOracleAdapter.sol";
 import {
     MultiPythOracleAdapterBeaconSetDeployer,
     MultiPythOracleAdapterBeaconSetDeployerConfig
-} from "src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
 
 bytes32 constant FEED_TSLA = 0x16dad506d7db8da01c87581c87ca897a012a153557d4d578c3b9c9e1bc0632f1;
 bytes32 constant FEED_COIN = 0xfee33f2a978bf32dd6b662b65ba8083c6773b494f8401194ec1870c640860245;

--- a/test/src/concrete/oracle/MultiPythOracleAdapter.fuzz.t.sol
+++ b/test/src/concrete/oracle/MultiPythOracleAdapter.fuzz.t.sol
@@ -13,17 +13,17 @@ import {
     ZeroVaultSharePrice,
     NonPositivePrice,
     CorporateActionPauseConfig
-} from "src/abstract/BasePythOracleAdapter.sol";
+} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
 import {
     MultiPythOracleAdapter,
     MultiPythOracleAdapterConfig,
     FeedConfig,
     AllFeedsStale
-} from "src/concrete/oracle/MultiPythOracleAdapter.sol";
+} from "st0x.oracle/concrete/oracle/MultiPythOracleAdapter.sol";
 import {
     MultiPythOracleAdapterBeaconSetDeployer,
     MultiPythOracleAdapterBeaconSetDeployerConfig
-} from "src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
 
 /// @dev Pyth contract address on Base (from LibPyth).
 address constant PYTH_BASE = 0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a;

--- a/test/src/concrete/oracle/MultiPythOracleAdapter.initialize.t.sol
+++ b/test/src/concrete/oracle/MultiPythOracleAdapter.initialize.t.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {LibFork} from "test/lib/LibFork.sol";
-import {ZeroVault, ZeroAdmin, CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
+import {ZeroVault, ZeroAdmin, CorporateActionPauseConfig} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
 import {
     MultiPythOracleAdapter,
     MultiPythOracleAdapterConfig,
@@ -14,11 +14,11 @@ import {
     ZeroFeeds,
     TooManyFeeds,
     MAX_FEEDS
-} from "src/concrete/oracle/MultiPythOracleAdapter.sol";
+} from "st0x.oracle/concrete/oracle/MultiPythOracleAdapter.sol";
 import {
     MultiPythOracleAdapterBeaconSetDeployer,
     MultiPythOracleAdapterBeaconSetDeployerConfig
-} from "src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
 
 uint256 constant BASE_CHAIN_ID = 8453;
 

--- a/test/src/concrete/oracle/MultiPythOracleAdapter.latestAnswer.t.sol
+++ b/test/src/concrete/oracle/MultiPythOracleAdapter.latestAnswer.t.sol
@@ -15,17 +15,17 @@ import {
     NonPositivePrice,
     OraclePausedManual,
     CorporateActionPauseConfig
-} from "src/abstract/BasePythOracleAdapter.sol";
+} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
 import {
     MultiPythOracleAdapter,
     MultiPythOracleAdapterConfig,
     FeedConfig,
     AllFeedsStale
-} from "src/concrete/oracle/MultiPythOracleAdapter.sol";
+} from "st0x.oracle/concrete/oracle/MultiPythOracleAdapter.sol";
 import {
     MultiPythOracleAdapterBeaconSetDeployer,
     MultiPythOracleAdapterBeaconSetDeployerConfig
-} from "src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
 
 /// @dev COIN/USD regular hours Pyth feed ID.
 bytes32 constant FEED_COIN_REGULAR = 0xfee33f2a978bf32dd6b662b65ba8083c6773b494f8401194ec1870c640860245;

--- a/test/src/concrete/oracle/MultiPythOracleAdapter.setFeedsOrdering.t.sol
+++ b/test/src/concrete/oracle/MultiPythOracleAdapter.setFeedsOrdering.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std/Test.sol";
-import {CorporateActionPauseConfig} from "src/abstract/BasePythOracleAdapter.sol";
+import {CorporateActionPauseConfig} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
 import {
     MultiPythOracleAdapter,
     MultiPythOracleAdapterConfig,
@@ -13,11 +13,11 @@ import {
     ZeroFeeds,
     TooManyFeeds,
     MAX_FEEDS
-} from "src/concrete/oracle/MultiPythOracleAdapter.sol";
+} from "st0x.oracle/concrete/oracle/MultiPythOracleAdapter.sol";
 import {
     MultiPythOracleAdapterBeaconSetDeployer,
     MultiPythOracleAdapterBeaconSetDeployerConfig
-} from "src/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
 
 bytes32 constant FEED_A = bytes32(uint256(0x1111));
 bytes32 constant FEED_B = bytes32(uint256(0x2222));

--- a/test/src/concrete/oracle/MultiPythOracleAdapter.storageLayout.t.sol
+++ b/test/src/concrete/oracle/MultiPythOracleAdapter.storageLayout.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {CorporateActionPauseConfig} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
+import {
+    MultiPythOracleAdapter,
+    MultiPythOracleAdapterConfig,
+    FeedConfig
+} from "st0x.oracle/concrete/oracle/MultiPythOracleAdapter.sol";
+import {
+    MultiPythOracleAdapterBeaconSetDeployer,
+    MultiPythOracleAdapterBeaconSetDeployerConfig
+} from "st0x.oracle/concrete/deploy/MultiPythOracleAdapterBeaconSetDeployer.sol";
+
+/// @title MultiPythOracleAdapterStorageLayoutTest
+/// @notice Pins the on-chain storage slot positions of
+/// `BasePythOracleAdapter.vault` and `MultiPythOracleAdapter.feedCount` so an
+/// accidental reordering of base-class state (e.g. forgetting to decrement
+/// `__gap`) is caught by CI rather than silently shifting subclass slots.
+///
+/// The slot for `feedCount` is the first slot AFTER the
+/// `BasePythOracleAdapter`'s 50-slot `__gap`. Adding new base-class state
+/// requires decrementing the `__gap` length by an equivalent number of slots
+/// so this assertion keeps holding without rewriting it.
+///
+/// No fork is required — initialization writes to storage on the in-memory
+/// EVM, and `vm.load` reads it back. The Pyth integration is not exercised.
+contract MultiPythOracleAdapterStorageLayoutTest is Test {
+    /// @dev Slot 0 of the proxy storage: `BasePythOracleAdapter.vault`.
+    uint256 internal constant VAULT_SLOT = 0;
+
+    /// @dev Post-`__gap` slot in `MultiPythOracleAdapter`: `feedCount`.
+    /// Derivation: 5 base-class slots (mutable governance + corporate-action
+    /// config) + 50 reserved gap slots = 55.
+    uint256 internal constant FEED_COUNT_SLOT = 55;
+
+    MultiPythOracleAdapterBeaconSetDeployer internal immutable I_DEPLOYER;
+
+    bytes32 constant FEED_A = 0xfee33f2a978bf32dd6b662b65ba8083c6773b494f8401194ec1870c640860245;
+
+    constructor() {
+        MultiPythOracleAdapter implementation = new MultiPythOracleAdapter();
+        I_DEPLOYER = new MultiPythOracleAdapterBeaconSetDeployer(
+            MultiPythOracleAdapterBeaconSetDeployerConfig({
+                initialOwner: address(this), initialMultiPythOracleAdapterImplementation: address(implementation)
+            })
+        );
+    }
+
+    /// @notice Initialize a proxy with a known vault and one feed; then read
+    /// slot 0 and the post-gap slot raw via `vm.load` and assert both match
+    /// the values written by `initialize`.
+    function testStorageLayoutPinned(address vault, address admin) external {
+        vm.assume(vault != address(0));
+        vm.assume(admin != address(0));
+
+        FeedConfig[] memory feeds = new FeedConfig[](1);
+        feeds[0] = FeedConfig({priceId: FEED_A, maxAge: 300});
+
+        CorporateActionPauseConfig memory pauseConfig = CorporateActionPauseConfig({
+            corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+        });
+
+        MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
+            MultiPythOracleAdapterConfig({vault: vault, feeds: feeds, admin: admin, pauseConfig: pauseConfig})
+        );
+
+        bytes32 vaultSlotValue = vm.load(address(adapter), bytes32(VAULT_SLOT));
+        assertEq(address(uint160(uint256(vaultSlotValue))), vault, "slot 0 must hold BasePythOracleAdapter.vault");
+
+        bytes32 feedCountSlotValue = vm.load(address(adapter), bytes32(FEED_COUNT_SLOT));
+        assertEq(uint256(feedCountSlotValue), 1, "post-gap slot must hold MultiPythOracleAdapter.feedCount");
+    }
+}

--- a/test/src/concrete/oracle/PythOracleAdapter.autoPause.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.autoPause.t.sol
@@ -16,8 +16,8 @@ import {
     OraclePausedManual,
     OraclePausedCorporateAction,
     HistoricalRoundDataUnsupported
-} from "src/abstract/BasePythOracleAdapter.sol";
-import {PythOracleAdapter} from "src/concrete/oracle/PythOracleAdapter.sol";
+} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
+import {PythOracleAdapter} from "st0x.oracle/concrete/oracle/PythOracleAdapter.sol";
 
 /// @dev Base chain ID.
 uint256 constant BASE_CHAIN_ID = 8453;

--- a/test/src/concrete/oracle/PythOracleAdapter.initialize.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.initialize.t.sol
@@ -3,13 +3,13 @@
 pragma solidity =0.8.25;
 
 import {PythOracleAdapterTest} from "test/abstract/PythOracleAdapterTest.sol";
-import {ZeroVault, ZeroAdmin} from "src/abstract/BasePythOracleAdapter.sol";
+import {ZeroVault, ZeroAdmin} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
 import {
     PythOracleAdapter,
     PythOracleAdapterConfig,
     ZeroPriceId,
     ZeroMaxAge
-} from "src/concrete/oracle/PythOracleAdapter.sol";
+} from "st0x.oracle/concrete/oracle/PythOracleAdapter.sol";
 import {Vm} from "forge-std/Test.sol";
 
 contract PythOracleAdapterInitializeTest is PythOracleAdapterTest {

--- a/test/src/concrete/oracle/PythOracleAdapter.latestAnswer.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.latestAnswer.t.sol
@@ -13,12 +13,12 @@ import {
     ZeroVaultSupply,
     VaultSharePriceOverflow,
     CorporateActionPauseConfig
-} from "src/abstract/BasePythOracleAdapter.sol";
-import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
+} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
+import {PythOracleAdapter, PythOracleAdapterConfig} from "st0x.oracle/concrete/oracle/PythOracleAdapter.sol";
 import {
     PythOracleAdapterBeaconSetDeployer,
     PythOracleAdapterBeaconSetDeployerConfig
-} from "src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
 
 /// @dev TSLA/USD Pyth price feed ID.
 bytes32 constant PRICE_FEED_ID_EQUITY_US_TSLA_USD = 0x16dad506d7db8da01c87581c87ca897a012a153557d4d578c3b9c9e1bc0632f1;

--- a/test/src/concrete/oracle/PythOracleAdapter.setPaused.t.sol
+++ b/test/src/concrete/oracle/PythOracleAdapter.setPaused.t.sol
@@ -3,9 +3,14 @@
 pragma solidity =0.8.25;
 
 import {PythOracleAdapterTest} from "test/abstract/PythOracleAdapterTest.sol";
-import {OraclePausedManual, OnlyAdmin, ZeroAdmin, BasePythOracleAdapter} from "src/abstract/BasePythOracleAdapter.sol";
-import {PythOracleAdapter} from "src/concrete/oracle/PythOracleAdapter.sol";
-import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
+import {
+    OraclePausedManual,
+    OnlyAdmin,
+    ZeroAdmin,
+    BasePythOracleAdapter
+} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
+import {PythOracleAdapter} from "st0x.oracle/concrete/oracle/PythOracleAdapter.sol";
+import {AggregatorV2V3Interface} from "st0x.oracle/interface/IAggregatorV2V3.sol";
 
 contract PythOracleAdapterSetPausedTest is PythOracleAdapterTest {
     /// Test that setPaused works for admin.

--- a/test/src/concrete/protocol/AutoPausePropagation.t.sol
+++ b/test/src/concrete/protocol/AutoPausePropagation.t.sol
@@ -8,33 +8,33 @@ import {IERC4626} from "openzeppelin-contracts/contracts/interfaces/IERC4626.sol
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {IPyth} from "pyth-sdk/IPyth.sol";
 import {PythStructs} from "pyth-sdk/PythStructs.sol";
-import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
+import {AggregatorV2V3Interface} from "st0x.oracle/interface/IAggregatorV2V3.sol";
 import {ACTION_TYPE_STOCK_SPLIT_V1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
 import {
     CorporateActionPauseConfig,
     OraclePausedCorporateAction,
     OraclePausedManual
-} from "src/abstract/BasePythOracleAdapter.sol";
-import {PythOracleAdapter, PythOracleAdapterConfig} from "src/concrete/oracle/PythOracleAdapter.sol";
+} from "st0x.oracle/abstract/BasePythOracleAdapter.sol";
+import {PythOracleAdapter, PythOracleAdapterConfig} from "st0x.oracle/concrete/oracle/PythOracleAdapter.sol";
 import {
     PythOracleAdapterBeaconSetDeployer,
     PythOracleAdapterBeaconSetDeployerConfig
-} from "src/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+} from "st0x.oracle/concrete/deploy/PythOracleAdapterBeaconSetDeployer.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig
-} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
-import {PassthroughProtocolAdapter} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
+} from "st0x.oracle/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
+import {PassthroughProtocolAdapter} from "st0x.oracle/concrete/protocol/PassthroughProtocolAdapter.sol";
 import {
     PassthroughProtocolAdapterBeaconSetDeployer,
     PassthroughProtocolAdapterBeaconSetDeployerConfig
-} from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
-import {MorphoProtocolAdapter} from "src/concrete/protocol/MorphoProtocolAdapter.sol";
+} from "st0x.oracle/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
+import {MorphoProtocolAdapter} from "st0x.oracle/concrete/protocol/MorphoProtocolAdapter.sol";
 import {
     MorphoProtocolAdapterBeaconSetDeployer,
     MorphoProtocolAdapterBeaconSetDeployerConfig
-} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
+} from "st0x.oracle/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
 
 /// @dev Pyth contract address on Base (from `LibPyth`). We mock at this
 /// address so the oracle's runtime call resolves regardless of fork state.

--- a/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/MorphoProtocolAdapter.t.sol
@@ -13,17 +13,17 @@ import {
     OracleNotFound,
     NonPositivePrice,
     UnexpectedOracleDecimals
-} from "src/concrete/protocol/MorphoProtocolAdapter.sol";
+} from "st0x.oracle/concrete/protocol/MorphoProtocolAdapter.sol";
 import {
     MorphoProtocolAdapterBeaconSetDeployer,
     MorphoProtocolAdapterBeaconSetDeployerConfig
-} from "src/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+} from "st0x.oracle/concrete/deploy/MorphoProtocolAdapterBeaconSetDeployer.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig
-} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
-import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
+} from "st0x.oracle/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
+import {AggregatorV2V3Interface} from "st0x.oracle/interface/IAggregatorV2V3.sol";
 
 contract MorphoProtocolAdapterTest is Test {
     MorphoProtocolAdapter internal immutable I_IMPLEMENTATION;
@@ -248,7 +248,7 @@ contract MorphoProtocolAdapterTest is Test {
 
         MorphoProtocolAdapter adapter = I_DEPLOYER.newMorphoProtocolAdapter(registry, vault, admin);
 
-        vm.expectRevert(abi.encodeWithSelector(NonPositivePrice.selector));
+        vm.expectRevert(abi.encodeWithSelector(NonPositivePrice.selector, int256(0)));
         adapter.price();
     }
 
@@ -297,7 +297,7 @@ contract MorphoProtocolAdapterTest is Test {
 
         MorphoProtocolAdapter adapter = I_DEPLOYER.newMorphoProtocolAdapter(registry, vault, admin);
 
-        vm.expectRevert(abi.encodeWithSelector(NonPositivePrice.selector));
+        vm.expectRevert(abi.encodeWithSelector(NonPositivePrice.selector, negativePrice));
         adapter.price();
     }
 

--- a/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
+++ b/test/src/concrete/protocol/PassthroughProtocolAdapter.t.sol
@@ -11,17 +11,17 @@ import {
     ZeroRegistry,
     ZeroVault,
     OracleNotFound
-} from "src/concrete/protocol/PassthroughProtocolAdapter.sol";
+} from "st0x.oracle/concrete/protocol/PassthroughProtocolAdapter.sol";
 import {
     PassthroughProtocolAdapterBeaconSetDeployer,
     PassthroughProtocolAdapterBeaconSetDeployerConfig
-} from "src/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
-import {OracleRegistry} from "src/concrete/registry/OracleRegistry.sol";
+} from "st0x.oracle/concrete/deploy/PassthroughProtocolAdapterBeaconSetDeployer.sol";
+import {OracleRegistry} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
 import {
     OracleRegistryBeaconSetDeployer,
     OracleRegistryBeaconSetDeployerConfig
-} from "src/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
-import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
+} from "st0x.oracle/concrete/deploy/OracleRegistryBeaconSetDeployer.sol";
+import {AggregatorV2V3Interface} from "st0x.oracle/interface/IAggregatorV2V3.sol";
 
 contract PassthroughProtocolAdapterTest is Test {
     PassthroughProtocolAdapter internal immutable I_IMPLEMENTATION;

--- a/test/src/concrete/registry/OracleRegistry.t.sol
+++ b/test/src/concrete/registry/OracleRegistry.t.sol
@@ -13,9 +13,9 @@ import {
     ArrayLengthMismatch,
     BulkLengthExceeded,
     MAX_BULK_LENGTH
-} from "src/concrete/registry/OracleRegistry.sol";
+} from "st0x.oracle/concrete/registry/OracleRegistry.sol";
 import {ICLONEABLE_V2_SUCCESS} from "rain.factory/interface/ICloneableV2.sol";
-import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
+import {AggregatorV2V3Interface} from "st0x.oracle/interface/IAggregatorV2V3.sol";
 import {Vm} from "forge-std/Test.sol";
 
 contract OracleRegistryInitializeTest is OracleRegistryTest {

--- a/test/src/lib/LibCorporateActionsPause.t.sol
+++ b/test/src/lib/LibCorporateActionsPause.t.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {NODE_NONE} from "st0x.deploy/src/lib/LibCorporateActionNode.sol";
-import {LibCorporateActionsPause} from "src/lib/LibCorporateActionsPause.sol";
+import {LibCorporateActionsPause} from "st0x.oracle/lib/LibCorporateActionsPause.sol";
 import {ACTION_TYPE_STOCK_SPLIT_V1} from "st0x.deploy/src/interface/ICorporateActionsV1.sol";
 import {MockCorporateActions} from "test/mocks/MockCorporateActions.sol";
 


### PR DESCRIPTION
Bulk LOW-severity stylistic / refactor changes that have no behavioural
risk:

Style:
- #114 #117 #122 #128 #131 #136 #137 #138 #139 #140 #141 #142 #143:
  project-namespaced remapping `st0x.oracle/=src/`; all internal
  imports rewritten to use it so the repo is consumable as a git
  submodule without remapping conflicts.
- #134: LibProdDeploy.sol pragma pinned to =0.8.25.
- #119: MultiZero*/InitializeMultiOracleFailed errors in
  MultiPythOracleAdapterBeaconSetDeployer renamed to match sibling
  deployer naming (ZeroImplementation, ZeroBeaconOwner,
  InitializeAdapterFailed).

Refactors:
- #127: file-level OnlyAdmin / ZeroAdmin / ZeroVault / ZeroRegistry /
  OracleNotFound hoisted to src/lib/LibOracleErrors.sol; 4 consumers
  updated (BasePythOracleAdapter, OracleRegistry, MorphoProtocolAdapter,
  PassthroughProtocolAdapter).
- #130: OracleRegistry extracts _setOracle helper consumed by both
  setOracle and setOracleBulk.
- #124: MultiPythOracleAdapter.initialize bound checks already
  centralised in _setFeeds — no further dedup required (PR #230 #41).
- #125: MorphoProtocolAdapter.NonPositivePrice carries int256 price
  matching BasePythOracleAdapter.
- #126: MorphoProtocolAdapter 1e28 magic number replaced with named
  constants derived from MORPHO_PRICE_SCALE and EXPECTED_ORACLE_DECIMALS
  (SCALE_MULTIPLIER = MORPHO_PRICE_SCALE / 10**EXPECTED_ORACLE_DECIMALS).
- #115: BasePythOracleAdapter int256(price8) cast annotated with
  forge-lint disable + safety comment.
- #123: MultiPythOracleAdapter._tryGetPrice local `p` → `fetchedPrice`
  (named-return is already `price`, so use a distinct name).
- #133: LibCorporateActionsPause local `vault` → `corporateActions`
  to avoid shadowing the priced-vault meaning; also documents the
  discarded tuple-return placeholder.
- #200: LibCorporateActionsPause adds defensive `effectiveTime != 0`
  belt-and-suspenders on top of the NODE_NONE cursor check in both
  pre- and post-window branches.

Storage hardening (#116, #218):
- BasePythOracleAdapter storage groups separated by comment banners
  ("mutable governance" vs "immutable-after-init corporate-action
  config" vs "reserved slots"); ends with a `uint256[50] __gap`
  reserved-slot array so future base additions don't shift subclass
  slots. Subclass slot positions shift one-time by 50; safe because
  no live deployment exists. Adds vm.load-based storage layout test
  pinning `vault` at slot 0 and `MultiPythOracleAdapter.feedCount` at
  the post-gap slot 55.

forge build, forge fmt --check, slither (0 results), and REUSE all
green. Test count delta: 147 → 148 (+1, the new storage layout test).
No behaviour change to user-visible APIs beyond
NonPositivePrice(int256) shape change and storage layout (documented
above).

Closes #114, #115, #116, #117, #119, #122, #123, #124, #125, #126,
#127, #128, #130, #131, #133, #134, #136, #137, #138, #139, #140,
#141, #142, #143, #200, #218.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>