### PR TITLE
feat(wrapper): PausableOracleWrapper for any AggregatorV2V3 source

### DIFF
--- a/src/concrete/wrapper/PausableOracleWrapper.sol
+++ b/src/concrete/wrapper/PausableOracleWrapper.sol
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
+import {LibCorporateActionsPause} from "src/lib/LibCorporateActionsPause.sol";
+import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {Initializable} from "@openzeppelin-contracts-5.6.1/proxy/utils/Initializable.sol";
+
+/// @dev Error raised when the manual admin pause is active.
+error OraclePausedManual();
+
+/// @dev Error raised when an automatic corporate-action pause is active.
+/// @param effectiveTime The `effectiveTime` of the action whose window is
+/// currently open. When both a pending and a completed action's window
+/// overlap `now`, the pending action's `effectiveTime` is reported —
+/// integrators see the next event coming, not the last one done.
+error OraclePausedCorporateAction(uint64 effectiveTime);
+
+/// @dev Error raised when a zero address is provided for the upstream oracle.
+error ZeroUpstream();
+
+/// @dev Error raised when the caller is not the admin.
+error OnlyAdmin();
+
+/// @dev Error raised when a zero address is provided for the admin. A zero
+/// admin would permanently lock governance: `setPaused` becomes uncallable
+/// and the wrapper cannot be unpaused. Better to fail loud at init than to
+/// silently mint a broken oracle.
+error ZeroAdmin();
+
+/// @title CorporateActionPauseConfig
+/// @notice Configuration for the corporate-action-aware auto-pause feature.
+/// All fields are immutable after initialize.
+/// @param corporateActionsVault Address implementing `ICorporateActionsV1`.
+/// May be the same as the priced vault if it implements the interface, or a
+/// separate address (e.g. the underlying rebasing token under a wtStock
+/// wrapper). Zero address disables auto-pause entirely.
+/// @param actionTypeMask Bitmap of action types that trigger an auto-pause.
+/// `ACTION_TYPE_STOCK_SPLIT_V1` (`1 << 1`) for splits only, or
+/// `type(uint256).max` to catch every present and future action type.
+/// @param pauseTimeBefore Seconds before a pending action's `effectiveTime`
+/// to start pausing.
+/// @param pauseTimeAfter Seconds after a completed action's `effectiveTime`
+/// to keep pausing.
+struct CorporateActionPauseConfig {
+    address corporateActionsVault;
+    uint256 actionTypeMask;
+    uint64 pauseTimeBefore;
+    uint64 pauseTimeAfter;
+}
+
+/// @title PausableOracleWrapperConfig
+/// @notice Configuration for `PausableOracleWrapper.initialize`.
+/// @param admin The governance address with rights to toggle the manual pause
+/// and transfer admin. Cannot be zero.
+/// @param upstream The wrapped oracle. Any `AggregatorV2V3Interface` works —
+/// `ChronicleVaultOracle`, a raw Chainlink feed, another adapter. Immutable
+/// after init: redeploy and migrate consumers to swap.
+/// @param pauseConfig Corporate-action auto-pause config. All-zero disables
+/// auto-pause for the life of the proxy.
+struct PausableOracleWrapperConfig {
+    address admin;
+    AggregatorV2V3Interface upstream;
+    CorporateActionPauseConfig pauseConfig;
+}
+
+/// @title PausableOracleWrapper
+/// @notice A pure-decorator wrapper that adds operational pause semantics on
+/// top of any `AggregatorV2V3Interface` oracle. Decimals, description, and
+/// version are delegated transparently to the upstream so the wrapper is
+/// shape-preserving — consumers can drop it in wherever they'd otherwise
+/// drop the upstream and get pause-awareness for free.
+///
+/// Pause behaviour is layered:
+///
+/// 1. **Manual** — admin can `setPaused(true)` for emergencies. Persists
+///    until `setPaused(false)`. Reverts with `OraclePausedManual()`.
+/// 2. **Auto, corporate-action-aware** — driven by `ICorporateActionsV1` on
+///    a configured vault. Reverts with `OraclePausedCorporateAction(t)`
+///    whenever the current block is inside the configured pre- or post-window
+///    of a matching scheduled or completed action. See
+///    `LibCorporateActionsPause` for the exact semantics.
+///
+/// The two are independent and OR'd: either condition pauses the oracle.
+/// Distinct error selectors let integrators disambiguate via static-call
+/// introspection. Auto-pause configuration is set once at initialize and is
+/// immutable thereafter; manual pause stays as the operational escape hatch.
+///
+/// Deployed as a beacon-proxy clone via `ICloneableV2.initialize`.
+contract PausableOracleWrapper is AggregatorV2V3Interface, ICloneableV2, Initializable {
+    /// @dev Governance address.
+    address public admin;
+
+    /// @dev Manual emergency pause flag. Independent of corporate-action
+    /// auto-pause — either condition causes price reads to revert.
+    bool public paused;
+
+    /// @dev The wrapped oracle. Immutable after init.
+    AggregatorV2V3Interface public upstream;
+
+    /// @dev Address implementing `ICorporateActionsV1` consulted on every
+    /// price read for auto-pause. Zero address disables auto-pause.
+    /// Immutable after init.
+    address public corporateActionsVault;
+    /// @dev Bitmap of action types that trigger an auto-pause. Immutable.
+    uint256 public actionTypeMask;
+    /// @dev Seconds before a pending action's `effectiveTime` to start
+    /// pausing. Immutable.
+    uint64 public pauseTimeBefore;
+    /// @dev Seconds after a completed action's `effectiveTime` to keep
+    /// pausing. Immutable.
+    uint64 public pauseTimeAfter;
+
+    /// @notice Emitted when the manual pause state changes.
+    /// @param isPaused The new pause state.
+    event PauseSet(bool isPaused);
+
+    /// @notice Emitted when the admin is changed.
+    /// @param oldAdmin The previous admin address.
+    /// @param newAdmin The new admin address.
+    event AdminSet(address indexed oldAdmin, address indexed newAdmin);
+
+    /// @notice Emitted exactly once on initialize. Single source of truth for
+    /// off-chain indexers — all immutable config in one event.
+    /// @param sender The caller that initialized the proxy.
+    /// @param config The initialization configuration.
+    event PausableOracleWrapperInitialized(address indexed sender, PausableOracleWrapperConfig config);
+
+    modifier onlyAdmin() {
+        if (msg.sender != admin) revert OnlyAdmin();
+        _;
+    }
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Documents the typed signature of the initialize function. Per
+    /// `ICloneableV2` this overload MUST always revert; callers use the
+    /// `bytes calldata` overload below.
+    /// @dev Always reverts with `InitializeSignatureFn`.
+    /// @param config The initialization configuration. Ignored.
+    /// @return Never returns; included only for the function signature.
+    function initialize(PausableOracleWrapperConfig memory config) external pure returns (bytes32) {
+        (config);
+        revert InitializeSignatureFn();
+    }
+
+    /// @inheritdoc ICloneableV2
+    function initialize(bytes calldata data) external initializer returns (bytes32) {
+        PausableOracleWrapperConfig memory config = abi.decode(data, (PausableOracleWrapperConfig));
+
+        if (config.admin == address(0)) revert ZeroAdmin();
+        if (address(config.upstream) == address(0)) revert ZeroUpstream();
+
+        admin = config.admin;
+        upstream = config.upstream;
+        corporateActionsVault = config.pauseConfig.corporateActionsVault;
+        actionTypeMask = config.pauseConfig.actionTypeMask;
+        pauseTimeBefore = config.pauseConfig.pauseTimeBefore;
+        pauseTimeAfter = config.pauseConfig.pauseTimeAfter;
+
+        emit PausableOracleWrapperInitialized(msg.sender, config);
+
+        return ICLONEABLE_V2_SUCCESS;
+    }
+
+    /// @inheritdoc AggregatorV2V3Interface
+    /// @dev Delegated to upstream — wrapping is shape-preserving.
+    function decimals() external view override returns (uint8) {
+        return upstream.decimals();
+    }
+
+    /// @inheritdoc AggregatorV2V3Interface
+    /// @dev Delegated to upstream — wrapping is shape-preserving.
+    function description() external view override returns (string memory) {
+        return upstream.description();
+    }
+
+    /// @inheritdoc AggregatorV2V3Interface
+    /// @dev Delegated to upstream — wrapping is shape-preserving.
+    function version() external view override returns (uint256) {
+        return upstream.version();
+    }
+
+    /// @inheritdoc AggregatorV2V3Interface
+    function latestAnswer() external view override returns (int256) {
+        _validateNotPaused();
+        return upstream.latestAnswer();
+    }
+
+    /// @inheritdoc AggregatorV2V3Interface
+    function latestRoundData()
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        _validateNotPaused();
+        // slither-disable-next-line unused-return
+        return upstream.latestRoundData();
+    }
+
+    /// @inheritdoc AggregatorV2V3Interface
+    /// @dev Pause-gated as well — historical data must not leak during a
+    /// corporate-action window. Upstream may further reject the call (e.g.
+    /// `ChronicleVaultOracle` always reverts `HistoricalRoundDataUnsupported`).
+    function getRoundData(uint80 _roundId)
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        _validateNotPaused();
+        // slither-disable-next-line unused-return
+        return upstream.getRoundData(_roundId);
+    }
+
+    /// @notice Pause or unpause the wrapper's manual flag. Admin only.
+    /// @dev Independent of the corporate-action auto-pause; either condition
+    /// causes price reads to revert.
+    /// @param isPaused True to pause, false to unpause.
+    function setPaused(bool isPaused) external onlyAdmin {
+        paused = isPaused;
+        emit PauseSet(isPaused);
+    }
+
+    /// @notice Update the admin address. Admin only.
+    /// @dev One-step transfer — the new admin takes effect immediately. A
+    /// wrong `newAdmin` will lock the wrapper's governance permanently:
+    /// `setPaused` becomes uncallable. The only recovery is to redeploy the
+    /// wrapper and migrate consumers. Use a multisig that cannot be
+    /// misaddressed.
+    /// @param newAdmin The new admin address. Cannot be zero.
+    function setAdmin(address newAdmin) external onlyAdmin {
+        if (newAdmin == address(0)) revert ZeroAdmin();
+        emit AdminSet(admin, newAdmin);
+        admin = newAdmin;
+    }
+
+    /// @dev Reverts if either pause condition is currently active. Manual
+    /// pause is checked first because it is cheaper (single SLOAD) — when an
+    /// admin has explicitly set the manual flag we want that error returned,
+    /// not the corporate-action one.
+    function _validateNotPaused() internal view {
+        if (paused) revert OraclePausedManual();
+        (bool autoPaused, uint64 effectiveTime) = LibCorporateActionsPause.inPauseWindow(
+            corporateActionsVault, actionTypeMask, pauseTimeBefore, pauseTimeAfter
+        );
+        if (autoPaused) revert OraclePausedCorporateAction(effectiveTime);
+    }
+}

