### PR TITLE
feat(deploy): beacon-set + unified deployers for Chronicle stack

### DIFF
--- a/src/concrete/deploy/ChronicleOracleUnifiedDeployer.sol
+++ b/src/concrete/deploy/ChronicleOracleUnifiedDeployer.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
+import {ChronicleVaultOracle, ChronicleVaultOracleConfig} from "src/concrete/oracle/ChronicleVaultOracle.sol";
+import {
+    PausableOracleWrapper,
+    PausableOracleWrapperConfig,
+    CorporateActionPauseConfig
+} from "src/concrete/wrapper/PausableOracleWrapper.sol";
+import {ChronicleVaultOracleBeaconSetDeployer} from "src/concrete/deploy/ChronicleVaultOracleBeaconSetDeployer.sol";
+import {PausableOracleWrapperBeaconSetDeployer} from "src/concrete/deploy/PausableOracleWrapperBeaconSetDeployer.sol";
+
+/// @dev Error raised when a zero address is provided for an upstream beacon
+/// set deployer.
+error ZeroBeaconSetDeployer();
+
+/// @title ChronicleOracleUnifiedDeployerConstructorConfig
+/// @notice Wires the unified deployer to the two beacon-set deployers it
+/// composes.
+/// @param chronicleVaultOracleBeaconSetDeployer Deployer for the
+/// `ChronicleVaultOracle` proxies.
+/// @param pausableOracleWrapperBeaconSetDeployer Deployer for the
+/// `PausableOracleWrapper` proxies.
+struct ChronicleOracleUnifiedDeployerConstructorConfig {
+    ChronicleVaultOracleBeaconSetDeployer chronicleVaultOracleBeaconSetDeployer;
+    PausableOracleWrapperBeaconSetDeployer pausableOracleWrapperBeaconSetDeployer;
+}
+
+/// @title ChronicleOracleUnifiedDeployConfig
+/// @notice Per-deployment config bundle: the adapter side + the wrapper side
+/// minus the upstream (which is wired by the deployer itself).
+/// @param admin The wrapper's admin (governance for manual pause + admin
+/// rotation). Cannot be zero.
+/// @param oracleConfig The `ChronicleVaultOracle` init config (chronicle
+/// feed + vault + maxAge).
+/// @param pauseConfig The wrapper's corporate-action auto-pause config.
+struct ChronicleOracleUnifiedDeployConfig {
+    address admin;
+    ChronicleVaultOracleConfig oracleConfig;
+    CorporateActionPauseConfig pauseConfig;
+}
+
+/// @title ChronicleOracleUnifiedDeployer
+/// @notice One-shot factory that deploys a paired
+/// `(ChronicleVaultOracle, PausableOracleWrapper)` and wires the wrapper's
+/// upstream slot to the freshly-deployed adapter. The wrapper proxy is the
+/// canonical address consumers (Euler, lending markets) target — its upstream is
+/// immutable, so the adapter address never has to leak past deploy time.
+///
+/// Atomicity is the whole point: integrators don't want to coordinate a
+/// two-step deploy + wire-up, and getting the wiring wrong (e.g. wrapping
+/// the wrong adapter address) would mint a broken oracle.
+contract ChronicleOracleUnifiedDeployer {
+    /// @notice Emitted on every successful unified deployment.
+    /// @param caller The on-chain caller of `newOracleWithWrapper`.
+    /// @param oracle The new `ChronicleVaultOracle` proxy.
+    /// @param wrapper The new `PausableOracleWrapper` proxy (canonical
+    /// consumer-facing address).
+    event Deployment(address indexed caller, address indexed oracle, address indexed wrapper);
+
+    /// The beacon-set deployer for the underlying ChronicleVaultOracle proxies.
+    ChronicleVaultOracleBeaconSetDeployer public immutable I_CHRONICLE_VAULT_ORACLE_BEACON_SET_DEPLOYER;
+    /// The beacon-set deployer for the PausableOracleWrapper proxies.
+    PausableOracleWrapperBeaconSetDeployer public immutable I_PAUSABLE_ORACLE_WRAPPER_BEACON_SET_DEPLOYER;
+
+    constructor(ChronicleOracleUnifiedDeployerConstructorConfig memory config) {
+        if (address(config.chronicleVaultOracleBeaconSetDeployer) == address(0)) {
+            revert ZeroBeaconSetDeployer();
+        }
+        if (address(config.pausableOracleWrapperBeaconSetDeployer) == address(0)) {
+            revert ZeroBeaconSetDeployer();
+        }
+        I_CHRONICLE_VAULT_ORACLE_BEACON_SET_DEPLOYER = config.chronicleVaultOracleBeaconSetDeployer;
+        I_PAUSABLE_ORACLE_WRAPPER_BEACON_SET_DEPLOYER = config.pausableOracleWrapperBeaconSetDeployer;
+    }
+
+    /// @notice Deploys a ChronicleVaultOracle and a PausableOracleWrapper
+    /// wiring the latter's upstream to the former. Both are beacon proxies
+    /// off their respective beacons.
+    /// @param config The unified deploy config.
+    /// @return oracle The deployed ChronicleVaultOracle proxy.
+    /// @return wrapper The deployed PausableOracleWrapper proxy.
+    // slither-disable-next-line reentrancy-events
+    function newOracleWithWrapper(ChronicleOracleUnifiedDeployConfig memory config)
+        external
+        returns (ChronicleVaultOracle oracle, PausableOracleWrapper wrapper)
+    {
+        oracle = I_CHRONICLE_VAULT_ORACLE_BEACON_SET_DEPLOYER.newChronicleVaultOracle(config.oracleConfig);
+
+        wrapper = I_PAUSABLE_ORACLE_WRAPPER_BEACON_SET_DEPLOYER.newPausableOracleWrapper(
+            PausableOracleWrapperConfig({
+                admin: config.admin, upstream: AggregatorV2V3Interface(address(oracle)), pauseConfig: config.pauseConfig
+            })
+        );
+
+        emit Deployment(msg.sender, address(oracle), address(wrapper));
+
+        return (oracle, wrapper);
+    }
+}

