### PR TITLE
docs: rewrite SPEC + README around Chronicle stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,101 @@
 # st0x.oracle
 
-Oracle adapter system that bridges Pyth Network price feeds to DeFi lending protocols (Morpho Blue, Aave V3, Compound V3). Three-layer architecture: oracle adapters (price source), oracle registry (centralized vault→oracle mapping), and protocol adapters (protocol-specific interface). Allows independent upgrades, oracle swaps via single registry update, and protocol adapters that can opt-out to alternative registries.
+Chronicle-backed oracle stack for pricing ST0x `wtStock` ERC-4626 vault
+shares inside DeFi lending protocols (Euler, Aave V3, Compound V3, any
+Chainlink-compatible market). Exposes a single proxy address per vault
+behind `AggregatorV2V3Interface`.
 
 ## Architecture
 
+Two layers, separated by intent. The **adapter**
+(`ChronicleVaultOracle`) does pure price math: reads the underlying-asset
+price from a Chronicle Protocol feed, multiplies by the vault's
+`totalAssets / totalSupply` ratio, returns an 8-decimal `int256`. The
+**wrapper** (`PausableOracleWrapper`) is a shape-preserving decorator that
+adds operational pause semantics on top of any `AggregatorV2V3Interface`
+source — a manual admin emergency pause and an automatic corporate-action
+pause driven by `ICorporateActionsV1` via `LibCorporateActionsPause`.
+Consumers target the wrapper proxy; the wrapper's `upstream` slot is
+immutable.
+
 ```
-  PROTOCOL ADAPTERS (looks up oracle from registry)
-
-  ┌───────────────────────┐   ┌──────────────────────────────────────┐
-  │ MorphoProtocolAdapter │   │ PassthroughProtocolAdapter           │
-  │ IOracle (8→36 dec)    │   │ (instances: Aave, Compound, ...)     │
-  │                       │   │ AggregatorV3Interface passthrough    │
-  │ stores: registry,     │   │                                      │
-  │         vault         │   │ stores: registry, vault              │
-  └──────────┬────────────┘   └──────────────────┬───────────────────┘
-             │                                   │
-             └────────────────┬──────────────────┘
-                              │
-                              ▼
-                  ┌───────────────────────┐
-                  │    OracleRegistry     │  ← centralized vault→oracle mapping
-                  │                       │
-                  │  getOracle(vault)     │
-                  │  setOracle(vault, o)  │
-                  │  setOracleBulk(...)   │
-                  └───────────┬───────────┘
-                              │
-                              ▼
-                  ┌───────────────────────┐
-                  │ AggregatorV3Interface │  ← contract boundary
-                  └───────────────────────┘
-                              ▲
-                              │
-                    ┌─────────┴─────────┐
-                    │                   │
-                    ▼                   ▼
-  ┌──────────────────────┐   ┌──────────────────────┐
-  │ PythOracleAdapter    │   │ Future adapters      │
-  │ Pyth → 8 dec         │   │ (Chainlink etc)      │
-  │ pause, admin         │   │                      │
-  └──────────────────────┘   └──────────────────────┘
-
-  ORACLE ADAPTERS (canonical price source per asset)
+                ┌───────────────────────────────┐
+   consumers ──▶│     PausableOracleWrapper     │   ← canonical address
+                │     AggregatorV2V3Interface   │
+                │     + manual + auto pause     │
+                └───────────────┬───────────────┘
+                                │ upstream (immutable)
+                                ▼
+                ┌───────────────────────────────┐
+                │     ChronicleVaultOracle      │
+                │     chronicle.read() ×        │
+                │       totalAssets / totalSupply│
+                └───────────────────────────────┘
 ```
 
-**Oracle layer** -- one `PythOracleAdapter` per vault, implements `AggregatorV3Interface` at 8 decimals. Prices vault shares as `pythPrice * totalAssets / totalSupply`. Governance controls (pause for corporate actions) live here.
+**Flagship features:**
 
-**Registry layer** -- `OracleRegistry` maintains centralized `vault → oracle` mapping. Single `setOracle()` call updates the oracle for all protocol adapters serving that vault. Supports bulk updates via `setOracleBulk()`.
+- **Corporate-action auto-pause.** The wrapper consults
+  `ICorporateActionsV1` on every read. Inside a configured pre/post window
+  of any matching scheduled or completed action (stock splits, dividends,
+  ...), reads revert `OraclePausedCorporateAction(effectiveTime)`. Lending
+  markets that catch the revert treat the price as unavailable for the
+  window — no borrows, no liquidations across a NAV-rebalance boundary.
+- **`wtStock` NAV tracking via `convertToAssets`.** The adapter's
+  `totalAssets / totalSupply` factor is exactly ERC-4626
+  `convertToAssets(1 share)`. Post-split rebalances inside the underlying
+  `tStock` vault flow through to the share price automatically on the
+  first read after the pause window closes — no oracle-side intervention.
 
-**Protocol layer** -- `PassthroughProtocolAdapter` (Aave/Compound/any Chainlink-compatible) and `MorphoProtocolAdapter` (scales 8 to 36 decimals). Each stores `registry + vault` and looks up oracle at runtime. Can opt-out via `setRegistry()` to point to an alternative registry.
+See `SPEC.md` for the full specification.
 
-**Deployers** -- beacon proxy pattern via `st0x.deploy`. `OracleUnifiedDeployer` deploys an oracle adapter + all protocol adapters for a new vault. Admin must call `registry.setOracle()` separately to register the oracle.
+## Integrator Quickstart
+
+Deploy a paired `(oracle, wrapper)` for a new vault in one transaction:
+
+```solidity
+ChronicleOracleUnifiedDeployConfig memory config = ChronicleOracleUnifiedDeployConfig({
+    admin: governanceMultisig,
+    oracleConfig: ChronicleVaultOracleConfig({
+        chronicle: IChronicle(chronicleFeed),
+        vault:     wtStockVault,
+        maxAge:    60
+    }),
+    pauseConfig: CorporateActionPauseConfig({
+        corporateActionsVault: corporateActionsVault,
+        actionTypeMask:        type(uint256).max,
+        pauseTimeBefore:       1 hours,
+        pauseTimeAfter:        2 hours
+    })
+});
+
+(ChronicleVaultOracle oracle, PausableOracleWrapper wrapper) =
+    unifiedDeployer.newOracleWithWrapper(config);
+```
+
+Hand `address(wrapper)` to consumers as the `AggregatorV2V3Interface` source
+they already plug Chainlink feeds into. The adapter address is an internal
+detail.
+
+## Operational Preconditions for Consumers
+
+Anything that wraps reads in `try / catch` (Aave-style consumers) must respect
+two constraints, or the pause feature is silently defeated:
+
+1. **No fallback oracle on the same priced asset.** A fallback that catches
+   our pause revert and serves a raw Chronicle / raw Pyth / raw anything
+   price masks the exact failure mode the auto-pause exists to surface.
+   The pause must reach the protocol as `OraclePriceNotFound` or
+   equivalent, never get swallowed.
+2. **Consumer's `maxPriceAge` ≥ adapter's `maxAge`.** Otherwise the
+   consumer's staleness check rejects the read before our internal
+   `ChroniclePriceStale(age)` revert can surface, and the deployment
+   loses the layered staleness signal. Set consumer staleness as a strict
+   upper bound on adapter staleness.
 
 ## Setup
 
-This project uses Nix flakes for reproducible toolchain management.
+This project uses Nix flakes for a reproducible toolchain.
 
 ```bash
 nix develop
@@ -69,55 +110,38 @@ forge test -vvv          # verbose
 forge fmt --check        # check formatting
 ```
 