--- a/test/mocks/MockAggregatorV2V3.sol
+++ b/test/mocks/MockAggregatorV2V3.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
+
+/// @title MockAggregatorV2V3
+/// @notice Scriptable mock of `AggregatorV2V3Interface` for unit-testing
+/// adapters that wrap an upstream aggregator. Each read method returns the
+/// value previously set via the matching setter. `getRoundData` reverts by
+/// default — flip `setGetRoundDataReverts(false)` to make it return the same
+/// scripted 5-tuple as `latestRoundData`. The default-revert behaviour lets
+/// pause-gated tests verify the wrapper short-circuits BEFORE delegating
+/// (a paused wrapper that still hit the upstream would surface a different
+/// error than `OraclePaused*`).
+contract MockAggregatorV2V3 is AggregatorV2V3Interface {
+    uint8 private _decimals;
+    string private _description;
+    uint256 private _version;
+    int256 private _latestAnswer;
+    uint80 private _roundId;
+    int256 private _answer;
+    uint256 private _startedAt;
+    uint256 private _updatedAt;
+    uint80 private _answeredInRound;
+    bool private _getRoundDataReverts = true;
+
+    function setDecimals(uint8 d) external {
+        _decimals = d;
+    }
+
+    function setDescription(string calldata s) external {
+        _description = s;
+    }
+
+    function setVersion(uint256 v) external {
+        _version = v;
+    }
+
+    function setLatestAnswer(int256 a) external {
+        _latestAnswer = a;
+    }
+
+    function setLatestRoundData(
+        uint80 roundId_,
+        int256 answer_,
+        uint256 startedAt_,
+        uint256 updatedAt_,
+        uint80 answeredInRound_
+    ) external {
+        _roundId = roundId_;
+        _answer = answer_;
+        _startedAt = startedAt_;
+        _updatedAt = updatedAt_;
+        _answeredInRound = answeredInRound_;
+    }
+
+    function setGetRoundDataReverts(bool reverts) external {
+        _getRoundDataReverts = reverts;
+    }
+
+    function decimals() external view override returns (uint8) {
+        return _decimals;
+    }
+
+    function description() external view override returns (string memory) {
+        return _description;
+    }
+
+    function version() external view override returns (uint256) {
+        return _version;
+    }
+
+    function latestAnswer() external view override returns (int256) {
+        return _latestAnswer;
+    }
+
+    function latestRoundData() external view override returns (uint80, int256, uint256, uint256, uint80) {
+        return (_roundId, _answer, _startedAt, _updatedAt, _answeredInRound);
+    }
+
+    function getRoundData(uint80) external view override returns (uint80, int256, uint256, uint256, uint80) {
+        if (_getRoundDataReverts) revert("mock: getRoundData reverts");
+        return (_roundId, _answer, _startedAt, _updatedAt, _answeredInRound);
+    }
+}

