### PR TITLE
feat(oracle): ChronicleVaultOracle adapter

### DIFF
--- a/src/concrete/oracle/ChronicleVaultOracle.sol
+++ b/src/concrete/oracle/ChronicleVaultOracle.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IChronicle} from "src/interface/IChronicle.sol";
+import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
+import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
+import {IERC4626} from "@openzeppelin-contracts-5.6.1/interfaces/IERC4626.sol";
+import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {Initializable} from "@openzeppelin-contracts-5.6.1/proxy/utils/Initializable.sol";
+
+/// @dev Error raised when a zero address is provided for the Chronicle feed.
+error ZeroChronicle();
+
+/// @dev Error raised when a zero address is provided for the vault.
+error ZeroVault();
+
+/// @dev Error raised when a zero max age is provided. Zero would mean every
+/// price read is instantly stale, which is never the desired configuration.
+error ZeroMaxAge();
+
+/// @dev Error raised when the Chronicle reading is older than `maxAge` seconds.
+/// @param age The `block.timestamp` of the stale Chronicle poke.
+error ChroniclePriceStale(uint256 age);
+
+/// @dev Error raised when the vault has zero total supply (no shares minted).
+/// Pricing one share of a zero-supply vault is undefined.
+error ZeroVaultSupply();
+
+/// @dev Error raised when the computed vault share price is zero. A zero
+/// price is never a valid Chainlink-compatible answer.
+error ZeroVaultSharePrice();
+
+/// @dev Error raised when the vault share price overflows int256.
+/// @param price8 The unsigned 8-decimal share price that wouldn't fit.
+error VaultSharePriceOverflow(uint256 price8);
+
+/// @dev Error raised when a caller requests historical round data. Chronicle
+/// exposes only the latest poke, so there is no per-round history here.
+/// Callers needing historical data should query an indexer or Chronicle's
+/// off-chain feed history directly.
+/// @param roundId The unsupported round id that was requested.
+error HistoricalRoundDataUnsupported(uint80 roundId);
+
+/// @title ChronicleVaultOracleConfig
+/// @notice Configuration for `ChronicleVaultOracle.initialize`.
+/// @param chronicle The Chronicle Protocol oracle (`IChronicle`) for the
+/// underlying asset price.
+/// @param vault The ERC-4626 vault address whose shares we're pricing.
+/// `vault.totalAssets() / vault.totalSupply()` is the share-to-asset ratio
+/// applied on top of the Chronicle price. For a wtStock-style wrapper this
+/// captures the post-corporate-action NAV bump.
+/// @param maxAge Maximum acceptable Chronicle reading age in seconds.
+/// `block.timestamp - age > maxAge` reverts `ChroniclePriceStale`. Immutable
+/// after init — redeploy a fresh proxy to change.
+struct ChronicleVaultOracleConfig {
+    IChronicle chronicle;
+    address vault;
+    uint256 maxAge;
+}
+
+/// @title ChronicleVaultOracle
+/// @notice Prices ERC-4626 vault shares by reading the underlying asset price
+/// from a Chronicle Protocol feed and multiplying by the vault's
+/// assets-per-share ratio. Exposes prices via Chainlink's
+/// `AggregatorV2V3Interface` so consumers (Euler, Aave-style lending protocols)
+/// can target the same surface they already use for Chainlink feeds.
+///
+/// Math: `vaultSharePrice = chroniclePrice * totalAssets / totalSupply`
+/// scaled to 8 decimals. Performed in Rain float space throughout so neither
+/// operand can overflow uint256 — the conversion to fixed-point 8dp happens
+/// only at the final return.
+///
+/// Deliberately stateless beyond config. No admin, no pause flag. Operational
+/// concerns (manual emergency pause, corporate-action-aware auto-pause) live
+/// in `PausableOracleWrapper` so the same wrapper can decorate any
+/// `AggregatorV2V3Interface` source without coupling pause logic to one
+/// oracle provider.
+///
+/// Deployed as a beacon-proxy clone via `ICloneableV2.initialize`.
+contract ChronicleVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable {
+    /// @dev The Chronicle Protocol feed for the underlying asset.
+    IChronicle public chronicle;
+
+    /// @dev The ERC-4626 vault this oracle prices shares for.
+    address public vault;
+
+    /// @dev Maximum acceptable Chronicle reading age in seconds.
+    uint256 public maxAge;
+
+    /// @notice Emitted when the oracle is initialized. Single source of
+    /// truth for off-chain indexers — all immutable config in one event.
+    /// @param sender The caller that initialized the proxy.
+    /// @param config The initialization configuration.
+    event ChronicleVaultOracleInitialized(address indexed sender, ChronicleVaultOracleConfig config);
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Documents the typed signature of the initialize function. Per
+    /// `ICloneableV2` this overload MUST always revert; callers use the
+    /// `bytes calldata` overload below.
+    /// @dev Always reverts with `InitializeSignatureFn`.
+    /// @param config The initialization configuration. Ignored.
+    /// @return Never returns; included only for the function signature.
+    function initialize(ChronicleVaultOracleConfig memory config) external pure returns (bytes32) {
+        (config);
+        revert InitializeSignatureFn();
+    }
+
+    /// @inheritdoc ICloneableV2
+    function initialize(bytes calldata data) external initializer returns (bytes32) {
+        ChronicleVaultOracleConfig memory config = abi.decode(data, (ChronicleVaultOracleConfig));
+
+        if (address(config.chronicle) == address(0)) revert ZeroChronicle();
+        if (config.vault == address(0)) revert ZeroVault();
+        if (config.maxAge == 0) revert ZeroMaxAge();
+
+        chronicle = config.chronicle;
+        vault = config.vault;
+        maxAge = config.maxAge;
+
+        emit ChronicleVaultOracleInitialized(msg.sender, config);
+
+        return ICLONEABLE_V2_SUCCESS;
+    }
+
+    /// @inheritdoc AggregatorV2V3Interface
+    function description() external pure override returns (string memory) {
+        return "";
+    }
+
+    /// @inheritdoc AggregatorV2V3Interface
+    function decimals() external pure override returns (uint8) {
+        return 8;
+    }
+
+    /// @inheritdoc AggregatorV2V3Interface
+    function version() external pure override returns (uint256) {
+        return 1;
+    }
+
+    /// @inheritdoc AggregatorV2V3Interface
+    function latestAnswer() external view override returns (int256) {
+        (uint256 chroniclePrice,) = _readChronicleChecked();
+        return _vaultSharePrice(chroniclePrice);
+    }
+
+    /// @inheritdoc AggregatorV2V3Interface
+    /// @dev `roundId` and `answeredInRound` are derived from the Chronicle
+    /// `age` (truncated to `uint80`) so they advance monotonically per
+    /// Chainlink convention without adding storage. Integrators that diff
+    /// `roundId` between calls to detect a fresh update will see a different
+    /// value whenever Chronicle has produced a new poke. The `uint80` window
+    /// covers every plausible deployment lifetime.
+    function latestRoundData()
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        (uint256 chroniclePrice, uint256 age) = _readChronicleChecked();
+        int256 scaledPrice = _vaultSharePrice(chroniclePrice);
+
+        uint80 ageRound = uint80(age);
+        return (ageRound, scaledPrice, age, age, ageRound);
+    }
+
+    /// @inheritdoc AggregatorV2V3Interface
+    /// @dev Chronicle exposes only its latest value — no per-round history
+    /// through this interface. Every call reverts with
+    /// `HistoricalRoundDataUnsupported(_roundId)`. Callers needing
+    /// point-in-time data should query Chronicle's off-chain feed history
+    /// or an indexer of Chronicle pokes directly.
+    function getRoundData(uint80 _roundId) external pure override returns (uint80, int256, uint256, uint256, uint80) {
+        revert HistoricalRoundDataUnsupported(_roundId);
+    }
+
+    /// @dev Read Chronicle and revert if the reading is stale. We use
+    /// `readWithAge` (which reverts on no value) rather than `tryReadWithAge`
+    /// (which returns isValid=false) — a missing Chronicle value is always
+    /// an oracle failure that must surface, not be silently masked.
+    function _readChronicleChecked() internal view returns (uint256 value, uint256 age) {
+        // slither-disable-next-line chronicle-unchecked-price
+        (value, age) = chronicle.readWithAge();
+        // slither-disable-next-line timestamp
+        if (block.timestamp - age > maxAge) revert ChroniclePriceStale(age);
+    }
+
+    /// @dev Compute vault share price from a Chronicle reading via Rain float
+    /// math so neither operand can overflow uint256. Chronicle prices are
+    /// 18-decimal `uint256` (Chronicle convention). The vault ratio is
+    /// `totalAssets / totalSupply`. Output is 8-decimal `int256` per Chainlink
+    /// `latestAnswer` convention.
+    function _vaultSharePrice(uint256 chroniclePrice) internal view returns (int256) {
+        // Chronicle's value is 18-decimal uint256 — pack as a float with
+        // exponent -18 to recover the natural quantity.
+        Float priceFloat = LibDecimalFloat.fromFixedDecimalLosslessPacked(chroniclePrice, 18);
+
+        IERC4626 vaultContract = IERC4626(vault);
+        uint256 totalAssets = vaultContract.totalAssets();
+        uint256 totalSupply = vaultContract.totalSupply();
+
+        if (totalSupply == 0) revert ZeroVaultSupply();
+
+        Float assetsFloat = LibDecimalFloat.fromFixedDecimalLosslessPacked(totalAssets, 0);
+        Float supplyFloat = LibDecimalFloat.fromFixedDecimalLosslessPacked(totalSupply, 0);
+        Float vaultSharePriceFloat = LibDecimalFloat.div(LibDecimalFloat.mul(priceFloat, assetsFloat), supplyFloat);
+
+        // The second return (bool lossy) is intentionally ignored — lossy
+        // conversion is expected and acceptable when scaling to 8 decimals.
+        // slither-disable-next-line unused-return
+        (uint256 price8,) = LibDecimalFloat.toFixedDecimalLossy(vaultSharePriceFloat, 8);
+
+        if (price8 == 0) revert ZeroVaultSharePrice();
+        if (price8 > uint256(type(int256).max)) revert VaultSharePriceOverflow(price8);
+
+        return int256(price8);
+    }
+}

