### PR TITLE
feat(interface): vendor IChronicle from chronicle-std

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/interface/IChronicle.sol
+++ b/src/interface/IChronicle.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) 2024 Chronicle Labs, Inc.
+pragma solidity =0.8.25;
+
+// SYNC NOTE: This interface is a hand-typed copy of Chronicle Protocol's
+// canonical `IChronicle` from
+// `chronicleprotocol/chronicle-std:src/IChronicle.sol`, last synced
+// 2026-06-26 against `main` (commit-pinned vendor pending). Re-sync on
+// any upstream interface bump. No drift-detection test exists yet.
+//
+// Vendored rather than pulled as a soldeer/git dep — the interface is
+// small, stable, and Chronicle does not currently publish chronicle-std
+// to soldeer. Same pattern as `IAggregatorV2V3` (vendored Chainlink).
+
+/// @title IChronicle
+/// @notice Interface for Chronicle Protocol's oracle products. Returns
+/// 18-decimal `uint256` values. The `*WithAge` variants additionally
+/// surface the `block.timestamp` of the last poke, which consumers can
+/// use to enforce their own staleness windows.
+interface IChronicle {
+    /// @notice Returns the oracle's identifier.
+    /// @return id The oracle's identifier (named `wat` in Chronicle's upstream
+    /// docs — renamed here to avoid Solidity name-shadowing of the function).
+    function wat() external view returns (bytes32 id);
+
+    /// @notice Returns the oracle's current value.
+    /// @dev Reverts if no value set.
+    /// @return value The oracle's current value, 18 decimals.
+    function read() external view returns (uint256 value);
+
+    /// @notice Returns the oracle's current value and its age.
+    /// @dev Reverts if no value set.
+    /// @return value The oracle's current value, 18 decimals.
+    /// @return age The `block.timestamp` of the value's last poke.
+    function readWithAge() external view returns (uint256 value, uint256 age);
+
+    /// @notice Returns the oracle's current value.
+    /// @return isValid True if value exists, false otherwise.
+    /// @return value The oracle's current value if it exists, zero otherwise.
+    function tryRead() external view returns (bool isValid, uint256 value);
+
+    /// @notice Returns the oracle's current value and its age.
+    /// @return isValid True if value exists, false otherwise.
+    /// @return value The oracle's current value if it exists, zero otherwise.
+    /// @return age The value's age if value exists, zero otherwise.
+    function tryReadWithAge() external view returns (bool isValid, uint256 value, uint256 age);
+}


### PR DESCRIPTION
Hand-typed copy of Chronicle Protocol's canonical IChronicle (~40
lines, MIT-licensed) into src/interface/. Same vendor pattern as
IAggregatorV2V3 — Chronicle does not publish chronicle-std to
soldeer, and the interface is small/stable enough that vendoring
beats a git-source dep.

SYNC NOTE comment points at the upstream file so re-syncs are
mechanical. Consumed by the upcoming ChronicleVaultOracle adapter.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>