--- a/test/src/concrete/wrapper/PausableOracleWrapper.t.sol
+++ b/test/src/concrete/wrapper/PausableOracleWrapper.t.sol
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin-contracts-5.6.1/proxy/ERC1967/ERC1967Proxy.sol";
+import {Initializable} from "@openzeppelin-contracts-5.6.1/proxy/utils/Initializable.sol";
+import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
+import {
+    PausableOracleWrapper,
+    PausableOracleWrapperConfig,
+    CorporateActionPauseConfig,
+    OraclePausedManual,
+    OraclePausedCorporateAction,
+    ZeroUpstream,
+    ZeroAdmin,
+    OnlyAdmin
+} from "src/concrete/wrapper/PausableOracleWrapper.sol";
+import {MockAggregatorV2V3} from "test/mocks/MockAggregatorV2V3.sol";
+import {MockCorporateActions} from "test/mocks/MockCorporateActions.sol";
+import {ACTION_TYPE_STOCK_SPLIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
+
+/// @dev OZ v5's `ERC1967Proxy` reverts in its constructor when `_data` is
+/// empty. Override `_unsafeAllowUninitialized` so the test harness can stand
+/// the proxy up first and call `initialize(bytes)` explicitly — that lets
+/// every init test go through the same path (`proxy.initialize(...)`) and
+/// keeps return-value assertions on the success hash straightforward.
+contract TestERC1967Proxy is ERC1967Proxy {
+    constructor(address impl) ERC1967Proxy(impl, "") {}
+
+    function _unsafeAllowUninitialized() internal pure override returns (bool) {
+        return true;
+    }
+}
+
+contract PausableOracleWrapperTest is Test {
+    PausableOracleWrapper internal implementation;
+    MockAggregatorV2V3 internal upstream;
+    MockCorporateActions internal actions;
+
+    address internal constant ADMIN = address(0xA11CE);
+    address internal constant NON_ADMIN = address(0xB0B);
+
+    uint64 internal constant PAUSE_BEFORE = 3600;
+    uint64 internal constant PAUSE_AFTER = 3600;
+
+    event PauseSet(bool isPaused);
+    event AdminSet(address indexed oldAdmin, address indexed newAdmin);
+    event PausableOracleWrapperInitialized(address indexed sender, PausableOracleWrapperConfig config);
+
+    function setUp() public {
+        implementation = new PausableOracleWrapper();
+        upstream = new MockAggregatorV2V3();
+        actions = new MockCorporateActions();
+        // Warp far enough in that `block.timestamp - window` can't underflow.
+        vm.warp(1_000_000);
+    }
+
+    function _deployUninit() internal returns (PausableOracleWrapper) {
+        // Bare ERC1967 proxy is enough — beacon semantics are irrelevant for
+        // unit tests of the implementation surface.
+        TestERC1967Proxy proxy = new TestERC1967Proxy(address(implementation));
+        return PausableOracleWrapper(address(proxy));
+    }
+
+    function _deployProxy(PausableOracleWrapperConfig memory config) internal returns (PausableOracleWrapper) {
+        PausableOracleWrapper wrapper = _deployUninit();
+        bytes32 ok = wrapper.initialize(abi.encode(config));
+        assertEq(ok, ICLONEABLE_V2_SUCCESS);
+        return wrapper;
+    }
+
+    function _disabledPauseConfig() internal pure returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+        });
+    }
+
+    function _enabledPauseConfig() internal view returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: address(actions),
+            actionTypeMask: ACTION_TYPE_STOCK_SPLIT_V1,
+            pauseTimeBefore: PAUSE_BEFORE,
+            pauseTimeAfter: PAUSE_AFTER
+        });
+    }
+
+    function _defaultConfig() internal view returns (PausableOracleWrapperConfig memory) {
+        return PausableOracleWrapperConfig({
+            admin: ADMIN, upstream: AggregatorV2V3Interface(address(upstream)), pauseConfig: _disabledPauseConfig()
+        });
+    }
+
+    function _enabledConfig() internal view returns (PausableOracleWrapperConfig memory) {
+        return PausableOracleWrapperConfig({
+            admin: ADMIN, upstream: AggregatorV2V3Interface(address(upstream)), pauseConfig: _enabledPauseConfig()
+        });
+    }
+
+    // -------- Init validation --------
+
+    function testInitRevertsZeroAdmin() external {
+        PausableOracleWrapper wrapper = _deployUninit();
+        PausableOracleWrapperConfig memory config = _defaultConfig();
+        config.admin = address(0);
+        vm.expectRevert(ZeroAdmin.selector);
+        wrapper.initialize(abi.encode(config));
+    }
+
+    function testInitRevertsZeroUpstream() external {
+        PausableOracleWrapper wrapper = _deployUninit();
+        PausableOracleWrapperConfig memory config = _defaultConfig();
+        config.upstream = AggregatorV2V3Interface(address(0));
+        vm.expectRevert(ZeroUpstream.selector);
+        wrapper.initialize(abi.encode(config));
+    }
+
+    // -------- Init success --------
+
+    function testInitSuccessSetsStorageEmitsAndReturnsSuccess() external {
+        PausableOracleWrapper wrapper = _deployUninit();
+        PausableOracleWrapperConfig memory config = _enabledConfig();
+
+        vm.expectEmit(true, false, false, true, address(wrapper));
+        emit PausableOracleWrapperInitialized(address(this), config);
+
+        bytes32 ok = wrapper.initialize(abi.encode(config));
+        assertEq(ok, ICLONEABLE_V2_SUCCESS);
+        assertEq(wrapper.admin(), ADMIN);
+        assertEq(address(wrapper.upstream()), address(upstream));
+        assertEq(wrapper.corporateActionsVault(), address(actions));
+        assertEq(wrapper.actionTypeMask(), ACTION_TYPE_STOCK_SPLIT_V1);
+        assertEq(wrapper.pauseTimeBefore(), PAUSE_BEFORE);
+        assertEq(wrapper.pauseTimeAfter(), PAUSE_AFTER);
+        assertEq(wrapper.paused(), false);
+    }
+
+    function testInitAllZeroPauseConfigStoresCleanly() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        assertEq(wrapper.corporateActionsVault(), address(0));
+        assertEq(wrapper.actionTypeMask(), 0);
+        assertEq(wrapper.pauseTimeBefore(), 0);
+        assertEq(wrapper.pauseTimeAfter(), 0);
+    }
+
+    // -------- Typed overload reverts --------
+
+    function testTypedInitializeAlwaysReverts() external {
+        // The typed overload is `pure` and MUST always revert per
+        // `ICloneableV2`. Call against the implementation directly so we
+        // don't burn an initializer slot on a real proxy.
+        PausableOracleWrapperConfig memory config = _defaultConfig();
+        vm.expectRevert(ICloneableV2.InitializeSignatureFn.selector);
+        implementation.initialize(config);
+    }
+
+    // -------- initializer modifier --------
+
+    function testCannotInitializeTwice() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        wrapper.initialize(abi.encode(_defaultConfig()));
+    }
+
+    function testImplementationCannotBeInitialized() external {
+        // Constructor calls `_disableInitializers()` — direct calls to the
+        // implementation must revert.
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        implementation.initialize(abi.encode(_defaultConfig()));
+    }
+
+    // -------- Delegation (no pause) --------
+
+    function testDecimalsDelegatesToUpstream() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        upstream.setDecimals(8);
+        assertEq(wrapper.decimals(), 8);
+        upstream.setDecimals(18);
+        assertEq(wrapper.decimals(), 18);
+    }
+
+    function testDescriptionDelegatesToUpstream() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        upstream.setDescription("AAPL / USD");
+        assertEq(wrapper.description(), "AAPL / USD");
+    }
+
+    function testVersionDelegatesToUpstream() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        upstream.setVersion(42);
+        assertEq(wrapper.version(), 42);
+    }
+
+    function testLatestAnswerDelegatesToUpstream() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        upstream.setLatestAnswer(int256(123_456));
+        assertEq(wrapper.latestAnswer(), int256(123_456));
+    }
+
+    function testLatestRoundDataDelegatesToUpstream() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        upstream.setLatestRoundData(uint80(7), int256(999), 100, 200, uint80(7));
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
+            wrapper.latestRoundData();
+        assertEq(uint256(roundId), 7);
+        assertEq(answer, int256(999));
+        assertEq(startedAt, 100);
+        assertEq(updatedAt, 200);
+        assertEq(uint256(answeredInRound), 7);
+    }
+
+    function testGetRoundDataDelegatesToUpstream() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        upstream.setLatestRoundData(uint80(11), int256(555), 300, 400, uint80(11));
+        upstream.setGetRoundDataReverts(false);
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
+            wrapper.getRoundData(uint80(11));
+        assertEq(uint256(roundId), 11);
+        assertEq(answer, int256(555));
+        assertEq(startedAt, 300);
+        assertEq(updatedAt, 400);
+        assertEq(uint256(answeredInRound), 11);
+    }
+
+    // -------- Manual pause: access control --------
+
+    function testSetPausedOnlyAdmin() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        vm.prank(NON_ADMIN);
+        vm.expectRevert(OnlyAdmin.selector);
+        wrapper.setPaused(true);
+    }
+
+    function testSetPausedAdminSucceedsEmitsAndSetsFlag() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        vm.expectEmit(false, false, false, true, address(wrapper));
+        emit PauseSet(true);
+        vm.prank(ADMIN);
+        wrapper.setPaused(true);
+        assertEq(wrapper.paused(), true);
+    }
+
+    // -------- Manual pause: gating --------
+
+    function testLatestAnswerRevertsWhenManuallyPaused() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        upstream.setLatestAnswer(int256(123));
+        vm.prank(ADMIN);
+        wrapper.setPaused(true);
+        vm.expectRevert(OraclePausedManual.selector);
+        wrapper.latestAnswer();
+    }
+
+    function testLatestRoundDataRevertsWhenManuallyPaused() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        vm.prank(ADMIN);
+        wrapper.setPaused(true);
+        vm.expectRevert(OraclePausedManual.selector);
+        wrapper.latestRoundData();
+    }
+
+    function testGetRoundDataRevertsWhenManuallyPaused() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        // Note: upstream `getRoundData` reverts by default — the wrapper's
+        // pause check MUST fire first or this test would surface the mock's
+        // revert string instead of `OraclePausedManual`.
+        vm.prank(ADMIN);
+        wrapper.setPaused(true);
+        vm.expectRevert(OraclePausedManual.selector);
+        wrapper.getRoundData(uint80(1));
+    }
+
+    function testUnpauseRestoresReads() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        upstream.setLatestAnswer(int256(777));
+        vm.prank(ADMIN);
+        wrapper.setPaused(true);
+        vm.expectRevert(OraclePausedManual.selector);
+        wrapper.latestAnswer();
+        vm.prank(ADMIN);
+        wrapper.setPaused(false);
+        assertEq(wrapper.paused(), false);
+        assertEq(wrapper.latestAnswer(), int256(777));
+    }
+
+    function testMetadataNotPauseGated() external {
+        // decimals / description / version remain readable while paused —
+        // they're config metadata, not pricing data.
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        upstream.setDecimals(8);
+        upstream.setDescription("AAPL / USD");
+        upstream.setVersion(1);
+        vm.prank(ADMIN);
+        wrapper.setPaused(true);
+        assertEq(wrapper.decimals(), 8);
+        assertEq(wrapper.description(), "AAPL / USD");
+        assertEq(wrapper.version(), 1);
+    }
+
+    // -------- Admin rotation --------
+
+    function testSetAdminOnlyAdmin() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        vm.prank(NON_ADMIN);
+        vm.expectRevert(OnlyAdmin.selector);
+        wrapper.setAdmin(NON_ADMIN);
+    }
+
+    function testSetAdminRevertsZero() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        vm.prank(ADMIN);
+        vm.expectRevert(ZeroAdmin.selector);
+        wrapper.setAdmin(address(0));
+    }
+
+    function testSetAdminEmitsAndUpdates() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        address newAdmin = address(0xC0FFEE);
+        vm.expectEmit(true, true, false, false, address(wrapper));
+        emit AdminSet(ADMIN, newAdmin);
+        vm.prank(ADMIN);
+        wrapper.setAdmin(newAdmin);
+        assertEq(wrapper.admin(), newAdmin);
+    }
+
+    function testOldAdminCannotPauseAfterRotation() external {
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        address newAdmin = address(0xC0FFEE);
+        vm.prank(ADMIN);
+        wrapper.setAdmin(newAdmin);
+        vm.prank(ADMIN);
+        vm.expectRevert(OnlyAdmin.selector);
+        wrapper.setPaused(true);
+        // Sanity: new admin can.
+        vm.prank(newAdmin);
+        wrapper.setPaused(true);
+        assertEq(wrapper.paused(), true);
+    }
+
+    // -------- Corporate-action auto-pause --------
+
+    function testAutoPauseDisabledIgnoresMockState() external {
+        // pauseConfig is all-zero. Even if the mock has a pending action whose
+        // window would otherwise fire, the wrapper short-circuits because
+        // `corporateActionsVault == address(0)`.
+        PausableOracleWrapper wrapper = _deployProxy(_defaultConfig());
+        actions.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 60));
+        upstream.setLatestAnswer(int256(42));
+        assertEq(wrapper.latestAnswer(), int256(42));
+    }
+
+    function testAutoPausePendingInsidePreWindowReverts() external {
+        PausableOracleWrapper wrapper = _deployProxy(_enabledConfig());
+        uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
+        actions.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        upstream.setLatestAnswer(int256(42));
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
+        wrapper.latestAnswer();
+    }
+
+    function testAutoPauseCompletedInsidePostWindowReverts() external {
+        PausableOracleWrapper wrapper = _deployProxy(_enabledConfig());
+        uint64 effectiveTime = uint64(block.timestamp - PAUSE_AFTER / 2);
+        actions.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        upstream.setLatestAnswer(int256(42));
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
+        wrapper.latestAnswer();
+    }
+
+    function testAutoPauseNoMatchingActionReadsSucceed() external {
+        // Pause config enabled, but mock has no actions scripted → reads work.
+        PausableOracleWrapper wrapper = _deployProxy(_enabledConfig());
+        upstream.setLatestAnswer(int256(123));
+        assertEq(wrapper.latestAnswer(), int256(123));
+    }
+
+    function testManualPauseTakesPrecedenceOverAutoPause() external {
+        // Both conditions would fire — manual pause is checked first so its
+        // selector is what the integrator sees.
+        PausableOracleWrapper wrapper = _deployProxy(_enabledConfig());
+        uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
+        actions.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        vm.prank(ADMIN);
+        wrapper.setPaused(true);
+        vm.expectRevert(OraclePausedManual.selector);
+        wrapper.latestAnswer();
+    }
+}


### PR DESCRIPTION
Pure decorator wrapper that adds operational pause semantics on top of
any AggregatorV2V3Interface oracle. Decimals, description, and version
are delegated transparently to the upstream so the wrapper is
shape-preserving — drop it in wherever the raw upstream would go.

Pause layering:
  1. Manual emergency pause via admin setPaused(bool) → OraclePausedManual
  2. Corporate-action-aware auto-pause via LibCorporateActionsPause →
     OraclePausedCorporateAction(effectiveTime)

OR'd: either condition reverts price reads. Distinct selectors let
integrators disambiguate via static-call. Manual checked first
(single SLOAD).

Upstream is immutable after init — admin cannot rotate the priced
oracle (no rug vector). Rotation requires redeploy + consumer
re-config. Same trust model as the old per-vault PythOracleAdapter.

29 unit tests covering init validation, all-zero pause-config storage,
delegation of all six methods, manual pause gating, admin rotation
with old-admin lockout, corp-action pre/post-window auto-pause, and
manual-takes-precedence semantics. Reuses MockCorporateActions; adds
MockAggregatorV2V3.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>