--- a/test/mocks/MockChronicle.sol
+++ b/test/mocks/MockChronicle.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IChronicle} from "src/interface/IChronicle.sol";
+
+/// @title MockChronicle
+/// @notice Minimal mock of `IChronicle` for unit-testing oracle consumers.
+/// Tests script the `(value, age)` returned by `readWithAge`/`read` via the
+/// setters. Methods not consumed by `ChronicleVaultOracle` revert so a
+/// regression that reaches into the rest of the interface surfaces loudly.
+contract MockChronicle is IChronicle {
+    uint256 private _value;
+    uint256 private _age;
+
+    function setReadWithAge(uint256 value_, uint256 age_) external {
+        _value = value_;
+        _age = age_;
+    }
+
+    function setRead(uint256 value_) external {
+        _value = value_;
+    }
+
+    function read() external view override returns (uint256) {
+        return _value;
+    }
+
+    function readWithAge() external view override returns (uint256, uint256) {
+        return (_value, _age);
+    }
+
+    function wat() external pure override returns (bytes32) {
+        revert("mock: not implemented");
+    }
+
+    function tryRead() external pure override returns (bool, uint256) {
+        revert("mock: not implemented");
+    }
+
+    function tryReadWithAge() external pure override returns (bool, uint256, uint256) {
+        revert("mock: not implemented");
+    }
+}