--- a/src/concrete/deploy/ChronicleVaultOracleBeaconSetDeployer.sol
+++ b/src/concrete/deploy/ChronicleVaultOracleBeaconSetDeployer.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+import {UpgradeableBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/UpgradeableBeacon.sol";
+import {BeaconProxy} from "@openzeppelin-contracts-5.6.1/proxy/beacon/BeaconProxy.sol";
+import {ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {ChronicleVaultOracle, ChronicleVaultOracleConfig} from "src/concrete/oracle/ChronicleVaultOracle.sol";
+
+/// @dev Error raised when a zero address is provided for the implementation.
+error ZeroImplementation();
+
+/// @dev Error raised when a zero address is provided for the initial beacon
+/// owner. Only constrains construction-time ownership; subsequent owner
+/// rotations are the beacon's concern.
+error ZeroBeaconOwner();
+
+/// @dev Error raised when initialization of the oracle returns the wrong
+/// magic value (i.e. not `ICLONEABLE_V2_SUCCESS`). Indicates an
+/// implementation regression — should never fire in production.
+error InitializeOracleFailed();
+
+/// @title ChronicleVaultOracleBeaconSetDeployerConfig
+/// @notice Configuration for the `ChronicleVaultOracleBeaconSetDeployer`
+/// constructor.
+/// @param initialOwner The initial owner of the beacon (controls upgrades).
+/// @param initialChronicleVaultOracleImplementation The initial
+/// implementation contract behind the beacon.
+struct ChronicleVaultOracleBeaconSetDeployerConfig {
+    address initialOwner;
+    address initialChronicleVaultOracleImplementation;
+}
+
+/// @title ChronicleVaultOracleBeaconSetDeployer
+/// @notice Deploys a beacon and the `ChronicleVaultOracle` proxies that
+/// share it. Beacon management (upgrades, ownership transfer) is performed
+/// externally by the beacon owner; this contract retains no authority over
+/// the beacon after construction. Follows the canonical
+/// `st0x.deploy`-style BeaconSetDeployer pattern.
+contract ChronicleVaultOracleBeaconSetDeployer {
+    /// @notice Emitted when a new ChronicleVaultOracle proxy is deployed.
+    /// @param caller The direct on-chain caller of `newChronicleVaultOracle`.
+    /// For oracles created via `ChronicleOracleUnifiedDeployer` this is the
+    /// unified deployer contract, not the originating EOA. Indexed so
+    /// monitoring can filter by deployer.
+    /// @param oracle The address of the new proxy. Indexed for filtering.
+    event Deployment(address indexed caller, address indexed oracle);
+
+    /// The beacon for the ChronicleVaultOracle implementation contracts.
+    IBeacon public immutable I_CHRONICLE_VAULT_ORACLE_BEACON;
+
+    constructor(ChronicleVaultOracleBeaconSetDeployerConfig memory config) {
+        if (config.initialChronicleVaultOracleImplementation == address(0)) {
+            revert ZeroImplementation();
+        }
+        if (config.initialOwner == address(0)) {
+            revert ZeroBeaconOwner();
+        }
+
+        I_CHRONICLE_VAULT_ORACLE_BEACON =
+            new UpgradeableBeacon(config.initialChronicleVaultOracleImplementation, config.initialOwner);
+    }
+
+    /// @notice Deploys and initializes a new ChronicleVaultOracle proxy.
+    /// @param config The initialization configuration.
+    /// @return oracle The deployed proxy as a typed reference.
+    // slither-disable-next-line reentrancy-events
+    function newChronicleVaultOracle(ChronicleVaultOracleConfig memory config)
+        external
+        returns (ChronicleVaultOracle oracle)
+    {
+        oracle = ChronicleVaultOracle(address(new BeaconProxy(address(I_CHRONICLE_VAULT_ORACLE_BEACON), "")));
+
+        if (oracle.initialize(abi.encode(config)) != ICLONEABLE_V2_SUCCESS) {
+            revert InitializeOracleFailed();
+        }
+
+        emit Deployment(msg.sender, address(oracle));
+
+        return oracle;
+    }
+}

--- a/src/concrete/deploy/PausableOracleWrapperBeaconSetDeployer.sol
+++ b/src/concrete/deploy/PausableOracleWrapperBeaconSetDeployer.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+import {UpgradeableBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/UpgradeableBeacon.sol";
+import {BeaconProxy} from "@openzeppelin-contracts-5.6.1/proxy/beacon/BeaconProxy.sol";
+import {ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {PausableOracleWrapper, PausableOracleWrapperConfig} from "src/concrete/wrapper/PausableOracleWrapper.sol";
+
+/// @dev Error raised when a zero address is provided for the implementation.
+error ZeroImplementation();
+
+/// @dev Error raised when a zero address is provided for the initial beacon
+/// owner. Only constrains construction-time ownership; subsequent owner
+/// rotations are the beacon's concern.
+error ZeroBeaconOwner();
+
+/// @dev Error raised when initialization of the wrapper returns the wrong
+/// magic value. Indicates an implementation regression — should never fire
+/// in production.
+error InitializeWrapperFailed();
+
+/// @title PausableOracleWrapperBeaconSetDeployerConfig
+/// @notice Configuration for the `PausableOracleWrapperBeaconSetDeployer`
+/// constructor.
+/// @param initialOwner The initial owner of the beacon (controls upgrades).
+/// @param initialPausableOracleWrapperImplementation The initial
+/// implementation contract behind the beacon.
+struct PausableOracleWrapperBeaconSetDeployerConfig {
+    address initialOwner;
+    address initialPausableOracleWrapperImplementation;
+}
+
+/// @title PausableOracleWrapperBeaconSetDeployer
+/// @notice Deploys a beacon and the `PausableOracleWrapper` proxies that
+/// share it. Beacon management (upgrades, ownership transfer) is performed
+/// externally by the beacon owner; this contract retains no authority over
+/// the beacon after construction.
+contract PausableOracleWrapperBeaconSetDeployer {
+    /// @notice Emitted when a new PausableOracleWrapper proxy is deployed.
+    /// @param caller The direct on-chain caller of `newPausableOracleWrapper`.
+    /// For wrappers created via `ChronicleOracleUnifiedDeployer` this is the
+    /// unified deployer contract, not the originating EOA. Indexed.
+    /// @param wrapper The address of the new proxy. Indexed for filtering.
+    event Deployment(address indexed caller, address indexed wrapper);
+
+    /// The beacon for the PausableOracleWrapper implementation contracts.
+    IBeacon public immutable I_PAUSABLE_ORACLE_WRAPPER_BEACON;
+
+    constructor(PausableOracleWrapperBeaconSetDeployerConfig memory config) {
+        if (config.initialPausableOracleWrapperImplementation == address(0)) {
+            revert ZeroImplementation();
+        }
+        if (config.initialOwner == address(0)) {
+            revert ZeroBeaconOwner();
+        }
+
+        I_PAUSABLE_ORACLE_WRAPPER_BEACON =
+            new UpgradeableBeacon(config.initialPausableOracleWrapperImplementation, config.initialOwner);
+    }
+
+    /// @notice Deploys and initializes a new PausableOracleWrapper proxy.
+    /// @param config The initialization configuration.
+    /// @return wrapper The deployed proxy as a typed reference.
+    // slither-disable-next-line reentrancy-events
+    function newPausableOracleWrapper(PausableOracleWrapperConfig memory config)
+        external
+        returns (PausableOracleWrapper wrapper)
+    {
+        wrapper = PausableOracleWrapper(address(new BeaconProxy(address(I_PAUSABLE_ORACLE_WRAPPER_BEACON), "")));
+
+        if (wrapper.initialize(abi.encode(config)) != ICLONEABLE_V2_SUCCESS) {
+            revert InitializeWrapperFailed();
+        }
+
+        emit Deployment(msg.sender, address(wrapper));
+
+        return wrapper;
+    }
+}

--- a/test/src/concrete/deploy/ChronicleOracleUnifiedDeployer.t.sol
+++ b/test/src/concrete/deploy/ChronicleOracleUnifiedDeployer.t.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Vm} from "forge-std-1.16.1/src/Vm.sol";
+import {ChronicleVaultOracle, ChronicleVaultOracleConfig} from "src/concrete/oracle/ChronicleVaultOracle.sol";
+import {
+    PausableOracleWrapper,
+    PausableOracleWrapperConfig,
+    CorporateActionPauseConfig
+} from "src/concrete/wrapper/PausableOracleWrapper.sol";
+import {
+    ChronicleVaultOracleBeaconSetDeployer,
+    ChronicleVaultOracleBeaconSetDeployerConfig
+} from "src/concrete/deploy/ChronicleVaultOracleBeaconSetDeployer.sol";
+import {
+    PausableOracleWrapperBeaconSetDeployer,
+    PausableOracleWrapperBeaconSetDeployerConfig
+} from "src/concrete/deploy/PausableOracleWrapperBeaconSetDeployer.sol";
+import {
+    ChronicleOracleUnifiedDeployer,
+    ChronicleOracleUnifiedDeployerConstructorConfig,
+    ChronicleOracleUnifiedDeployConfig,
+    ZeroBeaconSetDeployer
+} from "src/concrete/deploy/ChronicleOracleUnifiedDeployer.sol";
+import {MockChronicle} from "test/mocks/MockChronicle.sol";
+import {MockERC4626} from "test/mocks/MockERC4626.sol";
+
+contract ChronicleOracleUnifiedDeployerTest is Test {
+    ChronicleVaultOracle internal oracleImpl;
+    PausableOracleWrapper internal wrapperImpl;
+    ChronicleVaultOracleBeaconSetDeployer internal oracleBSD;
+    PausableOracleWrapperBeaconSetDeployer internal wrapperBSD;
+    MockChronicle internal chronicle;
+    MockERC4626 internal vault;
+
+    address internal constant BEACON_OWNER = address(0xBEEF);
+    address internal constant ADMIN = address(0xA11CE);
+    uint256 internal constant MAX_AGE = 1 hours;
+
+    event Deployment(address indexed caller, address indexed oracle, address indexed wrapper);
+
+    function setUp() public {
+        oracleImpl = new ChronicleVaultOracle();
+        wrapperImpl = new PausableOracleWrapper();
+        chronicle = new MockChronicle();
+        vault = new MockERC4626();
+
+        oracleBSD = new ChronicleVaultOracleBeaconSetDeployer(
+            ChronicleVaultOracleBeaconSetDeployerConfig({
+                initialOwner: BEACON_OWNER, initialChronicleVaultOracleImplementation: address(oracleImpl)
+            })
+        );
+        wrapperBSD = new PausableOracleWrapperBeaconSetDeployer(
+            PausableOracleWrapperBeaconSetDeployerConfig({
+                initialOwner: BEACON_OWNER, initialPausableOracleWrapperImplementation: address(wrapperImpl)
+            })
+        );
+
+        vm.warp(1_000_000);
+    }
+
+    function _disabledPauseConfig() internal pure returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+        });
+    }
+
+    function _defaultDeployConfig() internal view returns (ChronicleOracleUnifiedDeployConfig memory) {
+        return ChronicleOracleUnifiedDeployConfig({
+            admin: ADMIN,
+            oracleConfig: ChronicleVaultOracleConfig({chronicle: chronicle, vault: address(vault), maxAge: MAX_AGE}),
+            pauseConfig: _disabledPauseConfig()
+        });
+    }
+
+    function _deployUnified() internal returns (ChronicleOracleUnifiedDeployer) {
+        return new ChronicleOracleUnifiedDeployer(
+            ChronicleOracleUnifiedDeployerConstructorConfig({
+                chronicleVaultOracleBeaconSetDeployer: oracleBSD, pausableOracleWrapperBeaconSetDeployer: wrapperBSD
+            })
+        );
+    }
+
+    // -------- Constructor validation --------
+
+    function testConstructorRevertsZeroChronicleBSD() external {
+        vm.expectRevert(ZeroBeaconSetDeployer.selector);
+        new ChronicleOracleUnifiedDeployer(
+            ChronicleOracleUnifiedDeployerConstructorConfig({
+                chronicleVaultOracleBeaconSetDeployer: ChronicleVaultOracleBeaconSetDeployer(address(0)),
+                pausableOracleWrapperBeaconSetDeployer: wrapperBSD
+            })
+        );
+    }
+
+    function testConstructorRevertsZeroWrapperBSD() external {
+        vm.expectRevert(ZeroBeaconSetDeployer.selector);
+        new ChronicleOracleUnifiedDeployer(
+            ChronicleOracleUnifiedDeployerConstructorConfig({
+                chronicleVaultOracleBeaconSetDeployer: oracleBSD,
+                pausableOracleWrapperBeaconSetDeployer: PausableOracleWrapperBeaconSetDeployer(address(0))
+            })
+        );
+    }
+
+    function testConstructorHappyPathStoresBoth() external {
+        ChronicleOracleUnifiedDeployer unified = _deployUnified();
+        assertEq(address(unified.I_CHRONICLE_VAULT_ORACLE_BEACON_SET_DEPLOYER()), address(oracleBSD));
+        assertEq(address(unified.I_PAUSABLE_ORACLE_WRAPPER_BEACON_SET_DEPLOYER()), address(wrapperBSD));
+    }
+
+    // -------- newOracleWithWrapper --------
+
+    function testNewOracleWithWrapperEmitsAndWires() external {
+        ChronicleOracleUnifiedDeployer unified = _deployUnified();
+
+        vm.recordLogs();
+        (ChronicleVaultOracle oracle, PausableOracleWrapper wrapper) =
+            unified.newOracleWithWrapper(_defaultDeployConfig());
+
+        // Wiring: wrapper.upstream() points at oracle, admin is the configured
+        // governance address, oracle.chronicle() is the configured chronicle.
+        assertEq(address(wrapper.upstream()), address(oracle), "wrapper.upstream not wired to oracle");
+        assertEq(wrapper.admin(), ADMIN, "wrapper.admin not set");
+        assertEq(address(oracle.chronicle()), address(chronicle), "oracle.chronicle not set");
+        assertEq(oracle.vault(), address(vault));
+        assertEq(oracle.maxAge(), MAX_AGE);
+
+        // Locate the unified Deployment(address,address,address) event in the
+        // recorded logs.
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        bytes32 sig = keccak256("Deployment(address,address,address)");
+        bool found;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].emitter == address(unified) && entries[i].topics[0] == sig) {
+                assertEq(address(uint160(uint256(entries[i].topics[1]))), address(this), "caller");
+                assertEq(address(uint160(uint256(entries[i].topics[2]))), address(oracle), "oracle topic");
+                assertEq(address(uint160(uint256(entries[i].topics[3]))), address(wrapper), "wrapper topic");
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found, "unified Deployment event not emitted");
+    }
+
+    function testEndToEndLatestAnswerThroughWrapper() external {
+        ChronicleOracleUnifiedDeployer unified = _deployUnified();
+        (ChronicleVaultOracle oracle, PausableOracleWrapper wrapper) =
+            unified.newOracleWithWrapper(_defaultDeployConfig());
+
+        // Mock Chronicle: $100 at 18dp, fresh.
+        chronicle.setReadWithAge(100e18, block.timestamp);
+        // Vault: 2 assets per share.
+        vault.setTotalAssets(2e18);
+        vault.setTotalSupply(1e18);
+
+        // Direct read against the underlying oracle.
+        int256 oracleAnswer = oracle.latestAnswer();
+        assertEq(oracleAnswer, int256(200e8), "oracle direct read");
+
+        // Read through the wrapper — same value since the wrapper is a pure
+        // pass-through with no pause active.
+        int256 wrapperAnswer = wrapper.latestAnswer();
+        assertEq(wrapperAnswer, oracleAnswer, "wrapper -> oracle pass-through");
+        assertEq(wrapperAnswer, int256(200e8));
+    }
+}

