### PR TITLE
fix(audit-low): close 2 hazard-surface findings

### DIFF
--- a/.github/workflows/suite-names-sync.yaml
+++ b/.github/workflows/suite-names-sync.yaml
@@ -1,0 +1,61 @@
+name: Suite names sync
+
+# Fails CI if the deployment-suite enum in
+# .github/workflows/manual-sol-artifacts.yaml diverges from the keccak256
+# preimages in script/Deploy.sol. The two lists must stay in sync because
+# manual-sol-artifacts.yaml passes the dropdown choice to forge as
+# DEPLOYMENT_SUITE, and Deploy.run() dispatches by keccak256 of that string.
+# A typo / reordering / missing entry on either side silently routes to a
+# `revert("Unknown deployment suite")` or (worse) to the wrong handler.
+#
+# Closes: hazard-surface finding #214 (HAZARD-CROSS-FILE-SYNC).
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  suite-names-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare suite names between Deploy.sol and manual-sol-artifacts.yaml
+        run: |
+          set -euo pipefail
+
+          # Canonical source: keccak256("...") preimages in script/Deploy.sol.
+          grep -oE 'keccak256\("[a-z0-9-]+"\)' script/Deploy.sol \
+            | sed -E 's/keccak256\("(.*)"\)/\1/' \
+            | sort -u > /tmp/suites-from-sol.txt
+
+          # Mirror: options: block under the `suite` workflow_dispatch input
+          # in .github/workflows/manual-sol-artifacts.yaml.
+          awk '
+            /^      suite:/ { in_suite=1; next }
+            in_suite && /^      [a-zA-Z_]+:/ { in_suite=0 }
+            in_suite && /^[a-z]/ { in_suite=0 }
+            in_suite && /^          - / { gsub(/^          - /,""); print }
+          ' .github/workflows/manual-sol-artifacts.yaml \
+            | sort -u > /tmp/suites-from-yaml.txt
+
+          echo "Suite names declared in script/Deploy.sol:"
+          cat /tmp/suites-from-sol.txt
+          echo
+          echo "Suite names offered by .github/workflows/manual-sol-artifacts.yaml:"
+          cat /tmp/suites-from-yaml.txt
+          echo
+
+          if ! diff -u /tmp/suites-from-sol.txt /tmp/suites-from-yaml.txt; then
+            echo
+            echo "ERROR: deployment-suite enum has drifted between"
+            echo "  script/Deploy.sol (canonical, via keccak256 preimages)"
+            echo "  .github/workflows/manual-sol-artifacts.yaml (operator dropdown)"
+            echo
+            echo "Update the dropdown 'options:' list in manual-sol-artifacts.yaml"
+            echo "to exactly match the keccak256(\"...\") arguments in Deploy.sol,"
+            echo "or add the missing keccak256(\"...\") branch in Deploy.sol."
+            exit 1
+          fi
+
+          echo "OK: suite names are in sync."

--- a/foundry.lock
+++ b/foundry.lock
@@ -6,6 +6,6 @@
     "rev": "e7a45068d5aac93e92aec55d7bf1f58e66319a53"
   },
   "lib/st0x.deploy": {
-    "rev": "766b468f67149789337bdca39fdd2bab9b9216e2"
+    "rev": "9955248669714aa37aaaa8fff994d763f6c12e89"
   }
 }


### PR DESCRIPTION
- #146 CONFIG-SUBMODULE-LOCK: regenerate foundry.lock to align with
  the working-tree pointer for lib/st0x.deploy (99552486...). Prior
  state had foundry.lock pinned to 766b468f... while .gitmodules
  resolved to 99552486..., producing a build warning on every nix
  invocation. The working-tree pointer is what the code is actually
  compiled against, so the lock is updated to match it (not the
  other way around).
- #214 HAZARD-CROSS-FILE-SYNC: add .github/workflows/suite-names-sync.yaml
  (Option B in the issue — the simpler fence). The workflow extracts the
  deployment-suite names from script/Deploy.sol's keccak256("...")
  preimages and compares them against the operator-facing dropdown's
  options: list in .github/workflows/manual-sol-artifacts.yaml. If the
  two lists diverge, CI fails with a diff and a hint pointing at both
  files. This catches both typos and missing-entry drift in the same
  PR that introduces them, instead of at deploy time as a "Unknown
  deployment suite" revert. Chosen over Option A (generated source of
  truth) because it ships in one workflow file with no new build
  step, no jq dependency, and the existing duplication in Deploy.sol
  stays readable as plain Solidity.

forge build no longer warns about the revision mismatch. nix CI green
(forge fmt no-op, rainix-sol-static clean, rainix-sol-legal clean, 169
tests pass under the standard --no-match-contract exclusions).

Closes #146, #214.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>