### PR TITLE
Handle non-stale Pyth errors in multi feed oracle

### DIFF
--- a/src/concrete/oracle/MultiPythOracleAdapter.sol
+++ b/src/concrete/oracle/MultiPythOracleAdapter.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.25;
 
 import {IPyth} from "pyth-sdk/IPyth.sol";
 import {PythStructs} from "pyth-sdk/PythStructs.sol";
+import {PythErrors} from "pyth-sdk/PythErrors.sol";
 import {LibPyth} from "rain.pyth/src/lib/pyth/LibPyth.sol";
 import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain.factory/interface/ICloneableV2.sol";
 import {Initializable} from "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
@@ -174,9 +175,27 @@ contract MultiPythOracleAdapter is BasePythOracleAdapter, ICloneableV2, Initiali
     {
         try pyth.getPriceNoOlderThan(feedPriceId, feedMaxAge) returns (PythStructs.Price memory p) {
             return (true, p);
-        } catch {
-            return (false, price);
+        } catch (bytes memory err) {
+            if (_isStalePrice(err)) {
+                return (false, price);
+            }
+
+            assembly ("memory-safe") {
+                revert(add(err, 0x20), mload(err))
+            }
         }
+    }
+
+    function _isStalePrice(bytes memory err) internal pure returns (bool) {
+        if (err.length < 4) {
+            return false;
+        }
+
+        bytes4 selector;
+        assembly ("memory-safe") {
+            selector := mload(add(err, 0x20))
+        }
+        return selector == PythErrors.StalePrice.selector;
     }
 
     /// @dev Internal feed setter. Validates and stores feeds.

--- a/test/src/concrete/oracle/MultiPythOracleAdapter.fuzz.t.sol
+++ b/test/src/concrete/oracle/MultiPythOracleAdapter.fuzz.t.sol
@@ -6,6 +6,7 @@ import {Test} from "forge-std/Test.sol";
 import {IERC4626} from "openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {IPyth} from "pyth-sdk/IPyth.sol";
+import {PythErrors} from "pyth-sdk/PythErrors.sol";
 import {PythStructs} from "pyth-sdk/PythStructs.sol";
 import {ZeroVaultSupply, ZeroVaultSharePrice, NonPositivePrice} from "src/abstract/BasePythOracleAdapter.sol";
 import {
@@ -65,8 +66,31 @@ contract MultiPythOracleAdapterFuzzTest is Test {
     /// @dev Mock Pyth to revert (stale) for the given feed.
     function _mockStaleFeed(bytes32 feedId, uint256 maxAge) internal {
         vm.mockCallRevert(
-            PYTH_BASE, abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, feedId, maxAge), "stale"
+            PYTH_BASE,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, feedId, maxAge),
+            abi.encodeWithSelector(PythErrors.StalePrice.selector)
         );
+    }
+
+    function testNonStalePythRevertBubbles() external {
+        address mockVault = address(uint160(uint256(keccak256("v.non-stale-revert"))));
+        _mockVault(mockVault, 1000e18, 1000e18);
+
+        FeedConfig[] memory feeds = new FeedConfig[](1);
+        feeds[0] = FeedConfig({priceId: MOCK_FEED, maxAge: 300});
+
+        MultiPythOracleAdapter adapter = I_DEPLOYER.newMultiPythOracleAdapter(
+            MultiPythOracleAdapterConfig({vault: mockVault, feeds: feeds, admin: address(this)})
+        );
+
+        vm.mockCallRevert(
+            PYTH_BASE,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, MOCK_FEED, uint256(300)),
+            abi.encodeWithSelector(PythErrors.PriceFeedNotFound.selector)
+        );
+
+        vm.expectRevert(PythErrors.PriceFeedNotFound.selector);
+        adapter.latestAnswer();
     }
 
     /// @notice Fuzz vault ratio: for any valid totalAssets/totalSupply,


### PR DESCRIPTION
## Summary
- Treat only the canonical `PythErrors.StalePrice()` revert as a stale-feed fallback in `MultiPythOracleAdapter`.
- Revert with the original Pyth error data for non-staleness failures such as `PriceFeedNotFound()`, preserving the operational signal instead of masking it as `AllFeedsStale()`.
- Update the stale-feed fuzz mock to use the real Pyth stale selector and add regression coverage for bubbling a non-stale Pyth revert.

Fixes #34.

## Validation
- `forge fmt --check src/concrete/oracle/MultiPythOracleAdapter.sol test/src/concrete/oracle/MultiPythOracleAdapter.fuzz.t.sol`
- `forge build`
- `forge test --match-path test/src/concrete/oracle/MultiPythOracleAdapter.fuzz.t.sol -vvv` -> 3 passed
- `RPC_URL_BASE_FORK=https://mainnet.base.org forge test --match-path 'test/src/concrete/oracle/MultiPythOracleAdapter*.t.sol' -vv` -> 38 passed
- `RPC_URL_BASE_FORK=https://mainnet.base.org FORK_BLOCK_BASE=38996123 forge test --no-match-contract ProdForkTest` -> 122 passed

Note: full `forge test` currently has unrelated `ProdForkTest` failures against production fork assumptions; the suite above covers all non-production-fork tests plus the complete MultiPythOracleAdapter tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Oracle adapter to intelligently handle price feed errors. Stale price data now triggers automatic fallback to the next available feed instead of causing transaction failure. Other error types continue to propagate appropriately.

* **Tests**
  * Added test coverage for non-stale price feed error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.oracle/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->