--- a/test/src/concrete/deploy/ChronicleVaultOracleBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/ChronicleVaultOracleBeaconSetDeployer.t.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Vm} from "forge-std-1.16.1/src/Vm.sol";
+import {UpgradeableBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/UpgradeableBeacon.sol";
+import {IChronicle} from "src/interface/IChronicle.sol";
+import {
+    ChronicleVaultOracle,
+    ChronicleVaultOracleConfig,
+    ZeroVault
+} from "src/concrete/oracle/ChronicleVaultOracle.sol";
+import {
+    ChronicleVaultOracleBeaconSetDeployer,
+    ChronicleVaultOracleBeaconSetDeployerConfig,
+    ZeroImplementation,
+    ZeroBeaconOwner
+} from "src/concrete/deploy/ChronicleVaultOracleBeaconSetDeployer.sol";
+import {MockChronicle} from "test/mocks/MockChronicle.sol";
+import {MockERC4626} from "test/mocks/MockERC4626.sol";
+
+contract ChronicleVaultOracleBeaconSetDeployerTest is Test {
+    ChronicleVaultOracle internal implementation;
+    MockChronicle internal chronicle;
+    MockERC4626 internal vault;
+    address internal constant BEACON_OWNER = address(0xBEEF);
+    uint256 internal constant MAX_AGE = 1 hours;
+
+    event Deployment(address indexed caller, address indexed oracle);
+
+    function setUp() public {
+        implementation = new ChronicleVaultOracle();
+        chronicle = new MockChronicle();
+        vault = new MockERC4626();
+        vm.warp(1_000_000);
+    }
+
+    function _deployBSD() internal returns (ChronicleVaultOracleBeaconSetDeployer) {
+        return new ChronicleVaultOracleBeaconSetDeployer(
+            ChronicleVaultOracleBeaconSetDeployerConfig({
+                initialOwner: BEACON_OWNER, initialChronicleVaultOracleImplementation: address(implementation)
+            })
+        );
+    }
+
+    function _defaultOracleConfig() internal view returns (ChronicleVaultOracleConfig memory) {
+        return ChronicleVaultOracleConfig({chronicle: chronicle, vault: address(vault), maxAge: MAX_AGE});
+    }
+
+    // -------- Constructor validation --------
+
+    function testConstructorRevertsZeroImplementation() external {
+        vm.expectRevert(ZeroImplementation.selector);
+        new ChronicleVaultOracleBeaconSetDeployer(
+            ChronicleVaultOracleBeaconSetDeployerConfig({
+                initialOwner: BEACON_OWNER, initialChronicleVaultOracleImplementation: address(0)
+            })
+        );
+    }
+
+    function testConstructorRevertsZeroBeaconOwner() external {
+        vm.expectRevert(ZeroBeaconOwner.selector);
+        new ChronicleVaultOracleBeaconSetDeployer(
+            ChronicleVaultOracleBeaconSetDeployerConfig({
+                initialOwner: address(0), initialChronicleVaultOracleImplementation: address(implementation)
+            })
+        );
+    }
+
+    function testConstructorHappyPathDeploysBeacon() external {
+        ChronicleVaultOracleBeaconSetDeployer bsd = _deployBSD();
+        address beacon = address(bsd.I_CHRONICLE_VAULT_ORACLE_BEACON());
+        assertTrue(beacon != address(0));
+        assertEq(UpgradeableBeacon(beacon).owner(), BEACON_OWNER);
+        assertEq(UpgradeableBeacon(beacon).implementation(), address(implementation));
+    }
+
+    // -------- newChronicleVaultOracle --------
+
+    function testNewChronicleVaultOracleEmitsDeployment() external {
+        ChronicleVaultOracleBeaconSetDeployer bsd = _deployBSD();
+
+        // We can't predict the proxy address without computing CREATE nonce —
+        // so check caller (indexed) and ignore the address topic by using
+        // checkData=false on the second indexed slot via `vm.recordLogs`.
+        vm.recordLogs();
+        ChronicleVaultOracle oracle = bsd.newChronicleVaultOracle(_defaultOracleConfig());
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        // Walk entries to find the Deployment event from the BSD itself.
+        bytes32 sig = keccak256("Deployment(address,address)");
+        bool found;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].emitter == address(bsd) && entries[i].topics[0] == sig) {
+                assertEq(address(uint160(uint256(entries[i].topics[1]))), address(this), "caller mismatch");
+                assertEq(address(uint160(uint256(entries[i].topics[2]))), address(oracle), "oracle mismatch");
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found, "Deployment event not emitted");
+    }
+
+    function testNewChronicleVaultOracleInitsState() external {
+        ChronicleVaultOracleBeaconSetDeployer bsd = _deployBSD();
+        ChronicleVaultOracle oracle = bsd.newChronicleVaultOracle(_defaultOracleConfig());
+        assertEq(address(oracle.chronicle()), address(chronicle));
+        assertEq(oracle.vault(), address(vault));
+        assertEq(oracle.maxAge(), MAX_AGE);
+    }
+
+    function testNewChronicleVaultOraclePropagatesInitRevert() external {
+        ChronicleVaultOracleBeaconSetDeployer bsd = _deployBSD();
+        ChronicleVaultOracleConfig memory badConfig =
+            ChronicleVaultOracleConfig({chronicle: chronicle, vault: address(0), maxAge: MAX_AGE});
+        vm.expectRevert(ZeroVault.selector);
+        bsd.newChronicleVaultOracle(badConfig);
+    }
+
+    function testMultipleProxiesShareBeacon() external {
+        ChronicleVaultOracleBeaconSetDeployer bsd = _deployBSD();
+        ChronicleVaultOracle a = bsd.newChronicleVaultOracle(_defaultOracleConfig());
+        ChronicleVaultOracle b = bsd.newChronicleVaultOracle(_defaultOracleConfig());
+        assertTrue(address(a) != address(b), "proxies must be distinct");
+
+        // Both proxies should resolve through the same beacon address.
+        // BeaconProxy stores the beacon in a known slot; we verify indirectly
+        // by checking both proxies still resolve the same implementation
+        // (this is `UpgradeableBeacon.implementation()` reached via the proxy
+        // logic).
+        address beacon = address(bsd.I_CHRONICLE_VAULT_ORACLE_BEACON());
+        assertEq(UpgradeableBeacon(beacon).implementation(), address(implementation));
+
+        // Functional sanity: both proxies share the same logic and behave
+        // identically given identical state. We didn't init them with the
+        // same vault state, but they should both have the same maxAge value
+        // from their own storage (set during the per-proxy init).
+        assertEq(a.maxAge(), b.maxAge());
+    }
+}