--- a/test/mocks/MockERC4626.sol
+++ b/test/mocks/MockERC4626.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @title MockERC4626
+/// @notice Minimal mock that only exposes `totalAssets()` and `totalSupply()`,
+/// which are the only ERC-4626 surface points `ChronicleVaultOracle` actually
+/// consumes. Tests set them via the setters. The rest of the IERC4626 / IERC20
+/// surface is intentionally absent — if a consumer regresses into needing
+/// e.g. `convertToAssets`, the call will revert and surface the new dependency.
+contract MockERC4626 {
+    uint256 private _totalAssets;
+    uint256 private _totalSupply;
+
+    function setTotalAssets(uint256 v) external {
+        _totalAssets = v;
+    }
+
+    function setTotalSupply(uint256 v) external {
+        _totalSupply = v;
+    }
+
+    function totalAssets() external view returns (uint256) {
+        return _totalAssets;
+    }
+
+    function totalSupply() external view returns (uint256) {
+        return _totalSupply;
+    }
+}

--- a/test/src/concrete/oracle/ChronicleVaultOracle.t.sol
+++ b/test/src/concrete/oracle/ChronicleVaultOracle.t.sol
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin-contracts-5.6.1/proxy/ERC1967/ERC1967Proxy.sol";
+
+/// @dev OZ v5's `ERC1967Proxy` reverts in its constructor when `_data` is
+/// empty. Override `_unsafeAllowUninitialized` so the test harness can stand
+/// the proxy up first and call `initialize(bytes)` explicitly — that lets
+/// every init test go through the same path (`proxy.initialize(...)`) and
+/// keeps return-value assertions on the success hash straightforward.
+contract TestERC1967Proxy is ERC1967Proxy {
+    constructor(address impl) ERC1967Proxy(impl, "") {}
+
+    function _unsafeAllowUninitialized() internal pure override returns (bool) {
+        return true;
+    }
+}
+import {Initializable} from "@openzeppelin-contracts-5.6.1/proxy/utils/Initializable.sol";
+import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {IChronicle} from "src/interface/IChronicle.sol";
+import {
+    ChronicleVaultOracle,
+    ChronicleVaultOracleConfig,
+    ZeroChronicle,
+    ZeroVault,
+    ZeroMaxAge,
+    ChroniclePriceStale,
+    ZeroVaultSupply,
+    ZeroVaultSharePrice,
+    HistoricalRoundDataUnsupported
+} from "src/concrete/oracle/ChronicleVaultOracle.sol";
+import {MockChronicle} from "test/mocks/MockChronicle.sol";
+import {MockERC4626} from "test/mocks/MockERC4626.sol";
+
+contract ChronicleVaultOracleTest is Test {
+    ChronicleVaultOracle internal implementation;
+    MockChronicle internal chronicle;
+    MockERC4626 internal vault;
+    uint256 internal constant MAX_AGE = 1 hours;
+
+    event ChronicleVaultOracleInitialized(address indexed sender, ChronicleVaultOracleConfig config);
+
+    function setUp() public {
+        implementation = new ChronicleVaultOracle();
+        chronicle = new MockChronicle();
+        vault = new MockERC4626();
+        // Warp far enough in that `block.timestamp - age` doesn't underflow.
+        vm.warp(1_000_000);
+    }
+
+    function _deployUninit() internal returns (ChronicleVaultOracle) {
+        // Bare ERC1967 proxy is enough — beacon semantics are irrelevant for
+        // unit tests of the implementation surface.
+        TestERC1967Proxy proxy = new TestERC1967Proxy(address(implementation));
+        return ChronicleVaultOracle(address(proxy));
+    }
+
+    function _deployProxy(ChronicleVaultOracleConfig memory config) internal returns (ChronicleVaultOracle) {
+        ChronicleVaultOracle oracle = _deployUninit();
+        bytes32 ok = oracle.initialize(abi.encode(config));
+        assertEq(ok, ICLONEABLE_V2_SUCCESS);
+        return oracle;
+    }
+
+    function _defaultConfig() internal view returns (ChronicleVaultOracleConfig memory) {
+        return ChronicleVaultOracleConfig({chronicle: chronicle, vault: address(vault), maxAge: MAX_AGE});
+    }
+
+    // -------- Init validation --------
+
+    function testInitRevertsZeroChronicle() external {
+        ChronicleVaultOracle oracle = _deployUninit();
+        ChronicleVaultOracleConfig memory config =
+            ChronicleVaultOracleConfig({chronicle: IChronicle(address(0)), vault: address(vault), maxAge: MAX_AGE});
+        vm.expectRevert(ZeroChronicle.selector);
+        oracle.initialize(abi.encode(config));
+    }
+
+    function testInitRevertsZeroVault() external {
+        ChronicleVaultOracle oracle = _deployUninit();
+        ChronicleVaultOracleConfig memory config =
+            ChronicleVaultOracleConfig({chronicle: chronicle, vault: address(0), maxAge: MAX_AGE});
+        vm.expectRevert(ZeroVault.selector);
+        oracle.initialize(abi.encode(config));
+    }
+
+    function testInitRevertsZeroMaxAge() external {
+        ChronicleVaultOracle oracle = _deployUninit();
+        ChronicleVaultOracleConfig memory config =
+            ChronicleVaultOracleConfig({chronicle: chronicle, vault: address(vault), maxAge: 0});
+        vm.expectRevert(ZeroMaxAge.selector);
+        oracle.initialize(abi.encode(config));
+    }
+
+    // -------- Init success --------
+
+    function testInitSuccessSetsStorageEmitsAndReturnsSuccess() external {
+        ChronicleVaultOracle oracle = _deployUninit();
+        ChronicleVaultOracleConfig memory config = _defaultConfig();
+
+        vm.expectEmit(true, false, false, true, address(oracle));
+        emit ChronicleVaultOracleInitialized(address(this), config);
+
+        bytes32 ok = oracle.initialize(abi.encode(config));
+        assertEq(ok, ICLONEABLE_V2_SUCCESS);
+        assertEq(address(oracle.chronicle()), address(chronicle));
+        assertEq(oracle.vault(), address(vault));
+        assertEq(oracle.maxAge(), MAX_AGE);
+    }
+
+    // -------- Typed overload reverts --------
+
+    function testTypedInitializeAlwaysReverts() external {
+        // The typed overload is `pure` and MUST always revert per
+        // `ICloneableV2`. Call against the implementation directly so we
+        // don't burn an initializer slot on a real proxy.
+        ChronicleVaultOracleConfig memory config = _defaultConfig();
+        vm.expectRevert(ICloneableV2.InitializeSignatureFn.selector);
+        implementation.initialize(config);
+    }
+
+    // -------- Constants --------
+
+    function testConstants() external {
+        ChronicleVaultOracle oracle = _deployProxy(_defaultConfig());
+        assertEq(oracle.decimals(), 8);
+        assertEq(oracle.description(), "");
+        assertEq(oracle.version(), 1);
+    }
+
+    // -------- latestAnswer happy path --------
+
+    function testLatestAnswerHappyPath() external {
+        ChronicleVaultOracle oracle = _deployProxy(_defaultConfig());
+        // Chronicle: $100 at 18dp.
+        chronicle.setReadWithAge(100e18, block.timestamp);
+        // Vault: 2 assets per share.
+        vault.setTotalAssets(2e18);
+        vault.setTotalSupply(1e18);
+
+        // 100 * 2 / 1 = 200, scaled to 8dp = 200e8.
+        int256 answer = oracle.latestAnswer();
+        assertEq(answer, int256(200e8));
+    }
+
+    // -------- latestAnswer stale --------
+
+    function testLatestAnswerRevertsWhenStale() external {
+        ChronicleVaultOracle oracle = _deployProxy(_defaultConfig());
+        uint256 staleAge = block.timestamp - MAX_AGE - 1;
+        chronicle.setReadWithAge(100e18, staleAge);
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(ChroniclePriceStale.selector, staleAge));
+        oracle.latestAnswer();
+    }
+
+    function testLatestAnswerAtMaxAgeBoundaryNotStale() external {
+        // `block.timestamp - age > maxAge` reverts — equal is OK.
+        ChronicleVaultOracle oracle = _deployProxy(_defaultConfig());
+        uint256 age = block.timestamp - MAX_AGE;
+        chronicle.setReadWithAge(100e18, age);
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+
+        int256 answer = oracle.latestAnswer();
+        assertEq(answer, int256(100e8));
+    }
+
+    // -------- latestAnswer zero supply --------
+
+    function testLatestAnswerRevertsZeroSupply() external {
+        ChronicleVaultOracle oracle = _deployProxy(_defaultConfig());
+        chronicle.setReadWithAge(100e18, block.timestamp);
+        vault.setTotalAssets(2e18);
+        vault.setTotalSupply(0);
+
+        vm.expectRevert(ZeroVaultSupply.selector);
+        oracle.latestAnswer();
+    }
+
+    // -------- latestAnswer zero share price --------
+
+    function testLatestAnswerRevertsZeroSharePrice() external {
+        ChronicleVaultOracle oracle = _deployProxy(_defaultConfig());
+        // chroniclePrice = 1 (raw uint with 18dp = 1e-18 USD).
+        // totalAssets = 1, totalSupply = 1e18 → ratio = 1e-18.
+        // Final = 1e-18 * 1e-18 = 1e-36, scaled to 8dp -> 0.
+        chronicle.setReadWithAge(1, block.timestamp);
+        vault.setTotalAssets(1);
+        vault.setTotalSupply(1e18);
+
+        vm.expectRevert(ZeroVaultSharePrice.selector);
+        oracle.latestAnswer();
+    }
+
+    // -------- latestRoundData --------
+
+    function testLatestRoundData() external {
+        ChronicleVaultOracle oracle = _deployProxy(_defaultConfig());
+        uint256 age = block.timestamp - 5;
+        chronicle.setReadWithAge(100e18, age);
+        vault.setTotalAssets(2e18);
+        vault.setTotalSupply(1e18);
+
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
+            oracle.latestRoundData();
+
+        assertEq(answer, int256(200e8));
+        assertEq(uint256(roundId), age);
+        assertEq(uint256(answeredInRound), age);
+        assertEq(startedAt, age);
+        assertEq(updatedAt, age);
+    }
+
+    function testLatestRoundDataMatchesLatestAnswer() external {
+        ChronicleVaultOracle oracle = _deployProxy(_defaultConfig());
+        chronicle.setReadWithAge(123e18, block.timestamp);
+        vault.setTotalAssets(7e18);
+        vault.setTotalSupply(3e18);
+
+        int256 expected = oracle.latestAnswer();
+        (, int256 answer,,,) = oracle.latestRoundData();
+        assertEq(answer, expected);
+    }
+
+    // -------- getRoundData always reverts --------
+
+    function testGetRoundDataAlwaysReverts(uint80 roundId) external {
+        ChronicleVaultOracle oracle = _deployProxy(_defaultConfig());
+        vm.expectRevert(abi.encodeWithSelector(HistoricalRoundDataUnsupported.selector, roundId));
+        oracle.getRoundData(roundId);
+    }
+
+    function testGetRoundDataRevertsForZero() external {
+        ChronicleVaultOracle oracle = _deployProxy(_defaultConfig());
+        vm.expectRevert(abi.encodeWithSelector(HistoricalRoundDataUnsupported.selector, uint80(0)));
+        oracle.getRoundData(0);
+    }
+
+    // -------- initializer modifier --------
+
+    function testCannotInitializeTwice() external {
+        ChronicleVaultOracle oracle = _deployProxy(_defaultConfig());
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        oracle.initialize(abi.encode(_defaultConfig()));
+    }
+
+    function testImplementationCannotBeInitialized() external {
+        // Constructor calls `_disableInitializers()` — direct calls to the
+        // implementation must revert.
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        implementation.initialize(abi.encode(_defaultConfig()));
+    }
+}


### PR DESCRIPTION
Prices ERC-4626 vault shares by reading the underlying asset price
from a Chronicle Protocol feed and multiplying by the vault's
totalAssets/totalSupply ratio. Implements AggregatorV2V3Interface
so consumers (Everst, Euler, Aave-style protocols) target the same
Chainlink-compatible surface they already use.

Deliberately stateless beyond config — no admin, no pause. Operational
concerns (manual emergency pause, corporate-action-aware auto-pause)
live in PausableOracleWrapper in the next PR, so the same wrapper can
decorate any AggregatorV2V3Interface source without coupling pause
logic to one oracle provider.

Math in Rain float space throughout to avoid uint256 overflow. 8dp
output per Chainlink convention. Staleness gated by immutable maxAge
against Chronicle's readWithAge() age.

Beacon-proxy-clone via ICloneableV2.initialize(bytes) — same pattern
as the old Pyth adapter. 17 unit tests covering init validation,
constants, latestAnswer happy path + stale/zero-supply/zero-price
reverts, latestRoundData fields, getRoundData unsupported,
double-init guard.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>