-Fork tests require a Base RPC URL:
-
-```bash
-export RPC_URL_BASE_FORK=<your-base-rpc-url>
-forge test
-```
-
 ## Repository Structure
 
 ```
 src/
 ├── concrete/
 │   ├── oracle/
-│   │   └── PythOracleAdapter.sol
-│   ├── registry/
-│   │   └── OracleRegistry.sol
-│   ├── protocol/
-│   │   ├── MorphoProtocolAdapter.sol
-│   │   └── PassthroughProtocolAdapter.sol
+│   │   └── ChronicleVaultOracle.sol
+│   ├── wrapper/
+│   │   └── PausableOracleWrapper.sol
 │   └── deploy/
-│       ├── PythOracleAdapterBeaconSetDeployer.sol
-│       ├── OracleRegistryBeaconSetDeployer.sol
-│       ├── MorphoProtocolAdapterBeaconSetDeployer.sol
-│       ├── PassthroughProtocolAdapterBeaconSetDeployer.sol
-│       └── OracleUnifiedDeployer.sol
+│       ├── ChronicleVaultOracleBeaconSetDeployer.sol
+│       ├── PausableOracleWrapperBeaconSetDeployer.sol
+│       └── ChronicleOracleUnifiedDeployer.sol
 ├── interface/
-│   └── IAggregatorV3.sol
+│   ├── IChronicle.sol           (vendored from chronicleprotocol/chronicle-std, MIT)
+│   └── IAggregatorV2V3.sol      (vendored Chainlink shape)
 └── lib/
-    └── LibProdDeploy.sol
+    └── LibCorporateActionsPause.sol
 test/
-├── abstract/
-│   ├── PythOracleAdapterTest.sol
-│   └── OracleRegistryTest.sol
-├── lib/
-│   └── LibFork.sol
+├── mocks/
 └── src/
-    └── concrete/
-        ├── deploy/
-        ├── oracle/
-        ├── registry/
-        └── protocol/
+    ├── concrete/{oracle,wrapper,deploy}/
+    ├── lib/
+    └── e2e/
 ```
 
 ## Dependencies
 