--- a/test/src/concrete/deploy/PausableOracleWrapperBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/PausableOracleWrapperBeaconSetDeployer.t.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Vm} from "forge-std-1.16.1/src/Vm.sol";
+import {UpgradeableBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/UpgradeableBeacon.sol";
+import {AggregatorV2V3Interface} from "src/interface/IAggregatorV2V3.sol";
+import {
+    PausableOracleWrapper,
+    PausableOracleWrapperConfig,
+    CorporateActionPauseConfig,
+    ZeroAdmin,
+    ZeroUpstream
+} from "src/concrete/wrapper/PausableOracleWrapper.sol";
+import {
+    PausableOracleWrapperBeaconSetDeployer,
+    PausableOracleWrapperBeaconSetDeployerConfig,
+    ZeroImplementation,
+    ZeroBeaconOwner
+} from "src/concrete/deploy/PausableOracleWrapperBeaconSetDeployer.sol";
+import {MockAggregatorV2V3} from "test/mocks/MockAggregatorV2V3.sol";
+
+contract PausableOracleWrapperBeaconSetDeployerTest is Test {
+    PausableOracleWrapper internal implementation;
+    MockAggregatorV2V3 internal upstream;
+    address internal constant BEACON_OWNER = address(0xBEEF);
+    address internal constant ADMIN = address(0xA11CE);
+
+    event Deployment(address indexed caller, address indexed wrapper);
+
+    function setUp() public {
+        implementation = new PausableOracleWrapper();
+        upstream = new MockAggregatorV2V3();
+        vm.warp(1_000_000);
+    }
+
+    function _deployBSD() internal returns (PausableOracleWrapperBeaconSetDeployer) {
+        return new PausableOracleWrapperBeaconSetDeployer(
+            PausableOracleWrapperBeaconSetDeployerConfig({
+                initialOwner: BEACON_OWNER, initialPausableOracleWrapperImplementation: address(implementation)
+            })
+        );
+    }
+
+    function _disabledPauseConfig() internal pure returns (CorporateActionPauseConfig memory) {
+        return CorporateActionPauseConfig({
+            corporateActionsVault: address(0), actionTypeMask: 0, pauseTimeBefore: 0, pauseTimeAfter: 0
+        });
+    }
+
+    function _defaultWrapperConfig() internal view returns (PausableOracleWrapperConfig memory) {
+        return PausableOracleWrapperConfig({
+            admin: ADMIN, upstream: AggregatorV2V3Interface(address(upstream)), pauseConfig: _disabledPauseConfig()
+        });
+    }
+
+    // -------- Constructor validation --------
+
+    function testConstructorRevertsZeroImplementation() external {
+        vm.expectRevert(ZeroImplementation.selector);
+        new PausableOracleWrapperBeaconSetDeployer(
+            PausableOracleWrapperBeaconSetDeployerConfig({
+                initialOwner: BEACON_OWNER, initialPausableOracleWrapperImplementation: address(0)
+            })
+        );
+    }
+
+    function testConstructorRevertsZeroBeaconOwner() external {
+        vm.expectRevert(ZeroBeaconOwner.selector);
+        new PausableOracleWrapperBeaconSetDeployer(
+            PausableOracleWrapperBeaconSetDeployerConfig({
+                initialOwner: address(0), initialPausableOracleWrapperImplementation: address(implementation)
+            })
+        );
+    }
+
+    function testConstructorHappyPathDeploysBeacon() external {
+        PausableOracleWrapperBeaconSetDeployer bsd = _deployBSD();
+        address beacon = address(bsd.I_PAUSABLE_ORACLE_WRAPPER_BEACON());
+        assertTrue(beacon != address(0));
+        assertEq(UpgradeableBeacon(beacon).owner(), BEACON_OWNER);
+        assertEq(UpgradeableBeacon(beacon).implementation(), address(implementation));
+    }
+
+    // -------- newPausableOracleWrapper --------
+
+    function testNewPausableOracleWrapperEmitsDeployment() external {
+        PausableOracleWrapperBeaconSetDeployer bsd = _deployBSD();
+
+        vm.recordLogs();
+        PausableOracleWrapper wrapper = bsd.newPausableOracleWrapper(_defaultWrapperConfig());
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        bytes32 sig = keccak256("Deployment(address,address)");
+        bool found;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].emitter == address(bsd) && entries[i].topics[0] == sig) {
+                assertEq(address(uint160(uint256(entries[i].topics[1]))), address(this), "caller mismatch");
+                assertEq(address(uint160(uint256(entries[i].topics[2]))), address(wrapper), "wrapper mismatch");
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found, "Deployment event not emitted");
+    }
+
+    function testNewPausableOracleWrapperInitsState() external {
+        PausableOracleWrapperBeaconSetDeployer bsd = _deployBSD();
+        PausableOracleWrapper wrapper = bsd.newPausableOracleWrapper(_defaultWrapperConfig());
+        assertEq(wrapper.admin(), ADMIN);
+        assertEq(address(wrapper.upstream()), address(upstream));
+        assertEq(wrapper.paused(), false);
+    }
+
+    function testNewPausableOracleWrapperPropagatesInitRevertZeroAdmin() external {
+        PausableOracleWrapperBeaconSetDeployer bsd = _deployBSD();
+        PausableOracleWrapperConfig memory badConfig = PausableOracleWrapperConfig({
+            admin: address(0), upstream: AggregatorV2V3Interface(address(upstream)), pauseConfig: _disabledPauseConfig()
+        });
+        vm.expectRevert(ZeroAdmin.selector);
+        bsd.newPausableOracleWrapper(badConfig);
+    }
+
+    function testMultipleProxiesShareBeacon() external {
+        PausableOracleWrapperBeaconSetDeployer bsd = _deployBSD();
+        PausableOracleWrapper a = bsd.newPausableOracleWrapper(_defaultWrapperConfig());
+        PausableOracleWrapper b = bsd.newPausableOracleWrapper(_defaultWrapperConfig());
+        assertTrue(address(a) != address(b), "proxies must be distinct");
+
+        address beacon = address(bsd.I_PAUSABLE_ORACLE_WRAPPER_BEACON());
+        assertEq(UpgradeableBeacon(beacon).implementation(), address(implementation));
+
+        // Both proxies independently delegate to the same implementation, so
+        // both `upstream()` reads should succeed and return the value each
+        // was initialized with.
+        assertEq(address(a.upstream()), address(b.upstream()));
+    }
+}


### PR DESCRIPTION
Three contracts:
  - ChronicleVaultOracleBeaconSetDeployer — one beacon + factory for
    ChronicleVaultOracle proxies. Beacon owner controls upgrades;
    deployer keeps no authority post-construction.
  - PausableOracleWrapperBeaconSetDeployer — same pattern for the
    wrapper.
  - ChronicleOracleUnifiedDeployer — one-shot factory that deploys a
    paired (oracle, wrapper) and wires wrapper.upstream = oracle
    atomically. The wrapper proxy is the canonical consumer-facing
    address (Everst, Euler).

Atomicity matters: a two-step deploy + wire-up risks integrators
wrapping the wrong adapter and minting a broken oracle. The unified
deployer eliminates that footgun.

19 unit tests across the three files — constructor validation,
Deployment event emission (via vm.recordLogs since proxy addresses
aren't predictable), init revert propagation, multi-proxy beacon
sharing, and an end-to-end wiring check that hits
wrapper.latestAnswer() through a mocked Chronicle feed and a 2:1
vault to prove the full path.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>