-- [rain.pyth](https://github.com/rainlanguage/rain.pyth) -- `LibPyth.getPriceFeedContract()` and price feed ID constants
-- [pyth-sdk-solidity](https://github.com/pyth-network/pyth-sdk-solidity) -- `IPyth`, `PythStructs`
-- [st0x.deploy](https://github.com/S01-Issuer/st0x.deploy) -- `BeaconSetDeployer` pattern, `ICloneableV2`
-- [openzeppelin-contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) -- `UpgradeableBeacon`, `BeaconProxy`, `Initializable`
+- [chronicle-std](https://github.com/chronicleprotocol/chronicle-std) -- `IChronicle` interface, vendored locally (MIT)
+- [st0x.deploy](https://github.com/S01-Issuer/st0x.deploy) -- `ICorporateActionsV1`, BeaconSetDeployer pattern, `ICloneableV2`
+- [rain-math-float](https://github.com/rainlanguage/rain.math.float) -- decimal-float arithmetic for the share-price computation
+- [openzeppelin-contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) -- `UpgradeableBeacon`, `BeaconProxy`, `Initializable`, `IERC4626`
 
 ## License
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,414 +1,529 @@
-# 🔮 ST0x Oracle Adapters Specification
+# ST0x Oracle Stack Specification
 
 **Repository:** `st0x.oracle`
-**Version:** 2.0
+**Version:** 3.0
 **Status:** Draft
-**Date:** 2026-02-06
+**Date:** 2026-06-26
 
 ---
 
 ## 1. Problem Statement
 
-ST0x wrapped tokenized equities (ERC-4626 vault shares) need to integrate with DeFi lending protocols (Morpho Blue, Aave V3, Compound V3, and future protocols) to enable borrowing against tokenized stock collateral. The oracle prices vault shares by combining the Pyth price of the underlying equity with the vault's assets-per-share ratio. Each protocol has its own oracle interface requirements:
+ST0x issues wrapped tokenized equities — `wtStock` ERC-4626 vaults wrapping
+`tStock` rebasing-receipt vaults — that need to be priced inside DeFi lending
+protocols (Euler, Aave V3, Compound V3, future Chainlink-compatible
+markets). Consumers already speak Chainlink's `AggregatorV2V3Interface`; the
+oracle stack's job is to expose a single proxy address per vault that:
 
-- **Morpho Blue**: Expects `IOracle.price()` returning a `uint256` scaled to 1e36
-- **Aave V3**: Expects Chainlink's `AggregatorV3Interface` with `latestAnswer()` and `latestRoundData()`
-- **Compound V3 (Comet)**: Expects Chainlink's `AggregatorV3Interface` with 8 decimal precision
+1. Returns an 8-decimal `int256` price for one share of the vault, denominated
+   in USD, drawn from a market-grade off-chain feed for the underlying equity.
+2. Tracks the vault's `totalAssets / totalSupply` ratio so the share price
+   moves with any NAV change — most importantly the post-stock-split rebalance
+   inside the underlying `tStock` vault.
+3. Refuses to serve a price during scheduled corporate actions (splits,
+   dividend distributions), so downstream lending markets can't liquidate or
+   borrow against a stale-by-construction share price while the vault NAV is
+   mid-rebalance.
+4. Gives ST0x governance a manual emergency pause independent of the
+   corporate-action machinery.
 
-The underlying price source is **Pyth Network**, which provides NBBO pricing for equities.
-
-**Key challenges:**
-
-1. Different protocols expect different interfaces and scaling
-2. Oracle addresses are often immutable once set in lending markets (especially Morpho)
-3. Corporate actions (splits, dividends) require pausing price feeds temporarily
-4. Upgrades to one layer shouldn't require upgrades to another
-5. Swapping oracles requires updating multiple protocol adapters individually
-
----
-
-## 2. Goals
-
-1. **True onchain modularity**: Oracle adapters and protocol adapters are separate deployments
-2. **Industry standard interface**: Use Chainlink's `AggregatorV3Interface` as the contract boundary
-3. **Swappable sources**: Protocol adapters can point to any oracle (Pyth today, Chainlink tomorrow)
-4. **Independent upgrade paths**: Fix bugs in Pyth parsing without touching protocol adapters
-5. **Beacon proxy pattern**: All layers use beacon proxies per `st0x.deploy` patterns
-6. **Centralized oracle management**: Single registry update propagates to all protocol adapters
-
-### 2.1 Relationship to rain.pyth
-
-| Aspect | rain.pyth | st0x.oracle |
-|--------|-----------|-------------|
-| Purpose | Rain interpreter word | DeFi protocol integration |
-| Interface | Returns `Float` (Rain format) | Returns `int256` (8 decimals) |
-| Lookup | Runtime symbol lookup | Per-token deployed proxy |
-| Pattern | Direct deployment | BeaconSetDeployer pattern |
-| Governance | None (stateless) | Admin controls (pause, setPriceId) |
-
-**What we reuse from rain.pyth:**
-
-- `LibPyth.getPriceFeedContract(block.chainid)` - derives Pyth contract address at runtime (audited code)
-- Price feed ID constants for all supported equities
+The previous architecture (Pyth + per-protocol adapters + a registry indirection
+layer) has been replaced. Chronicle Protocol now supplies the underlying price,
+all protocol-specific adapter shims are gone (consumers target
+`AggregatorV2V3Interface` directly), and the registry indirection has been
+removed in favour of a simple `(adapter, wrapper)` proxy pair per vault.
 
 ---
 
-## 3. Architecture Overview
+## 2. Architecture Overview
 
 ```
-PROTOCOL ADAPTERS
-(indirection layer - looks up oracle from registry)
-
-┌─────────────────┐  ┌────────────────────────────────────┐
-│ MorphoAdapter   │  │ PassthroughAdapter                 │
-│                 │  │ (multiple instances: Aave,         │
-│ IOracle         │  │  Compound, future protocols)       │
-│ (8→36 dec)      │  │ AggregatorV3 (passthrough)         │
-│                 │  │                                    │
-│ stores:         │  │ stores:                            │
-│  - registry     │  │  - registry                        │
-│  - vault        │  │  - vault                           │
-└───────┬─────────┘  └───────────────┬────────────────────┘
-        │                            │
-        └────────────┬───────────────┘
-                     ▼
-           ┌─────────────────────────┐
-           │     OracleRegistry      │  ← centralized vault→oracle mapping
-           │                         │
-           │  getOracle(vault)       │
-           │  setOracle(vault, oracle)│
-           │  setOracleBulk(...)     │
-           └───────────┬─────────────┘
-                       │
-                       ▼
-           ┌─────────────────────────┐
-           │  AggregatorV3Interface  │  ← industry standard
-           └─────────────────────────┘
-                     ▲
-          ┌──────────┴───────────────┐
-          │       implements         │
-          ▼                          ▼
-┌─────────────────────┐    ┌─────────────────────┐
-│ PythOracleAdapter   │    │ ChainlinkOracle     │
-│                     │    │ Adapter (future)    │
-│ Governance:         │    │                     │
-│  - set priceId      │    │                     │
-│  - set maxAge       │    │                     │
-│  - pause/unpause    │    │                     │
-└─────────────────────┘    └─────────────────────┘
-
-ORACLE ADAPTERS
-(canonical oracle per asset, all governance here)
+                    ┌──────────────────────────────────────┐
+   consumers ──────▶│        PausableOracleWrapper         │   ← canonical
+   (Euler, Aave,    │                                      │     consumer-facing
+    Compound,       │   AggregatorV2V3Interface            │     address
+    other lending)  │                                      │
+                    │   + OraclePausedManual()             │
+                    │   + OraclePausedCorporateAction(t)   │
+                    └────────────────┬─────────────────────┘
+                                     │ upstream (immutable)
+                                     ▼
+                    ┌──────────────────────────────────────┐
+                    │         ChronicleVaultOracle         │
+                    │                                      │
+                    │   AggregatorV2V3Interface (8 dec)    │
+                    │                                      │
+                    │   price = chronicle.read()           │
+                    │         × vault.totalAssets()        │
+                    │         / vault.totalSupply()        │
+                    └────────────────┬─────────────────────┘
+                                     │
+                ┌────────────────────┴────────────────────┐
+                ▼                                         ▼
+       ┌─────────────────┐                    ┌──────────────────┐
+       │   IChronicle    │                    │  ERC-4626 vault  │
+       │  (off-chain     │                    │   (wtStock)      │
+       │   poked price)  │                    │                  │
+       └─────────────────┘                    └──────────────────┘
+                                                       ▲
+                                                       │ ICorporateActionsV1
+                                                       │ (consulted by wrapper
+                                                       │  on every read)
+                                                       │
+                                              ┌──────────────────┐
+                                              │  corporateActions│
+                                              │      Vault       │
+                                              └──────────────────┘
 ```
 
-**Why a registry layer:**
+**Two layers, separated by intent:**
 
-Without registry:
-- Each protocol adapter stores its own oracle reference
-- Pyth dies → Need to call `setOracle()` on every protocol adapter individually
-- N vaults × M protocols = N×M `setOracle()` calls
+- **Adapter layer** — `ChronicleVaultOracle`. Pure price math. Reads Chronicle
+  for the underlying, multiplies by the vault's assets-per-share ratio, scales
+  to 8 decimals. No admin, no pause flag, nothing operational. Replaceable by
+  a different price-source adapter without touching the wrapper.
+- **Wrapper layer** — `PausableOracleWrapper`. Pure decorator. Adds pause
+  semantics (manual + corporate-action-aware) on top of any
+  `AggregatorV2V3Interface`. Shape-preserving — `decimals`, `description`,
+  `version` are delegated. The same wrapper implementation will decorate a
+  Chainlink-direct adapter, a different vendor adapter, or anything else
+  satisfying the interface, with zero changes.
 
-With registry:
-- Protocol adapters look up oracle from registry at runtime
-- Pyth dies → Call `registry.setOracle(vault, chainlinkOracle)` once
-- N vaults = N `setOracle()` calls (regardless of protocol count)
-
-**Why protocol adapters still exist (even with registry):**
-
-Without protocol adapter:
-- Aave/Compound points directly to `PythOracleAdapter`
-- Pyth dies → Need Aave/Compound governance to update their oracle registry
-- ST0x has no control over the switch
-
-With protocol adapter:
-- Aave/Compound points to `PassthroughProtocolAdapter`
-- Pyth dies → ST0x calls `registry.setOracle(vault, chainlinkOracleAdapter)`
-- Protocol is unaware, no governance action needed on their side
+The wrapper proxy is the canonical consumer-facing address. The adapter
+proxy's address is an internal implementation detail of the wrapper and need
+not be exposed to integrators after deploy time.
 
 ---
 
-## 4. OracleRegistry Implementation
+## 3. `ChronicleVaultOracle`
 
-Centralized vault→oracle mapping. Beacon proxy pattern.
+**Location:** `src/concrete/oracle/ChronicleVaultOracle.sol`
 
-**Storage:**
+Prices ERC-4626 vault shares by combining the Chronicle Protocol price of the
+underlying asset with the vault's `totalAssets / totalSupply` ratio. Beacon-proxy
+clone via `ICloneableV2`. 8-decimal `AggregatorV2V3Interface` output.
 
-```solidity
-address public admin;
-mapping(address vault => AggregatorV3Interface oracle) internal _oracles;
-```
-
-**Functions:**
+### 3.1 Storage
 
 ```solidity
-/// @notice Set or update the oracle for a vault. Admin only.
-/// @dev Upsert semantics - works for both new registration and updates.
-function setOracle(address vault, AggregatorV3Interface oracle) external onlyAdmin;
-
-/// @notice Bulk set or update oracles for multiple vaults. Admin only.
-function setOracleBulk(address[] calldata vaults, AggregatorV3Interface[] calldata oracles) external onlyAdmin;
-
-/// @notice Get the oracle for a vault.
-/// @return The oracle adapter, or address(0) if not registered.
-function getOracle(address vault) external view returns (AggregatorV3Interface);
+IChronicle public chronicle;   // Chronicle feed for the underlying asset
+address    public vault;       // ERC-4626 vault whose shares are priced
+uint256    public maxAge;      // Max acceptable Chronicle reading age (seconds)
 ```
 
-**Events:**
+All three are set once by `initialize(bytes calldata)` and never written again.
+There is no admin, no pause flag, no setter. To change any of them, deploy a
+fresh proxy and migrate consumers.
 
-- `OracleRegistryInitialized(address indexed sender, OracleRegistryConfig config)`
-- `OracleSet(address indexed vault, address indexed oldOracle, address indexed newOracle)` — `oldOracle` is `address(0)` for new registrations
+### 3.2 Price Formula
 
-**Errors:**
+```
+                       chroniclePrice × vault.totalAssets()
+   vaultSharePrice  =  ─────────────────────────────────────     (then 8dp)
+                              vault.totalSupply()
+```
 
-- `OnlyAdmin()` — caller is not admin
-- `ZeroAdmin()` — zero admin address in config
-- `ZeroVault()` — zero vault address
-- `ZeroOracle()` — zero oracle address
-- `ArrayLengthMismatch()` — vaults and oracles arrays have different lengths
+- `chroniclePrice` is the 18-decimal `uint256` returned by
+  `IChronicle.readWithAge()`.
+- The full computation is performed in Rain decimal-float space
+  (`rain-math-float`), so neither operand can overflow `uint256` and decimal
+  scaling is exact until the final reduction. The conversion to fixed-point
+  8 decimals happens only at the return boundary.
+- The vault ratio `totalAssets / totalSupply` is exactly what an ERC-4626
+  `convertToAssets(1 share)` would compute, so the price tracks any NAV
+  change inside the vault — most importantly the post-split balance bump
+  applied to the underlying `tStock` vault. See §6.2.
+
+### 3.3 Surface
+
+`ChronicleVaultOracle implements AggregatorV2V3Interface, ICloneableV2,
+Initializable`:
+
+| Function | Behaviour |
+|----------|-----------|
+| `decimals()` | Returns `8`. Chainlink convention for USD-denominated price feeds. |
+| `description()` | Returns `""`. ST0x deployments do not rely on this string; consumers route by proxy address. |
+| `version()` | Returns `1`. |
+| `latestAnswer()` | Reads Chronicle (checks `maxAge`), computes share price, returns `int256`. |
+| `latestRoundData()` | As above, with `roundId == answeredInRound == uint80(age)` and `startedAt == updatedAt == age`. Integrators that diff `roundId` see a new value whenever Chronicle has produced a new poke. |
+| `getRoundData(_roundId)` | Always reverts `HistoricalRoundDataUnsupported(_roundId)`. Chronicle exposes only its latest poke through this interface. |
+
+### 3.4 Errors
+
+- `ZeroChronicle()` / `ZeroVault()` / `ZeroMaxAge()` — `initialize` rejects
+  zero values. `maxAge = 0` would make every read instantly stale; failing
+  loud at init is preferable to minting a broken oracle.
+- `ChroniclePriceStale(uint256 age)` — `block.timestamp - age > maxAge`. The
+  oracle uses `readWithAge` (which itself reverts on no value), not
+  `tryReadWithAge` — a missing Chronicle value is always an oracle failure
+  that must surface, never be silently masked.
+- `ZeroVaultSupply()` — `vault.totalSupply() == 0`. Pricing one share of a
+  zero-supply vault is undefined.
+- `ZeroVaultSharePrice()` — computed price rounds to zero. A zero price is
+  never a valid Chainlink-compatible answer.
+- `VaultSharePriceOverflow(uint256 price8)` — result wouldn't fit in `int256`.
+- `HistoricalRoundDataUnsupported(uint80 roundId)` — `getRoundData` is not
+  supported.
+
+### 3.5 Events
+
+- `ChronicleVaultOracleInitialized(address indexed sender,
+  ChronicleVaultOracleConfig config)` — emitted exactly once. Single source
+  of truth for off-chain indexers; all immutable config lives in this event.
 
 ---
 
-## 5. Protocol Adapter Types
+## 4. `PausableOracleWrapper`
 
-| Protocol | Interface | Adapter Type |
-|----------|-----------|-------------|
-| Morpho Blue | `IOracle.price()` (36 dec) | `MorphoProtocolAdapter` • scales 8→36 |
-| Aave V3 | `AggregatorV3Interface` (8 dec) | `PassthroughProtocolAdapter` instance |
-| Compound V3 | `AggregatorV3Interface` (8 dec) | `PassthroughProtocolAdapter` instance |
-| Future Chainlink-compatible | `AggregatorV3Interface` (8 dec) | `PassthroughProtocolAdapter` instance |
+**Location:** `src/concrete/wrapper/PausableOracleWrapper.sol`
 
-**Two adapter contracts (not three):**
+A pure-decorator wrapper that adds operational pause semantics on top of any
+`AggregatorV2V3Interface` upstream. Beacon-proxy clone via `ICloneableV2`.
 
-- `MorphoProtocolAdapter` - scales 8→36 decimals
-- `PassthroughProtocolAdapter` - used by Aave, Compound, any Chainlink-compatible protocol
+### 4.1 Storage
 
-Deploy multiple proxy *instances* from the same beacon for different protocols.
+```solidity
+address                 public admin;                  // governance
+bool                    public paused;                 // manual emergency flag
+AggregatorV2V3Interface public upstream;               // wrapped oracle (immutable)
+address                 public corporateActionsVault;  // ICorporateActionsV1, immutable
+uint256                 public actionTypeMask;         // bitmap, immutable
+uint64                  public pauseTimeBefore;        // pre-window (s), immutable
+uint64                  public pauseTimeAfter;         // post-window (s), immutable
+```
+
+`admin` and `paused` are the only mutable slots after `initialize`. `upstream`
+and the entire `CorporateActionPauseConfig` block are immutable — there is no
+admin upgrade path that could swap the priced source. Swapping the priced
+source means redeploying the wrapper and migrating consumers, which is by
+design (see §7).
+
+### 4.2 Pause Semantics
+
+Reads (`latestAnswer`, `latestRoundData`, `getRoundData`) revert if **either**
+of two independent conditions is true:
+
+1. **Manual pause.** `paused == true`, set by `admin` via `setPaused(bool)`.
+   Reverts `OraclePausedManual()`. Persists until `setPaused(false)`.
+2. **Corporate-action auto-pause.** `LibCorporateActionsPause.inPauseWindow(...)`
+   returns `true` for the configured vault, mask, and pre/post windows.
+   Reverts `OraclePausedCorporateAction(uint64 effectiveTime)`. The
+   `effectiveTime` payload disambiguates which scheduled or completed action
+   triggered the pause. See §5 for the windowing semantics.
+
+The two conditions are OR'd. The manual check runs first (cheaper — single
+`SLOAD`) so that when an admin has explicitly set the manual flag, integrators
+see `OraclePausedManual()` rather than a coincidental
+`OraclePausedCorporateAction(t)`.
+
+The error selectors are distinct so a consumer doing `try / catch` introspection
+can disambiguate "ops paused us" from "scheduled event in window" if they wish.
+For the simple case — a consumer that catches any revert and falls back to
+"no price available" — no disambiguation is needed.
+
+### 4.3 Shape Preservation
+
+`decimals()`, `description()`, and `version()` are delegated straight to
+`upstream`. The wrapper does not modify any value; it only adds revert
+conditions. A consumer dropping in a `PausableOracleWrapper` proxy where it
+would have used the underlying adapter sees identical shape and identical
+price behaviour outside pause windows.
+
+### 4.4 Admin Surface
+
+| Function | Behaviour |
+|----------|-----------|
+| `setPaused(bool isPaused)` | `onlyAdmin`. Toggles the manual flag. Emits `PauseSet(isPaused)`. |
+| `setAdmin(address newAdmin)` | `onlyAdmin`. One-step transfer; new admin takes effect immediately. Rejects zero. A misaddressed transfer permanently locks governance — use a multisig. Emits `AdminSet(oldAdmin, newAdmin)`. |
+
+### 4.5 Errors
+
+- `ZeroUpstream()` / `ZeroAdmin()` — `initialize` and `setAdmin` reject zero
+  values. A zero admin permanently locks `setPaused`; a zero upstream mints
+  a wrapper that always reverts.
+- `OnlyAdmin()` — caller is not `admin`.
+- `OraclePausedManual()` — manual pause is set.
+- `OraclePausedCorporateAction(uint64 effectiveTime)` — auto-pause window is
+  open. `effectiveTime` is the action whose window contains `now`.
+
+### 4.6 Events
+
+- `PausableOracleWrapperInitialized(address indexed sender,
+  PausableOracleWrapperConfig config)` — once on init.
+- `PauseSet(bool isPaused)`
+- `AdminSet(address indexed oldAdmin, address indexed newAdmin)`
 
 ---
 
-## 6. PythOracleAdapter Implementation
+## 5. `LibCorporateActionsPause`
 
-**Storage:**
+**Location:** `src/lib/LibCorporateActionsPause.sol`
 
-```solidity
-address public vault;            // ERC-4626 vault, set once, no setter
-bytes32 public priceId;          // Pyth feed ID for underlying asset
-uint256 public maxAge;           // Max acceptable price age
-bool public paused;              // Emergency pause
-address public admin;            // Admin for governance
-```
+Stateless, view-only helper. Consults an `ICorporateActionsV1` vault and
+decides whether the current block falls inside a configured pause window
+around any matching scheduled or completed action.
 
-Note: No `pyth` address storage - derived from `LibPyth.getPriceFeedContract(block.chainid)` at runtime.
+### 5.1 Window Semantics
 
-**Price Formula:**
+The library checks two windows independently and pauses if either is open.
+
+**Pre-window** (earliest pending action `A` matching the mask):
 
 ```
-vaultSharePrice = pythPrice * vault.totalAssets() / vault.totalSupply()
+   effectiveTime(A) - pauseTimeBefore  ≤  block.timestamp  <  effectiveTime(A)
 ```
 
-The oracle prices ERC-4626 vault shares by combining the Pyth price of the underlying equity with the vault's assets-per-share ratio. This correctly handles stock splits (totalAssets increases), dividend reinvestment (totalAssets increases), and the wrapped token premium/discount.
+Querying the earliest pending action is sufficient: pending effective-times
+are strictly increasing in their list traversal, so if the closest one's
+pre-window has not yet opened, no later one's has either.
 
-**Implementation:**
+**Post-window** (latest completed action `A` matching the mask):
 
-```solidity
-import {LibPyth} from "rain.pyth/src/lib/pyth/LibPyth.sol";
-import {IERC4626} from "openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
-
-function latestAnswer() external view override returns (int256) {
-    _validateNotPaused();
-
-    IPyth pyth = LibPyth.getPriceFeedContract(block.chainid);
-    PythStructs.Price memory priceData = pyth.getPriceNoOlderThan(priceId, maxAge);
-
-    return _vaultSharePrice(priceData);
-}
-
-function _vaultSharePrice(PythStructs.Price memory priceData) internal view returns (int256) {
-    int256 price8 = _conservativeScaledPrice(priceData);
-
-    IERC4626 vaultContract = IERC4626(vault);
-    uint256 totalAssets = vaultContract.totalAssets();
-    uint256 totalSupply = vaultContract.totalSupply();
-
-    if (totalSupply == 0) revert ZeroVaultSupply();
-
-    return int256(uint256(price8) * totalAssets / totalSupply);
-}
 ```
+   effectiveTime(A)  ≤  block.timestamp  ≤  effectiveTime(A) + pauseTimeAfter
+```
+
+Querying the latest completed action is sufficient: completed effective-times
+are strictly decreasing in their list traversal, so if the most recent one's
+post-window has closed, no earlier one's is open.
+
+Cancelled action nodes are unlinked from `ICorporateActionsV1`'s traversal
+API and so are excluded automatically — no explicit filter required here.
+
+Each call is at most two view calls into the vault.
+
+### 5.2 Mask
+
+`actionTypeMask` is a bitmap matching `ICorporateActionsV1`'s action-type
+encoding:
+
+- `ACTION_TYPE_STOCK_SPLIT_V1 = 1 << 1`
+- `ACTION_TYPE_STABLES_DIVIDEND_V1 = 1 << 2`
+- `type(uint256).max` matches every present and future action type.
+
+A `mask == 0` short-circuits to "not paused" — no action types match anything.
+A zero `corporateActionsVault` also short-circuits to "not paused" and
+disables auto-pause for the life of the wrapper proxy.
+
+### 5.3 Overlap Resolution: Pending Wins
+
+When both a pending pre-window and a completed post-window contain `now`
+(e.g. a back-to-back schedule where one action just completed and the next
+is about to fire), the **pending** action's `effectiveTime` is the one
+returned in `OraclePausedCorporateAction(effectiveTime)`. Rationale:
+integrators reading the revert payload care more about the next event coming
+than the last one done — the upcoming `effectiveTime` is what tells them when
+to expect the pause window to slide.
+
+This is implemented by checking the pending window first and short-circuiting
+the return.
+
+### 5.4 Audit Note: `NODE_NONE` Sentinel
+
+`ICorporateActionsV1` uses linked-list traversal with node ids; `cursor == 0`
+is a real bootstrap node (the `ACTION_TYPE_INIT_V1` entry). The no-match
+sentinel is `NODE_NONE = type(uint256).max`. An earlier draft of this
+library used `cursor != 0` as the "match found" check, which would have
+silently treated the bootstrap node as a real corporate action. The current
+implementation uses `cursor != NODE_NONE`. This is load-bearing — do not
+weaken it during future refactors.
 
 ---
 
-## 7. PassthroughProtocolAdapter Implementation
+## 6. Flagship Features
 
-For protocols using `AggregatorV3Interface` (Aave V3, Compound V3, future Chainlink-compatible protocols):
+The wrapper/adapter split surfaces two core ST0x security properties that
+downstream lending markets get for free.
 
-```solidity
-contract PassthroughProtocolAdapter is ICloneableV2, Initializable {
-    OracleRegistry public registry;   // Registry for oracle lookup
-    address public vault;             // Vault this adapter serves
-    address public admin;             // Admin for governance
+### 6.1 Corporate-Action Auto-Pause
 
-    function setRegistry(OracleRegistry newRegistry) external onlyAdmin {
-        if (address(newRegistry) == address(0)) revert ZeroRegistry();
-        emit RegistrySet(address(registry), address(newRegistry));
-        registry = newRegistry;
-    }
+Lending markets must not service borrows, repayments, or liquidations against
+a vault whose NAV is about to discontinuously change. A stock split inside
+the underlying `tStock` vault rebalances every receipt holder's balance at
+the split's `effectiveTime`; until that rebalance is reflected in
+`vault.totalAssets()`, the oracle's share price is correct-as-of-old-shares
+but the market sees new shares. Anyone trading across that boundary captures
+free value at the expense of slower participants.
 
-    function _getOracle() internal view returns (AggregatorV3Interface) {
-        AggregatorV3Interface oracle = registry.getOracle(vault);
-        if (address(oracle) == address(0)) revert OracleNotFound();
-        return oracle;
-    }
+The wrapper's corporate-action auto-pause closes the boundary: from
+`effectiveTime - pauseTimeBefore` through `effectiveTime + pauseTimeAfter`,
+every price read reverts `OraclePausedCorporateAction(effectiveTime)`.
+Lending markets that catch the revert (Aave-style `try/catch` consumers)
+treat the price as unavailable for the window — no new borrows, no liquidations.
 
-    function decimals() external view returns (uint8) {
-        return _getOracle().decimals();
-    }
+The auto-pause is consulted on every price read against the live
+`ICorporateActionsV1` state. There is no off-chain process to nudge, no
+scheduled job, no admin action required around the event. ST0x governance
+remains the keeper-of-record on the corporate-actions vault, but the
+oracle's reaction to that schedule is fully on-chain and deterministic.
 
-    function latestAnswer() external view returns (int256) {
-        return _getOracle().latestAnswer();
-    }
+### 6.2 `wtStock` NAV Tracking via `convertToAssets`
 
-    function latestRoundData() external view returns (
-        uint80 roundId,
-        int256 answer,
-        uint256 startedAt,
-        uint256 updatedAt,
-        uint80 answeredInRound
-    ) {
-        return _getOracle().latestRoundData();
-    }
-}
-```
+The vault under price is an ERC-4626 `wtStock` wrapper. Its
+`vault.totalAssets() / vault.totalSupply()` ratio is exactly what
+`convertToAssets(1 share)` would return, and is the canonical handle on any
+NAV bump the underlying `tStock` vault has applied. After a stock split, the
+underlying receipt vault's balances rebalance, `wtStock.totalAssets()` rises
+proportionally, and the next post-pause price read picks up the new ratio
+without any oracle-side intervention.
 
-**Usage:**
+This is intentional: the oracle does not encode split ratios, dividend
+amounts, or any action-specific math. All accounting lives in the vault;
+the oracle just multiplies. The auto-pause window covers the period where
+the rebalance is still settling and the ratio is mid-transition. After the
+post-window closes, reads resume against the updated ratio.
 
-- Deploy one proxy instance for Aave (AAPL)
-- Deploy another proxy instance for Compound (AAPL)
-- Both share the same beacon and implementation
-- Both point to the same registry and look up oracle for their vault
-- Changing the oracle in the registry updates both adapters
+This is also why the wrapper does not allow swapping `upstream`: if a future
+admin could redirect to a different priced source, the (paused-correctly)
+share-price invariant would no longer be guaranteed by construction.
 
 ---
 
-## 8. MorphoProtocolAdapter Implementation
+## 7. Beacon-Proxy & Upgrade Model
 
-Morpho Blue requires `IOracle.price()` returning 36-decimal scaled price:
+Both `ChronicleVaultOracle` and `PausableOracleWrapper` follow the standard
+`st0x.deploy` BeaconSetDeployer pattern:
 
-```solidity
-contract MorphoProtocolAdapter is IOracle, ICloneableV2, Initializable {
-    OracleRegistry public registry;   // Registry for oracle lookup
-    address public vault;             // Vault this adapter serves
-    address public admin;             // Admin for governance
+- Each contract has a `BeaconSetDeployer` constructor that takes an
+  implementation address and an initial beacon owner, then constructs a
+  fresh `UpgradeableBeacon` internally and holds it as an `immutable`.
+- Proxies (`BeaconProxy`) are minted via the deployer's `new...()` method
+  and initialized through `ICloneableV2.initialize(bytes)`. Init returning
+  anything other than `ICLONEABLE_V2_SUCCESS` reverts the deploy.
+- After construction, the deployer retains no authority over the beacon.
+  Implementation upgrades and beacon-owner rotations are handled externally
+  by whoever the beacon's `Ownable` owner is (ST0x governance multisig).
 
-    function setRegistry(OracleRegistry newRegistry) external onlyAdmin {
-        if (address(newRegistry) == address(0)) revert ZeroRegistry();
-        emit RegistrySet(address(registry), address(newRegistry));
-        registry = newRegistry;
-    }
+**What the beacon owner can do:**
 
-    function price() external view override returns (uint256) {
-        AggregatorV3Interface oracle = registry.getOracle(vault);
-        if (address(oracle) == address(0)) revert OracleNotFound();
+- Swap the implementation behind the beacon (bug fixes, gas optimisations).
 
-        int256 answer = oracle.latestAnswer();
-        if (answer <= 0) revert NonPositivePrice();
+**What the beacon owner cannot do:**
 
-        // Scale from 8 decimals to 36 decimals
-        return uint256(answer) * 1e28;
-    }
-}
-```
+- Change a proxy's `upstream` (it's immutable in the proxy's storage).
+- Change a proxy's `corporateActionsVault`, `actionTypeMask`,
+  `pauseTimeBefore`, or `pauseTimeAfter`.
+- Change a `ChronicleVaultOracle` proxy's `chronicle`, `vault`, or `maxAge`.
 
----
-
-## 9. BeaconSetDeployer Pattern
-
-Following `st0x.deploy` patterns:
-
-**Oracle Registry:**
-
-```solidity
-contract OracleRegistryBeaconSetDeployer {
-    IBeacon public immutable I_ORACLE_REGISTRY_BEACON;
-
-    function newOracleRegistry(OracleRegistryConfig memory config)
-        external returns (OracleRegistry);
-}
-```
-
-**Oracle Adapter Layer:**
-
-```solidity
-contract PythOracleAdapterBeaconSetDeployer {
-    IBeacon public immutable I_PYTH_ORACLE_ADAPTER_BEACON;
-
-    function newPythOracleAdapter(PythOracleAdapterConfig memory config)
-        external returns (PythOracleAdapter);
-}
-```
-
-**Protocol Adapter Layer:**
-
-```solidity
-contract PassthroughProtocolAdapterBeaconSetDeployer {
-    IBeacon public immutable I_PASSTHROUGH_PROTOCOL_ADAPTER_BEACON;
-
-    function newPassthroughProtocolAdapter(
-        OracleRegistry registry,
-        address vault,
-        address admin
-    ) external returns (PassthroughProtocolAdapter);
-}
-
-contract MorphoProtocolAdapterBeaconSetDeployer {
-    IBeacon public immutable I_MORPHO_PROTOCOL_ADAPTER_BEACON;
-
-    function newMorphoProtocolAdapter(
-        OracleRegistry registry,
-        address vault,
-        address admin
-    ) external returns (MorphoProtocolAdapter);
-}
-```
+These are immutable after init by design. A beacon upgrade can change
+behaviour but cannot redirect the priced source or weaken the pause windows.
+The only way to change a vault's priced source is to redeploy a fresh
+adapter and a fresh wrapper, then migrate consumers — which is, again, an
+intentional friction surface.
 
 ---
 
-## 10. Deployment Flow
+## 8. Deployers
 
-**Initial deployment (once per chain):**
+**Location:** `src/concrete/deploy/`
 
-1. Deploy OracleRegistryV1 implementation
-2. Deploy OracleRegistryBeaconSetDeployer (creates beacon internally)
-3. Deploy the canonical OracleRegistry proxy
-4. Deploy PythOracleAdapterV1 implementation
-5. Deploy PythOracleAdapterBeaconSetDeployer
-6. Deploy MorphoProtocolAdapterV1 implementation
-7. Deploy MorphoProtocolAdapterBeaconSetDeployer
-8. Deploy PassthroughProtocolAdapterV1 implementation
-9. Deploy PassthroughProtocolAdapterBeaconSetDeployer
-10. Deploy OracleUnifiedDeployer
+| Contract | Purpose |
+|----------|---------|
+| `ChronicleVaultOracleBeaconSetDeployer` | Owns the `ChronicleVaultOracle` beacon. Exposes `newChronicleVaultOracle(config)` to mint a proxy. |
+| `PausableOracleWrapperBeaconSetDeployer` | Owns the `PausableOracleWrapper` beacon. Exposes `newPausableOracleWrapper(config)` to mint a proxy. |
+| `ChronicleOracleUnifiedDeployer` | One-shot. `newOracleWithWrapper(config)` mints both proxies in a single transaction and wires `wrapper.upstream = oracle`. |
 
-**For a new vault (e.g., wrapped AAPL):**
+### 8.1 Unified Deploy
 
 ```solidity
-// Step 1: Deploy oracle + protocol adapters
-OracleUnifiedDeployer.newOracleAndProtocolAdapters(
-    vault,          // Wrapped AAPL ERC-4626 vault address
-    priceId,        // AAPL/USD feed ID (from LibPyth constants)
-    60,             // maxAge in seconds
-    registry        // The canonical OracleRegistry
-);
-// Returns oracleAdapter, morphoAdapter, passthroughAdapter addresses
+ChronicleOracleUnifiedDeployConfig memory config = ChronicleOracleUnifiedDeployConfig({
+    admin: governanceMultisig,
+    oracleConfig: ChronicleVaultOracleConfig({
+        chronicle: IChronicle(chronicleFeed),
+        vault:     wtStockVault,
+        maxAge:    60
+    }),
+    pauseConfig: CorporateActionPauseConfig({
+        corporateActionsVault: corporateActionsVault,
+        actionTypeMask:        type(uint256).max,
+        pauseTimeBefore:       1 hours,
+        pauseTimeAfter:        2 hours
+    })
+});
 
-// Step 2: Register oracle in registry (admin action, separate tx)
-registry.setOracle(vault, oracleAdapter);
+(ChronicleVaultOracle oracle, PausableOracleWrapper wrapper) =
+    unifiedDeployer.newOracleWithWrapper(config);
+
+// Hand `address(wrapper)` to consumers. Forget `address(oracle)`.
 ```
 
-**Why two-step deployment:**
+Atomicity is the point: a two-step deploy-then-wire-up flow opens a window
+for misaddressing the adapter, which would silently mint a wrapper around
+the wrong priced source. The unified deployer closes that window — the
+wrapper's `upstream` slot is set to the freshly-deployed adapter inside the
+same transaction that created the adapter, and both addresses are emitted
+in the deployer's `Deployment(caller, oracle, wrapper)` event.
 
-- `OracleUnifiedDeployer` can be called by anyone to deploy adapters
-- Only registry admin can register oracles
-- Separation prevents unauthorized oracle registration
+### 8.2 Per-Chain Deploy Sequence
+
+1. Deploy `ChronicleVaultOracle` implementation.
+2. Deploy `ChronicleVaultOracleBeaconSetDeployer` (it constructs its beacon).
+3. Deploy `PausableOracleWrapper` implementation.
+4. Deploy `PausableOracleWrapperBeaconSetDeployer` (it constructs its beacon).
+5. Deploy `ChronicleOracleUnifiedDeployer` wired to both BeaconSetDeployers.
+6. (Per vault) Call `unifiedDeployer.newOracleWithWrapper(...)`.
+
+Steps 1-5 happen once per chain. Step 6 is one transaction per vault.
+
+---
+
+## 9. Vendored Interfaces
+
+**Location:** `src/interface/`
+
+Two interfaces are vendored locally rather than pulled as soldeer or git
+dependencies:
+
+- **`IChronicle.sol`** — Chronicle Protocol's oracle interface
+  (`wat`, `read`, `readWithAge`, `tryRead`, `tryReadWithAge`). 18-decimal
+  `uint256` values. Hand-typed copy of
+  `chronicleprotocol/chronicle-std:src/IChronicle.sol` (MIT-licensed),
+  last synced 2026-06-26 against `main`. Vendored because the interface is
+  small, stable, and Chronicle does not currently publish `chronicle-std`
+  to soldeer. **No drift-detection test exists.** Re-sync on any upstream
+  bump.
+
+- **`IAggregatorV2V3.sol`** — Hybrid of Chainlink's `AggregatorInterface`
+  (v2 — `latestAnswer`) and `AggregatorV3Interface` (v3 — `latestRoundData`,
+  `getRoundData`). Vendored to avoid taking a Chainlink dependency for an
+  interface this small. The deprecated `latestAnswer()` is intentionally
+  retained because Aave V3 and Compound V3 still call it; new consumers
+  should prefer `latestRoundData()` and honour `updatedAt`.
+
+---
+
+## 10. Integrator Model
+
+Consumers (Euler, Aave V3, Compound V3, future Chainlink-compatible
+markets) target the `PausableOracleWrapper` proxy address at the
+`AggregatorV2V3Interface` they already use for Chainlink feeds. No
+protocol-specific shim is involved. The wrapper looks indistinguishable from
+a Chainlink feed except that:
+
+- `latestAnswer` / `latestRoundData` revert during pause windows. Consumers
+  must treat these reverts as "price unavailable", not "price is the last
+  successful read".
+- `getRoundData(_roundId)` always reverts when the upstream is
+  `ChronicleVaultOracle`. Consumers should not rely on historical round
+  lookups against this stack.
+
+### 10.1 Operational Preconditions
+
+For any consumer that wraps reads in `try / catch`:
+
+1. **Do not configure a fallback oracle on the same bToken that points at a
+   raw Chronicle feed (or a raw Pyth feed, or anything else).** A fallback
+   would silently mask the pause errors — exactly the failure mode the
+   auto-pause is supposed to make loud. A pause must surface to the
+   protocol as `OraclePriceNotFound` (or its equivalent), not get swallowed
+   by a fallback that wasn't aware the price was deliberately withheld.
+
+2. **The consumer's own `maxPriceAge` (or equivalent staleness threshold)
+   must be greater than or equal to the adapter's `maxAge`.** Otherwise
+   the consumer's check rejects the read before the adapter's internal
+   `ChroniclePriceStale(age)` revert can fire, and the deployment loses
+   the layered staleness signal. Configure consumer staleness as a strict
+   upper bound on adapter staleness.
 
 ---
 
@@ -416,98 +531,78 @@ registry.setOracle(vault, oracleAdapter);
 
 ```
 st0x.oracle/
-├── lib/
-│   ├── rain.pyth/                              # For LibPyth
-│   └── pyth-sdk-solidity/                      # Pyth structs
 ├── src/
 │   ├── concrete/
 │   │   ├── oracle/
-│   │   │   └── PythOracleAdapter.sol
-│   │   ├── registry/
-│   │   │   └── OracleRegistry.sol              # Centralized vault→oracle mapping
-│   │   ├── protocol/
-│   │   │   ├── MorphoProtocolAdapter.sol       # Scales 8→36, uses registry
-│   │   │   └── PassthroughProtocolAdapter.sol  # For Aave, Compound, uses registry
+│   │   │   └── ChronicleVaultOracle.sol
+│   │   ├── wrapper/
+│   │   │   └── PausableOracleWrapper.sol
 │   │   └── deploy/
-│   │       ├── OracleRegistryBeaconSetDeployer.sol
-│   │       ├── PythOracleAdapterBeaconSetDeployer.sol
-│   │       ├── MorphoProtocolAdapterBeaconSetDeployer.sol
-│   │       ├── PassthroughProtocolAdapterBeaconSetDeployer.sol
-│   │       └── OracleUnifiedDeployer.sol
+│   │       ├── ChronicleVaultOracleBeaconSetDeployer.sol
+│   │       ├── PausableOracleWrapperBeaconSetDeployer.sol
+│   │       └── ChronicleOracleUnifiedDeployer.sol
+│   ├── interface/
+│   │   ├── IChronicle.sol           ← vendored Chronicle (MIT)
+│   │   └── IAggregatorV2V3.sol      ← vendored Chainlink shape
 │   └── lib/
-│       └── LibProdDeploy.sol
+│       └── LibCorporateActionsPause.sol
 └── test/
+    ├── mocks/
+    │   ├── MockAggregatorV2V3.sol
+    │   ├── MockChronicle.sol
+    │   ├── MockCorporateActions.sol
+    │   └── MockERC4626.sol
+    └── src/
+        ├── concrete/
+        │   ├── oracle/
+        │   ├── wrapper/
+        │   └── deploy/
+        ├── lib/
+        └── e2e/
+            └── ChronicleStackE2E.t.sol
 ```
 
 ---
 
-## 12. LibPyth Usage
+## 12. Security Considerations
 
-**Runtime (in PythOracleAdapter):**
-
-```solidity
-// No pyth address stored - derived at runtime from audited code
-IPyth pyth = LibPyth.getPriceFeedContract(block.chainid);
-```
-
-**Constants (for deployment):**
-
-```solidity
-// From LibPyth.sol - already mapped
-bytes32 constant PRICE_FEED_ID_EQUITY_US_AAPL_USD = 0x49f6b65cb1de6b10eaf75e7c03ca029c306d0357e91b5311b175084a5ad55688;
-bytes32 constant PRICE_FEED_ID_EQUITY_US_TSLA_USD = 0x16dad506d7db8da01c87581c87ca897a012a153557d4d578c3b9c9e1bc0632f1;
-bytes32 constant PRICE_FEED_ID_EQUITY_US_NVDA_USD = 0xb1073854ed24cbc755dc527418f52b7d271f6cc967bbf8d8129112b18860a593;
-// ... GOOG, AMZN, MSFT, META, GME, MSTR, COIN, etc.
-
-// Chain ID → Pyth contract
-IPyth constant PRICE_FEED_CONTRACT_BASE = IPyth(0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a);
-```
-
----
-
-## 13. Governance
-
-All admin roles held by founder multisig:
-
-- **Beacon Owner**: Can upgrade implementation
-- **Registry Admin**: Can register/update vault→oracle mappings
-- **Oracle Admin**: Can update priceId, maxAge, pause/unpause
-- **Protocol Adapter Admin**: Can update registry reference (opt-out mechanism)
-
-No separation of roles.
+1. **Chronicle staleness must surface, not mask.** The adapter uses
+   `readWithAge` (reverts on no value), not `tryReadWithAge` (returns
+   `isValid=false`). A missing Chronicle value is always an oracle failure
+   that must reach the consumer.
+2. **`maxAge == 0` is rejected at init.** A zero `maxAge` would make every
+   read instantly stale; failing loud at init is preferable to minting an
+   always-reverting oracle.
+3. **Vault ratio is trusted.** `totalAssets / totalSupply` is taken at face
+   value. The vault must be a known ST0x deployment; pricing a hostile
+   ERC-4626 implementation is out of scope.
+4. **Zero vault supply reverts.** Pricing a share of a zero-supply vault
+   is undefined; the adapter reverts `ZeroVaultSupply()`.
+5. **`NODE_NONE` is the no-match sentinel, not `0`.** See §5.4. Misreading
+   this would treat the bootstrap node as a real corporate action.
+6. **Pending-wins overlap rule.** See §5.3. If a future change reverses
+   this, integrators reading the `effectiveTime` payload would see the
+   wrong "next event" timestamp.
+7. **Wrapper `admin` is single-step and zero-rejected on transfer.** A
+   misaddressed transfer permanently locks `setPaused`; use a multisig.
+8. **Upstream and pause config are immutable.** No admin path can redirect
+   the priced source or weaken pause windows; only redeploy + migration.
+9. **`getRoundData` reverts on Chronicle-backed deployments.** Consumers
+   that depend on historical round lookups will fail loudly, not get
+   wrong-but-plausible data.
+10. **Fallback oracles on the consumer side undermine the pause feature.**
+    See §10.1. The pause must reach the consumer; a fallback that hides it
+    defeats the security property.
 
 ---
 
-## 14. Upgrade & Migration Scenarios
+## 13. References
 
-| Scenario | Action | Unchanged |
-|----------|--------|-----------|
-| Bug in Pyth price parsing | Upgrade PythOracleBeacon implementation | Registry, all protocol adapters |
-| Bug in Morpho scaling | Upgrade MorphoAdapterBeacon implementation | Registry, all oracle adapters |
-| Add Aave support | Deploy PassthroughAdapter proxy pointing to existing registry | Everything else |
-| Pyth dies, switch to Chainlink | Deploy ChainlinkOracleAdapter, call `registry.setOracle(vault, chainlinkOracle)` | Protocol adapters automatically use new oracle |
-| Corporate action (AAPL split) | Pause PythOracleAdapter, execute split, unpause | Protocol adapters unaware |
-| Bulk oracle update (10 vaults) | `registry.setOracleBulk(vaults, oracles)` | Single tx updates all |
-| Protocol adapter wants different registry | `adapter.setRegistry(alternativeRegistry)` | Other adapters unaffected |
-
----
-
-## 15. Security Considerations
-
-1. **Negative prices**: Pyth prices can theoretically be negative; handle appropriately (revert)
-2. **Confidence intervals**: Pyth provides confidence data; consider rejecting wide confidence
-3. **Overflow**: Ensure scaling math cannot overflow (checked arithmetic in 0.8.25)
-4. **Corporate actions**: Pause mechanism exists to prevent trading during splits/dividends
-5. **Zero vault supply**: Revert when vault has no shares minted (no valid price)
-6. **Vault ratio manipulation**: Vault totalAssets/totalSupply is trusted — vault must be a known st0x deployment
-7. **Oracle not registered**: Protocol adapters revert with `OracleNotFound` if vault not in registry
-8. **Registry admin trust**: Registry admin can point any vault to any oracle — trust assumption
-
----
-
-## 16. References
-
-- **rain.pyth**: https://github.com/rainlanguage/rain.pyth
-- **st0x.deploy**: https://github.com/S01-Issuer/st0x.deploy
-- **Pyth Network**: https://docs.pyth.network/
-- **Chainlink AggregatorV3Interface**: https://github.com/smartcontractkit/chainlink
+- **Chronicle Protocol** — https://chroniclelabs.org/
+- **chronicle-std (`IChronicle` source of truth)** —
+  https://github.com/chronicleprotocol/chronicle-std
+- **`st0x.deploy` (corporate actions, BeaconSetDeployer pattern,
+  `ICloneableV2`)** — https://github.com/S01-Issuer/st0x.deploy
+- **`rain-math-float`** — https://github.com/rainlanguage/rain.math.float
+- **Chainlink `AggregatorV2V3Interface`** — https://github.com/smartcontractkit/chainlink
+- **ERC-4626 Tokenized Vault Standard** — https://eips.ethereum.org/EIPS/eip-4626


### PR DESCRIPTION
Drops the old Pyth + registry + protocol-adapter narrative; replaces
with the two-layer Chronicle architecture:

  - ChronicleVaultOracle — pure price math (Chronicle × ERC-4626
    vault share ratio → AggregatorV2V3Interface, 8dp)
  - PausableOracleWrapper — pause-decorator on top of any
    AggregatorV2V3 source (manual + corp-action-aware), canonical
    consumer-facing proxy

Organises the SPEC around the two flagship features (corporate-action
auto-pause via LibCorporateActionsPause with the pending-wins overlap
rule + NODE_NONE audit note; wtStock NAV tracking via totalAssets /
totalSupply) and adds an Integrator Model section keyed at Everst /
Euler / Aave-style consumers.

README includes two operational preconditions for try/catch consumers
like Everst: no same-asset fallback that would mask pause reverts,
and consumer.maxPriceAge >= adapter.maxAge so internal staleness
surfaces.

SPEC.md: 607 lines (was 513)
README.md: 148 lines (was 124)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>