### PR TITLE
feat: ST0xPriceOracle signed multi-pair price store + MorphoPairOracle adapter

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,24 @@ two constraints, or the pause feature is silently defeated:
    loses the layered staleness signal. Set consumer staleness as a strict
    upper bound on adapter staleness.
 
+## Signed-Price Stack
+
+Alongside the DIA stack, the repo ships a publisher-signed price stack for
+Morpho Blue markets:
+
+- **`ST0xPriceOracle`** — singleton multi-pair price store behind a beacon
+  proxy. Pair ids are deterministic (`keccak256(abi.encodePacked(base, quote))`,
+  no registration); values are opaque `uint256`s whose scaling belongs to the
+  publisher. `updatePrice` is permissionless — a global publisher's EIP-712
+  signature authorises each update, replay-protected by a strict per-pair
+  timestamp inequality (stale payloads no-op, future-dated payloads revert).
+  The EIP-712 domain deliberately binds name + version only, so one signed
+  payload serves every chain the oracle is deployed on. Global `signer` /
+  `timeout` rotate via `ORACLE_ADMIN_ROLE`-gated setters.
+- **`MorphoPairOracle`** — thin beacon-proxied adapter exposing one pair on
+  the central store through Morpho Blue's `IOracle.price()`; one shared
+  beacon upgrade retargets every deployed adapter at once.
+
 ## Setup
 
 This project uses Nix flakes for a reproducible toolchain.
@@ -128,7 +146,9 @@ forge fmt --check        # check formatting
 src/
 ├── concrete/
 │   ├── oracle/
-│   │   └── DIAVaultOracle.sol
+│   │   ├── DIAVaultOracle.sol
+│   │   ├── ST0xPriceOracle.sol
+│   │   └── MorphoPairOracle.sol
 │   ├── wrapper/
 │   │   └── PausableOracleWrapper.sol
 │   └── deploy/
@@ -137,7 +157,8 @@ src/
 │       └── DIAOracleUnifiedDeployer.sol
 ├── interface/
 │   ├── IDIAOracleV2.sol         (vendored DIA Data Association's published interface)
-│   └── IAggregatorV2V3.sol      (vendored Chainlink shape)
+│   ├── IAggregatorV2V3.sol      (vendored Chainlink shape)
+│   └── IOracle.sol              (vendored Morpho Blue oracle shape)
 └── lib/
     └── LibCorporateActionsPause.sol
 test/

--- a/foundry.toml
+++ b/foundry.toml
@@ -23,6 +23,7 @@ remappings = [
 [dependencies]
 forge-std = "1.16.1"
 "@openzeppelin-contracts" = "5.6.1"
+"@openzeppelin-contracts-upgradeable" = "5.6.1"
 "rain-factory" = "0.1.1"
 "rain-math-float" = "0.1.1"
 "rain-intorastring" = "0.1.0"

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,5 @@
 @openzeppelin-contracts-5.6.1/=dependencies/@openzeppelin-contracts-5.6.1/
+@openzeppelin-contracts-upgradeable-5.6.1/=dependencies/@openzeppelin-contracts-upgradeable-5.6.1/
 forge-std-1.16.1/=dependencies/forge-std-1.16.1/
 rain-factory-0.1.1/=dependencies/rain-factory-0.1.1/
 rain-intorastring-0.1.0/=dependencies/rain-intorastring-0.1.0/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -6,6 +6,13 @@ checksum = "a3b6bc661be858c7c27f60a1708cbebe8c71034b4cc1e9fe270d0a05b069352f"
 integrity = "bce03af7ada1eee21a7fff393f238bcd7cd75a022a4db55ffb6b0dbb32433d35"
 
 [[dependencies]]
+name = "@openzeppelin-contracts-upgradeable"
+version = "5.6.1"
+url = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts-upgradeable/5_6_1_15-03-2026_09:19:56_contracts-upgradeable.zip"
+checksum = "f6257dbc993c2499fe08fdc93f66e12459fe3458ee62ce716b92e1d95ee0b504"
+integrity = "2f539b6241258fc3c127c97225b3cb1b5e9225e422d2c1cb233c52a6f5c29002"
+
+[[dependencies]]
 name = "forge-std"
 version = "1.16.1"
 url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_16_1_08-05-2026_08:51:16_forge-std-1.16.zip"
@@ -32,6 +39,13 @@ version = "0.1.1"
 url = "https://soldeer-revisions.s3.amazonaws.com/rain-math-float/0_1_1_13-05-2026_13:48:34_rain.math.zip"
 checksum = "322956f272ae3073ee02b0e7301b8834f08f2de62bcd6c309c44e946d7cd7056"
 integrity = "dccdd4406a37db6af690872b805084a7dbe5211c57961a61ef083a7912ddbdc9"
+
+[[dependencies]]
+name = "rain-tofu-erc20-decimals"
+version = "0.1.1"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-tofu-erc20-decimals/0_1_1_12-05-2026_15:44:19_rain.tofu.zip"
+checksum = "2a48a362ac80a85a8792492fcaf943a86a95009a8aeaced3b50554bbed1e5874"
+integrity = "9e1fccf893dd0d90aeb445c78f9eee3904bc50287ff1da30b954508f18412cd2"
 
 [[dependencies]]
 name = "rain-vats"

--- a/src/concrete/oracle/MorphoPairOracle.sol
+++ b/src/concrete/oracle/MorphoPairOracle.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Initializable} from "@openzeppelin-contracts-upgradeable-5.6.1/proxy/utils/Initializable.sol";
+
+import {IOracle} from "src/interface/IOracle.sol";
+import {ST0xPriceOracle} from "src/concrete/oracle/ST0xPriceOracle.sol";
+
+/// @title MorphoPairOracle
+/// @notice Thin adapter binding one Morpho Blue market to one pair on the
+/// central `ST0xPriceOracle`. It is literally the interface: `price()`
+/// forwards `iCentral.price(sPairId)` verbatim — scaling, staleness policy,
+/// signer rotation and update mechanics all live on the central oracle.
+///
+/// Beacon-proxy implementation: every market's adapter is a `BeaconProxy`
+/// over one shared `UpgradeableBeacon`, so upgrading the beacon retargets
+/// ALL deployed adapters at once. The central oracle is an implementation
+/// immutable — it is chain-constant and shared by every proxy, so it lives
+/// in code, not in per-proxy storage. Only the per-market `sPairId` is
+/// proxy storage, set once in `initialize`.
+contract MorphoPairOracle is Initializable, IOracle {
+    /// @notice The central multi-pair price store this adapter reads —
+    /// chain-constant, shared by all beacon proxies, hence an
+    /// implementation immutable.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    ST0xPriceOracle public immutable iCentral;
+
+    /// @notice The pair this adapter forwards, on `iCentral`'s canonical
+    /// `pairId(base, quote)` derivation.
+    bytes32 public sPairId;
+
+    error ZeroCentral();
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(ST0xPriceOracle central) {
+        if (address(central) == address(0)) revert ZeroCentral();
+        iCentral = central;
+        _disableInitializers();
+    }
+
+    /// @notice Initialise one beacon proxy with the pair it forwards.
+    function initialize(bytes32 pairId) external initializer {
+        sPairId = pairId;
+    }
+
+    /// @inheritdoc IOracle
+    function price() external view returns (uint256) {
+        return iCentral.price(sPairId);
+    }
+}

--- a/src/concrete/oracle/ST0xPriceOracle.sol
+++ b/src/concrete/oracle/ST0xPriceOracle.sol
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Initializable} from "@openzeppelin-contracts-upgradeable-5.6.1/proxy/utils/Initializable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin-contracts-upgradeable-5.6.1/access/AccessControlUpgradeable.sol";
+import {ECDSA} from "@openzeppelin-contracts-5.6.1/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin-contracts-5.6.1/utils/cryptography/MessageHashUtils.sol";
+
+/// @title ST0xPriceOracle
+/// @notice Singleton multi-pair price store. Lives behind a beacon proxy:
+/// Initializable + AccessControl with ERC-7201 namespaced storage.
+///
+/// There is NO pair registration: a pair either has a stored price or it
+/// doesn't. Pair ids are deterministic —
+/// `keccak256(abi.encodePacked(baseToken, quoteToken))`, exposed as the
+/// `pairId` pure helper — and the first `updatePrice` on a brand-new pair
+/// simply works. The publisher key (`signer`) and the staleness bound
+/// (`timeout`) are GLOBAL, shared by every pair, and rotated via two
+/// separate role-gated setters (separate functions deliberately, so a
+/// signer rotation can never race a timeout change in one calldata blob).
+///
+/// Price VALUES are opaque `uint256`s: scaling and semantics belong
+/// entirely to the publisher / consumer of each pair. Each pair's publisher
+/// decides what its values mean; this contract never interprets them.
+///
+/// `updatePrice` is PERMISSIONLESS — the global publisher's EIP-712
+/// signature is what authorises an update, not the caller. Replay
+/// protection is the STRICT per-pair timestamp inequality: an update
+/// applies only if its timestamp is strictly newer than the stored one. A
+/// not-strictly-newer payload is a NO-OP that returns `false` rather than a
+/// revert, so callers may push a signed price in the same transaction that
+/// consumes it without risking a brick on a lost race. An invalid signature
+/// on an otherwise-fresh payload is malformed input and reverts.
+///
+/// CROSS-CHAIN REPLAY IS DELIBERATE: the EIP-712 domain binds name +
+/// version ONLY — no chainId, no verifyingContract — and there is no nonce,
+/// so the same signed price payload is valid on every deployment sharing
+/// the global signer. One publisher signature fans out to every chain the
+/// oracle is deployed on; that is a feature for multi-chain deployment, not
+/// an oversight.
+///
+/// Roles:
+///  - `DEFAULT_ADMIN_ROLE` — role administration only (granted to `admin`
+///    at `initialize`).
+///  - `ORACLE_ADMIN_ROLE` — `setSigner` / `setTimeout`.
+contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
+    bytes32 public constant ORACLE_ADMIN_ROLE = keccak256("ORACLE_ADMIN");
+
+    /// @notice EIP-712 typehash binding (pairId, price, timestamp). No
+    /// nonce — replay protection is the strict timestamp inequality in
+    /// `updatePrice`.
+    bytes32 public constant PRICE_UPDATE_TYPEHASH =
+        keccak256("PriceUpdate(bytes32 pairId,uint256 price,uint256 timestamp)");
+
+    /// @dev The EIP-712 domain separator. The domain deliberately omits
+    /// chainId and verifyingContract so a signed price replays across every
+    /// chain / deployment (see contract NatSpec):
+    /// keccak256(abi.encode(
+    ///     keccak256("EIP712Domain(string name,string version)"),
+    ///     keccak256("ST0xPriceOracle"),
+    ///     keccak256("1")
+    /// ))
+    bytes32 private constant DOMAIN_SEPARATOR = 0x661a9d4f8ddbbd7ecb90573d81a96060fc99c958049c913cf71722ddcc8ddd48;
+
+    /// @dev Latest accepted price state for one pair.
+    struct PricePoint {
+        uint256 price;
+        uint256 timestamp;
+    }
+
+    /// @custom:storage-location erc7201:st0x.priceoracle.main
+    struct MainStorage {
+        // ---- global configuration (setSigner / setTimeout) ----
+        // Publisher key whose ECDSA signature authorises every price update.
+        address signer;
+        // Maximum allowed staleness on `price()` before it reverts.
+        uint64 timeout;
+        // ---- per-pair price state (updatePrice) ----
+        mapping(bytes32 pairId => PricePoint) prices;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("st0x.priceoracle.main")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant MAIN_STORAGE_LOCATION = 0x8bea1968915949cd5f395bf014546362fbf876c96d338f9e38ecadb2c70bcf00;
+
+    function _main() private pure returns (MainStorage storage $) {
+        assembly ("memory-safe") {
+            $.slot := MAIN_STORAGE_LOCATION
+        }
+    }
+
+    error ZeroAdmin();
+    error ZeroSigner();
+    error PriceUnset(bytes32 pairId);
+    error PriceStale(bytes32 pairId);
+    error PriceFuture(bytes32 pairId);
+    error PriceUpdateInvalidSignature(bytes32 pairId);
+
+    event SignerSet(address signer);
+    event TimeoutSet(uint64 timeout);
+    event PriceUpdated(bytes32 indexed pairId, uint256 price, uint256 timestamp);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initialise the singleton. `admin` receives
+    /// `DEFAULT_ADMIN_ROLE` (role administration only — grant
+    /// `ORACLE_ADMIN_ROLE` separately to whoever rotates config). The
+    /// initial global signer and timeout are set here and announced through
+    /// the same events the setters emit.
+    function initialize(address admin, address signer_, uint64 timeout_) external initializer {
+        if (admin == address(0)) revert ZeroAdmin();
+        if (signer_ == address(0)) revert ZeroSigner();
+        __AccessControl_init();
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+
+        MainStorage storage $ = _main();
+        $.signer = signer_;
+        $.timeout = timeout_;
+        emit SignerSet(signer_);
+        emit TimeoutSet(timeout_);
+    }
+
+    // ------------------------------------------------------------------ //
+    //                        Global configuration                        //
+    // ------------------------------------------------------------------ //
+
+    /// @notice Rotate the GLOBAL publisher key. Deliberately a separate
+    /// function from `setTimeout` so the two config axes can never race
+    /// each other inside one calldata blob.
+    function setSigner(address newSigner) external onlyRole(ORACLE_ADMIN_ROLE) {
+        if (newSigner == address(0)) revert ZeroSigner();
+        _main().signer = newSigner;
+        emit SignerSet(newSigner);
+    }
+
+    /// @notice Set the GLOBAL staleness bound applied by `price()`.
+    function setTimeout(uint64 newTimeout) external onlyRole(ORACLE_ADMIN_ROLE) {
+        _main().timeout = newTimeout;
+        emit TimeoutSet(newTimeout);
+    }
+
+    // ------------------------------------------------------------------ //
+    //                            Price updates                           //
+    // ------------------------------------------------------------------ //
+
+    /// @notice The canonical pair id: base token first, quote token second,
+    /// plain concatenation. Deterministic — no registration step exists;
+    /// consumers and publishers derive the same id independently.
+    function pairId(address baseToken, address quoteToken) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(baseToken, quoteToken));
+    }
+
+    /// @notice Push a signed price for a pair. Open — anyone may submit;
+    /// the global publisher's EIP-712 signature over
+    /// (pairId, price, timestamp) is what authorises. No registration is
+    /// required: the first update on a brand-new pair works as-is.
+    /// @return applied `true` if the update was strictly newer and was
+    /// stored (a `PriceUpdated` event was emitted); `false` if the payload
+    /// was not strictly newer than the stored timestamp — a deliberate
+    /// NO-OP, so a lost update race can never revert a surrounding call. A
+    /// strictly-newer payload timestamped in the FUTURE (`> block.timestamp`)
+    /// reverts `PriceFuture` — it would strand `price()` behind an arithmetic
+    /// underflow. An invalid signature on an otherwise-valid payload is
+    /// malformed input and reverts `PriceUpdateInvalidSignature`.
+    function updatePrice(bytes32 id, uint256 newPrice, uint256 newTimestamp, bytes calldata signature)
+        external
+        returns (bool applied)
+    {
+        MainStorage storage $ = _main();
+        PricePoint storage stored = $.prices[id];
+
+        // Not strictly newer → no-op, not a revert. Checked BEFORE the
+        // signature so stale replays are cheap and never brick a caller.
+        if (newTimestamp <= stored.timestamp) {
+            return false;
+        }
+
+        // A future timestamp is out-of-model input: `price()` computes
+        // `block.timestamp - stored.timestamp`, which would underflow (revert
+        // with an arithmetic panic) for any stored timestamp ahead of the
+        // block clock — stranding the pair for every consumer until wall-clock
+        // catches up, and blocking every honest lower-timestamped update in
+        // between. Reject it rather than admit an un-serveable price. Miner
+        // drift on block.timestamp only moves the accept/reject boundary by
+        // seconds and cannot forge a signature, so the comparison is safe.
+        // slither-disable-next-line timestamp
+        if (newTimestamp > block.timestamp) {
+            revert PriceFuture(id);
+        }
+
+        bytes32 structHash = keccak256(abi.encode(PRICE_UPDATE_TYPEHASH, id, newPrice, newTimestamp));
+        if (ECDSA.recover(MessageHashUtils.toTypedDataHash(DOMAIN_SEPARATOR, structHash), signature) != $.signer) {
+            revert PriceUpdateInvalidSignature(id);
+        }
+
+        stored.price = newPrice;
+        stored.timestamp = newTimestamp;
+        emit PriceUpdated(id, newPrice, newTimestamp);
+        return true;
+    }
+
+    // ------------------------------------------------------------------ //
+    //                            Read views                              //
+    // ------------------------------------------------------------------ //
+
+    /// @notice The stored price for a pair. Reverts `PriceUnset` when no
+    /// update has ever landed (stored timestamp 0) and `PriceStale` when
+    /// the stored timestamp has aged past the global `timeout`. Value
+    /// semantics are the publisher's — this contract treats them as opaque.
+    function price(bytes32 id) external view returns (uint256) {
+        MainStorage storage $ = _main();
+        PricePoint storage stored = $.prices[id];
+        if (stored.timestamp == 0) revert PriceUnset(id);
+        // Staleness is measured against block time by design — miner drift
+        // is seconds against a timeout measured in minutes/hours.
+        // slither-disable-next-line timestamp
+        if (block.timestamp - stored.timestamp > $.timeout) revert PriceStale(id);
+        return stored.price;
+    }
+
+    /// @notice The global publisher key.
+    function signer() external view returns (address) {
+        return _main().signer;
+    }
+
+    /// @notice The global staleness bound applied by `price()`.
+    function timeout() external view returns (uint64) {
+        return _main().timeout;
+    }
+
+    /// @notice Raw stored price state (no staleness check) — for publishers
+    /// sizing their next timestamp and for off-chain monitoring.
+    function pairPrice(bytes32 id) external view returns (uint256 storedPrice, uint256 storedTimestamp) {
+        PricePoint storage stored = _main().prices[id];
+        return (stored.price, stored.timestamp);
+    }
+
+    /// @notice EIP-712 domain separator — used by publishers / tests. A
+    /// constant: the domain binds name + version only, so signed payloads
+    /// replay across chains and deployments by design.
+    function domainSeparator() external pure returns (bytes32) {
+        return DOMAIN_SEPARATOR;
+    }
+}

--- a/src/interface/IOracle.sol
+++ b/src/interface/IOracle.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @title IOracle
+/// @notice Morpho Blue oracle interface, vendored from Morpho's published
+/// shape.
+/// @dev `price()` returns the price of 1 unit of collateral in loan token,
+/// scaled by `1e36 * 10^loanDecimals / 10^collateralDecimals`.
+interface IOracle {
+    function price() external view returns (uint256);
+}

--- a/test/mocks/MorphoPairOracleV2.sol
+++ b/test/mocks/MorphoPairOracleV2.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {MorphoPairOracle} from "src/concrete/oracle/MorphoPairOracle.sol";
+import {ST0xPriceOracle} from "src/concrete/oracle/ST0xPriceOracle.sol";
+
+/// @title MorphoPairOracleV2
+/// @dev Trivial V2 implementation used only to prove that upgrading the
+/// shared adapter beacon retargets every deployed MorphoPairOracle proxy
+/// at once.
+contract MorphoPairOracleV2 is MorphoPairOracle {
+    constructor(ST0xPriceOracle central) MorphoPairOracle(central) {}
+
+    function version() external pure returns (uint256) {
+        return 2;
+    }
+}

--- a/test/src/concrete/oracle/MorphoPairOracle.t.sol
+++ b/test/src/concrete/oracle/MorphoPairOracle.t.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+
+import {UpgradeableBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/UpgradeableBeacon.sol";
+import {BeaconProxy} from "@openzeppelin-contracts-5.6.1/proxy/beacon/BeaconProxy.sol";
+import {Initializable} from "@openzeppelin-contracts-upgradeable-5.6.1/proxy/utils/Initializable.sol";
+
+import {ST0xPriceOracle} from "src/concrete/oracle/ST0xPriceOracle.sol";
+import {MorphoPairOracle} from "src/concrete/oracle/MorphoPairOracle.sol";
+import {MorphoPairOracleV2} from "test/mocks/MorphoPairOracleV2.sol";
+
+/// @title MorphoPairOracleTest
+/// @notice Unit coverage for the `MorphoPairOracle` beacon-proxied
+/// forwarding adapter: verbatim forwarding of the central `price(pairId)`
+/// (reverts included), constructor / initializer guards, and the shared
+/// beacon upgrade retargeting every deployed adapter proxy at once.
+contract MorphoPairOracleTest is Test {
+    uint256 constant SIGNER_PK = uint256(keccak256("st0x.price-oracle.signer.test"));
+    address SIGNER;
+
+    address constant ADMIN = address(0xC0DE);
+
+    address constant BASE_TOKEN = address(0xAAA1);
+    address constant QUOTE_TOKEN = address(0xBBB2);
+    uint64 constant TIMEOUT = 1 hours;
+
+    bytes32 PAIR_A;
+    bytes32 constant PAIR_UNKNOWN = keccak256("pair-unknown");
+
+    ST0xPriceOracle oracle;
+    UpgradeableBeacon adapterBeacon;
+
+    function setUp() public {
+        SIGNER = vm.addr(SIGNER_PK);
+        // Same shape as production: implementation behind a beacon proxy.
+        ST0xPriceOracle impl = new ST0xPriceOracle();
+        UpgradeableBeacon beacon = new UpgradeableBeacon(address(impl), ADMIN);
+        oracle = ST0xPriceOracle(
+            address(
+                new BeaconProxy(address(beacon), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, SIGNER, TIMEOUT)))
+            )
+        );
+
+        // The adapter beacon, shared by every MorphoPairOracle proxy.
+        MorphoPairOracle adapterImpl = new MorphoPairOracle(oracle);
+        adapterBeacon = new UpgradeableBeacon(address(adapterImpl), ADMIN);
+
+        PAIR_A = oracle.pairId(BASE_TOKEN, QUOTE_TOKEN);
+    }
+
+    /// @notice The adapter is literally the interface: `price()` forwards
+    /// `iCentral.price(sPairId)` verbatim, unset/staleness reverts included.
+    function test_MorphoPairOracle_ForwardsVerbatim() public {
+        MorphoPairOracle adapter = _deployAdapter(PAIR_A);
+        assertEq(address(adapter.iCentral()), address(oracle), "central wired");
+        assertEq(adapter.sPairId(), PAIR_A, "pairId wired");
+
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUnset.selector, PAIR_A));
+        adapter.price();
+
+        _push(PAIR_A, 42e18, block.timestamp);
+        assertEq(adapter.price(), 42e18, "forwards the central price");
+
+        vm.warp(block.timestamp + TIMEOUT + 1);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceStale.selector, PAIR_A));
+        adapter.price();
+    }
+
+    function test_MorphoPairOracle_ZeroCentral_Reverts() public {
+        vm.expectRevert(MorphoPairOracle.ZeroCentral.selector);
+        new MorphoPairOracle(ST0xPriceOracle(address(0)));
+    }
+
+    function test_MorphoPairOracle_InitializeOnlyOnce() public {
+        MorphoPairOracle adapter = _deployAdapter(PAIR_A);
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        adapter.initialize(PAIR_UNKNOWN);
+    }
+
+    function test_MorphoPairOracle_ImplementationInitializersDisabled() public {
+        MorphoPairOracle impl = new MorphoPairOracle(oracle);
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        impl.initialize(PAIR_A);
+    }
+
+    /// @notice One shared-beacon upgrade retargets EVERY deployed adapter
+    /// proxy at once, with per-proxy state (`sPairId`) and the
+    /// implementation immutable (`iCentral`) surviving the upgrade.
+    function test_MorphoPairOracle_BeaconUpgradeRetargetsAllProxies() public {
+        bytes32 pairB = oracle.pairId(QUOTE_TOKEN, BASE_TOKEN);
+        MorphoPairOracle adapterA = _deployAdapter(PAIR_A);
+        MorphoPairOracle adapterB = _deployAdapter(pairB);
+
+        // V1 has no `version()` — both proxies revert on it pre-upgrade.
+        (bool okBefore,) = address(adapterA).staticcall(abi.encodeWithSignature("version()"));
+        assertFalse(okBefore, "V1 has no version()");
+
+        // One beacon upgrade...
+        MorphoPairOracleV2 v2Impl = new MorphoPairOracleV2(oracle);
+        vm.prank(ADMIN);
+        adapterBeacon.upgradeTo(address(v2Impl));
+
+        // ...retargets ALL deployed adapters.
+        assertEq(MorphoPairOracleV2(address(adapterA)).version(), 2, "adapter A retargeted");
+        assertEq(MorphoPairOracleV2(address(adapterB)).version(), 2, "adapter B retargeted");
+
+        // Per-proxy state survives the upgrade and forwarding still works.
+        assertEq(adapterA.sPairId(), PAIR_A, "adapter A proxy state intact");
+        assertEq(adapterB.sPairId(), pairB, "adapter B proxy state intact");
+        assertEq(address(adapterA.iCentral()), address(oracle), "central immutable intact");
+        _push(PAIR_A, 42e18, block.timestamp);
+        assertEq(adapterA.price(), 42e18, "still forwards the central price");
+    }
+
+    // -------- Helpers --------
+
+    function _deployAdapter(bytes32 id) internal returns (MorphoPairOracle) {
+        return MorphoPairOracle(
+            address(new BeaconProxy(address(adapterBeacon), abi.encodeCall(MorphoPairOracle.initialize, (id))))
+        );
+    }
+
+    function _digest(bytes32 id, uint256 price, uint256 timestamp) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(oracle.PRICE_UPDATE_TYPEHASH(), id, price, timestamp));
+        return keccak256(abi.encodePacked("\x19\x01", oracle.domainSeparator(), structHash));
+    }
+
+    function _sign(bytes32 id, uint256 price, uint256 timestamp) internal view returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PK, _digest(id, price, timestamp));
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _push(bytes32 id, uint256 price, uint256 timestamp) internal {
+        assertTrue(oracle.updatePrice(id, price, timestamp, _sign(id, price, timestamp)));
+    }
+}

--- a/test/src/concrete/oracle/ST0xPriceOracle.t.sol
+++ b/test/src/concrete/oracle/ST0xPriceOracle.t.sol
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+
+import {UpgradeableBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/UpgradeableBeacon.sol";
+import {BeaconProxy} from "@openzeppelin-contracts-5.6.1/proxy/beacon/BeaconProxy.sol";
+import {Initializable} from "@openzeppelin-contracts-upgradeable-5.6.1/proxy/utils/Initializable.sol";
+import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
+
+import {ST0xPriceOracle} from "src/concrete/oracle/ST0xPriceOracle.sol";
+
+/// @title ST0xPriceOracleTest
+/// @notice Unit coverage for the central multi-pair oracle: global signer /
+/// timeout config, the strict-timestamp no-op-vs-revert semantics of
+/// `updatePrice` (no registration, no nonce), `price()` unset/staleness
+/// reverts, and the deterministic `pairId` derivation.
+contract ST0xPriceOracleTest is Test {
+    uint256 constant SIGNER_PK = uint256(keccak256("st0x.price-oracle.signer.test"));
+    address SIGNER;
+
+    address constant ADMIN = address(0xC0DE);
+    address constant ORACLE_ADMIN = address(0xADDD);
+    address constant RANDO = address(0xF00D);
+
+    address constant BASE_TOKEN = address(0xAAA1);
+    address constant QUOTE_TOKEN = address(0xBBB2);
+    uint64 constant TIMEOUT = 1 hours;
+
+    bytes32 PAIR_A;
+    bytes32 constant PAIR_UNKNOWN = keccak256("pair-unknown");
+
+    ST0xPriceOracle oracle;
+    UpgradeableBeacon beacon;
+
+    function setUp() public {
+        SIGNER = vm.addr(SIGNER_PK);
+        // Same shape as production: implementation behind a beacon proxy.
+        ST0xPriceOracle impl = new ST0xPriceOracle();
+        beacon = new UpgradeableBeacon(address(impl), ADMIN);
+        oracle = ST0xPriceOracle(
+            address(
+                new BeaconProxy(address(beacon), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, SIGNER, TIMEOUT)))
+            )
+        );
+        // Cache the role hash first — the `external view` call would
+        // otherwise consume the single `vm.prank`.
+        bytes32 oracleAdminRole = oracle.ORACLE_ADMIN_ROLE();
+        vm.prank(ADMIN);
+        oracle.grantRole(oracleAdminRole, ORACLE_ADMIN);
+
+        PAIR_A = oracle.pairId(BASE_TOKEN, QUOTE_TOKEN);
+    }
+
+    // -------- pairId: deterministic derivation --------
+
+    /// @notice `pairId` is `keccak256(abi.encodePacked(base, quote))` —
+    /// base first, quote second, plain concatenation.
+    function test_PairId_IsPackedKeccakBaseThenQuote() public view {
+        assertEq(
+            oracle.pairId(BASE_TOKEN, QUOTE_TOKEN),
+            keccak256(abi.encodePacked(BASE_TOKEN, QUOTE_TOKEN)),
+            "packed keccak, base first"
+        );
+        assertTrue(
+            oracle.pairId(BASE_TOKEN, QUOTE_TOKEN) != oracle.pairId(QUOTE_TOKEN, BASE_TOKEN), "order is significant"
+        );
+    }
+
+    // -------- initialize --------
+
+    function test_Initialize_SetsGlobalsAndEmits() public {
+        ST0xPriceOracle impl = new ST0xPriceOracle();
+        UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
+        // Initial values arrive as initialize params but are announced
+        // through the same events the setters emit.
+        vm.expectEmit();
+        emit ST0xPriceOracle.SignerSet(SIGNER);
+        vm.expectEmit();
+        emit ST0xPriceOracle.TimeoutSet(TIMEOUT);
+        ST0xPriceOracle fresh = ST0xPriceOracle(
+            address(new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, SIGNER, TIMEOUT))))
+        );
+        assertEq(fresh.signer(), SIGNER, "global signer set");
+        assertEq(fresh.timeout(), TIMEOUT, "global timeout set");
+    }
+
+    function test_Initialize_ZeroAdmin_Reverts() public {
+        ST0xPriceOracle impl = new ST0xPriceOracle();
+        UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
+        vm.expectRevert(ST0xPriceOracle.ZeroAdmin.selector);
+        new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (address(0), SIGNER, TIMEOUT)));
+    }
+
+    function test_Initialize_ZeroSigner_Reverts() public {
+        ST0xPriceOracle impl = new ST0xPriceOracle();
+        UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
+        vm.expectRevert(ST0xPriceOracle.ZeroSigner.selector);
+        new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, address(0), TIMEOUT)));
+    }
+
+    function test_Initialize_OnlyOnce() public {
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        oracle.initialize(RANDO, SIGNER, TIMEOUT);
+    }
+
+    // -------- updatePrice: applied vs no-op vs revert --------
+
+    /// @notice There is NO pair registration — the very first update on a
+    /// brand-new pair just works (stored timestamp starts at 0 and any real
+    /// timestamp is strictly newer).
+    function test_UpdatePrice_FirstUpdateOnBrandNewPair_AppliesAndEmits() public {
+        vm.expectEmit(true, false, false, true, address(oracle));
+        emit ST0xPriceOracle.PriceUpdated(PAIR_A, 42e18, block.timestamp);
+        bool applied = oracle.updatePrice(PAIR_A, 42e18, block.timestamp, _sign(PAIR_A, 42e18, block.timestamp));
+        assertTrue(applied, "fresh update should apply");
+
+        (uint256 storedPrice, uint256 storedTs) = oracle.pairPrice(PAIR_A);
+        assertEq(storedPrice, 42e18, "price stored");
+        assertEq(storedTs, block.timestamp, "timestamp stored");
+        assertEq(oracle.price(PAIR_A), 42e18, "price() serves stored value");
+    }
+
+    /// @notice A timestamp EQUAL to stored is not strictly newer — a NO-OP,
+    /// not a revert: no state change, no event, even with a garbage
+    /// signature (freshness is checked before the signature).
+    function test_UpdatePrice_EqualTimestamp_NoOpNotRevert() public {
+        _push(PAIR_A, 42e18, block.timestamp);
+
+        vm.recordLogs();
+        bool applied = oracle.updatePrice(PAIR_A, 99e18, block.timestamp, hex"deadbeef");
+        assertFalse(applied, "equal timestamp must be a no-op");
+        assertEq(vm.getRecordedLogs().length, 0, "no event on a no-op");
+
+        (uint256 storedPrice, uint256 storedTs) = oracle.pairPrice(PAIR_A);
+        assertEq(storedPrice, 42e18, "price unchanged");
+        assertEq(storedTs, block.timestamp, "timestamp unchanged");
+    }
+
+    /// @notice A timestamp older than stored is equally a NO-OP.
+    function test_UpdatePrice_OlderTimestamp_NoOpNotRevert() public {
+        vm.warp(block.timestamp + 100);
+        _push(PAIR_A, 42e18, block.timestamp);
+
+        vm.recordLogs();
+        bool applied = oracle.updatePrice(PAIR_A, 99e18, block.timestamp - 50, hex"deadbeef");
+        assertFalse(applied, "older timestamp must be a no-op");
+        assertEq(vm.getRecordedLogs().length, 0, "no event on a no-op");
+
+        (uint256 storedPrice, uint256 storedTs) = oracle.pairPrice(PAIR_A);
+        assertEq(storedPrice, 42e18, "price unchanged");
+        assertEq(storedTs, block.timestamp, "timestamp unchanged");
+    }
+
+    /// @notice An invalid signature (checked against the GLOBAL signer) on
+    /// a strictly-newer payload is malformed input — that DOES revert.
+    function test_UpdatePrice_InvalidSignatureOnFreshTimestamp_Reverts() public {
+        uint256 wrongPk = uint256(keccak256("wrong-signer"));
+        bytes32 digest = _digest(PAIR_A, 42e18, block.timestamp);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, digest);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUpdateInvalidSignature.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 42e18, block.timestamp, abi.encodePacked(r, s, v));
+    }
+
+    /// @notice `updatePrice` is permissionless — any caller with a validly
+    /// signed fresh payload succeeds.
+    function test_UpdatePrice_Permissionless() public {
+        bytes memory sig = _sign(PAIR_A, 42e18, block.timestamp);
+        vm.prank(RANDO);
+        assertTrue(oracle.updatePrice(PAIR_A, 42e18, block.timestamp, sig), "rando can push a signed price");
+    }
+
+    /// @notice DELIBERATE PROPERTY: with no nonce and an EIP-712 domain
+    /// that binds name + version only (no chainId, no verifyingContract),
+    /// the exact same signed payload applies on a different chain and a
+    /// different oracle deployment — one publisher signature fans out to a
+    /// multi-chain deployment.
+    function test_UpdatePrice_CrossChainReplay_SameSignatureAppliesOnOtherDeployment() public {
+        bytes memory sig = _sign(PAIR_A, 42e18, block.timestamp);
+        assertTrue(oracle.updatePrice(PAIR_A, 42e18, block.timestamp, sig), "applies on the home chain");
+
+        // A second deployment (fresh proxy → different verifyingContract)
+        // on a different chainId, sharing the global signer.
+        vm.chainId(424242);
+        ST0xPriceOracle impl = new ST0xPriceOracle();
+        UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
+        ST0xPriceOracle other = ST0xPriceOracle(
+            address(new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, SIGNER, TIMEOUT))))
+        );
+        assertTrue(other.updatePrice(PAIR_A, 42e18, block.timestamp, sig), "same signature replays cross-chain");
+        assertEq(other.price(PAIR_A), 42e18, "replayed price served");
+    }
+
+    /// @notice A payload timestamped in the FUTURE (ahead of block.timestamp)
+    /// must be rejected. Accepting it strands the pair: `price()` computes
+    /// `block.timestamp - stored.timestamp`, which underflows (arithmetic
+    /// panic) for a future stored timestamp — bricking every consumer read
+    /// until wall-clock catches up, and blocking every honest
+    /// lower-timestamped update in the meantime. The signer is trusted, but
+    /// a clock-skewed / buggy publisher signing `now + delta` is a realistic
+    /// operational fault, so the contract must reject it rather than admit
+    /// an un-serveable price.
+    function test_UpdatePrice_FutureTimestamp_Rejected() public {
+        uint256 future = block.timestamp + 1 hours;
+        bytes memory sig = _sign(PAIR_A, 42e18, future);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceFuture.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 42e18, future, sig);
+
+        // The pair stays unset — nothing was stored, so price() reverts the
+        // normal unset revert (NOT an arithmetic panic).
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUnset.selector, PAIR_A));
+        oracle.price(PAIR_A);
+    }
+
+    /// @notice The boundary: a payload timestamped at EXACTLY block.timestamp
+    /// is not in the future and applies. (`newTimestamp <= block.timestamp`
+    /// is the accepted region.)
+    function test_UpdatePrice_CurrentTimestamp_Applies() public {
+        assertTrue(
+            oracle.updatePrice(PAIR_A, 42e18, block.timestamp, _sign(PAIR_A, 42e18, block.timestamp)),
+            "now is not the future"
+        );
+        assertEq(oracle.price(PAIR_A), 42e18, "current-timestamp price is servable");
+    }
+
+    // -------- constant-derivation pins (convention-vs-enforcement) --------
+
+    /// @notice `DOMAIN_SEPARATOR` is a hardcoded hex literal — pin it to its
+    /// normative EIP-712 derivation so a wrong literal can never ship
+    /// undetected. Recomputed independently here (not read off the contract).
+    function test_DomainSeparator_MatchesNormativeDerivation() public view {
+        bytes32 expected = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version)"), keccak256("ST0xPriceOracle"), keccak256("1")
+            )
+        );
+        assertEq(oracle.domainSeparator(), expected, "domain separator must equal its EIP-712 derivation");
+    }
+
+    /// @notice The `PRICE_UPDATE_TYPEHASH` matches its normative string.
+    function test_PriceUpdateTypehash_MatchesNormativeDerivation() public view {
+        assertEq(
+            oracle.PRICE_UPDATE_TYPEHASH(),
+            keccak256("PriceUpdate(bytes32 pairId,uint256 price,uint256 timestamp)"),
+            "typehash must equal its EIP-712 struct derivation"
+        );
+    }
+
+    /// @notice The ERC-7201 `MainStorage` slot constant is a hardcoded hex
+    /// literal with no getter. Pin it to the normative derivation by proving
+    /// storage actually lands there: after `initialize`, the first field
+    /// (`signer`) must be readable at the recomputed slot.
+    function test_MainStorageLocation_MatchesErc7201Derivation() public view {
+        bytes32 derived =
+            keccak256(abi.encode(uint256(keccak256("st0x.priceoracle.main")) - 1)) & ~bytes32(uint256(0xff));
+        // signer is the first member of MainStorage → sits exactly at the slot.
+        address storedSigner = address(uint160(uint256(vm.load(address(oracle), derived))));
+        assertEq(storedSigner, oracle.signer(), "MainStorage must be namespaced at the ERC-7201 derived slot");
+    }
+
+    // -------- price(): unset + staleness --------
+
+    /// @notice A pair either has a stored price or it doesn't — an unset
+    /// pair (stored timestamp 0) reverts `PriceUnset`.
+    function test_Price_UnsetPair_Reverts() public {
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUnset.selector, PAIR_UNKNOWN));
+        oracle.price(PAIR_UNKNOWN);
+    }
+
+    function test_Price_RevertsWhenPastGlobalTimeout() public {
+        _push(PAIR_A, 42e18, block.timestamp);
+
+        vm.warp(block.timestamp + TIMEOUT);
+        assertEq(oracle.price(PAIR_A), 42e18, "still fresh at the timeout bound");
+
+        vm.warp(block.timestamp + 1);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceStale.selector, PAIR_A));
+        oracle.price(PAIR_A);
+    }
+
+    // -------- setSigner / setTimeout --------
+
+    /// @notice Rotating the global signer emits `SignerSet`, invalidates
+    /// payloads signed by the old key, and honours the new one. Stored
+    /// price state is untouched.
+    function test_SetSigner_RotatesAndEmits() public {
+        _push(PAIR_A, 42e18, block.timestamp);
+
+        uint256 newPk = uint256(keccak256("rotated-signer"));
+        address newSigner = vm.addr(newPk);
+        vm.expectEmit(address(oracle));
+        emit ST0xPriceOracle.SignerSet(newSigner);
+        vm.prank(ORACLE_ADMIN);
+        oracle.setSigner(newSigner);
+        assertEq(oracle.signer(), newSigner, "signer rotated");
+
+        // Old key no longer authorises a fresh payload...
+        vm.warp(block.timestamp + 1);
+        bytes memory oldKeySig = _sign(PAIR_A, 43e18, block.timestamp);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUpdateInvalidSignature.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 43e18, block.timestamp, oldKeySig);
+
+        // ...the new key does.
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(newPk, _digest(PAIR_A, 43e18, block.timestamp));
+        assertTrue(oracle.updatePrice(PAIR_A, 43e18, block.timestamp, abi.encodePacked(r, s, v)), "new key applies");
+
+        // Rotation preserved the previously stored state until then.
+        assertEq(oracle.price(PAIR_A), 43e18, "state advanced under the new key");
+    }
+
+    function test_SetSigner_RoleGated() public {
+        bytes32 oracleAdminRole = oracle.ORACLE_ADMIN_ROLE();
+        vm.prank(RANDO);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, RANDO, oracleAdminRole)
+        );
+        oracle.setSigner(RANDO);
+    }
+
+    /// @notice `DEFAULT_ADMIN_ROLE` administers roles only — it does NOT
+    /// carry `ORACLE_ADMIN_ROLE`.
+    function test_SetSigner_AdminWithoutOracleAdminRole_Reverts() public {
+        bytes32 oracleAdminRole = oracle.ORACLE_ADMIN_ROLE();
+        vm.prank(ADMIN);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, ADMIN, oracleAdminRole)
+        );
+        oracle.setSigner(RANDO);
+    }
+
+    function test_SetSigner_ZeroSigner_Reverts() public {
+        vm.prank(ORACLE_ADMIN);
+        vm.expectRevert(ST0xPriceOracle.ZeroSigner.selector);
+        oracle.setSigner(address(0));
+    }
+
+    /// @notice Tightening the global timeout emits `TimeoutSet` and
+    /// immediately applies to every pair's `price()`.
+    function test_SetTimeout_UpdatesAndEmits() public {
+        _push(PAIR_A, 42e18, block.timestamp);
+        vm.warp(block.timestamp + 10 minutes);
+        assertEq(oracle.price(PAIR_A), 42e18, "fresh under the 1h timeout");
+
+        vm.expectEmit(address(oracle));
+        emit ST0xPriceOracle.TimeoutSet(5 minutes);
+        vm.prank(ORACLE_ADMIN);
+        oracle.setTimeout(5 minutes);
+        assertEq(oracle.timeout(), 5 minutes, "timeout updated");
+
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceStale.selector, PAIR_A));
+        oracle.price(PAIR_A);
+    }
+
+    function test_SetTimeout_RoleGated() public {
+        bytes32 oracleAdminRole = oracle.ORACLE_ADMIN_ROLE();
+        vm.prank(RANDO);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, RANDO, oracleAdminRole)
+        );
+        oracle.setTimeout(5 minutes);
+    }
+
+    // -------- Helpers --------
+
+    function _digest(bytes32 id, uint256 price, uint256 timestamp) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(oracle.PRICE_UPDATE_TYPEHASH(), id, price, timestamp));
+        return keccak256(abi.encodePacked("\x19\x01", oracle.domainSeparator(), structHash));
+    }
+
+    function _sign(bytes32 id, uint256 price, uint256 timestamp) internal view returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PK, _digest(id, price, timestamp));
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _push(bytes32 id, uint256 price, uint256 timestamp) internal {
+        assertTrue(oracle.updatePrice(id, price, timestamp, _sign(id, price, timestamp)));
+    }
+}


### PR DESCRIPTION
Adds a publisher-signed price stack alongside the existing DIA stack: a central multi-pair price store plus a thin Morpho Blue adapter. Extracted from an internal integration.

## Contracts

### `ST0xPriceOracle` — central multi-pair price store

Singleton behind a beacon proxy (`Initializable` + `AccessControlUpgradeable`, ERC-7201 namespaced storage).

- **No pair registration.** Pair ids are deterministic — `keccak256(abi.encodePacked(baseToken, quoteToken))`, exposed as the `pairId` pure helper — and the first `updatePrice` on a brand-new pair simply works.
- **Opaque values.** Prices are raw `uint256`s; scaling and semantics belong entirely to each pair's publisher/consumer.
- **Permissionless `updatePrice(id, price, timestamp, signature)`.** The global publisher's EIP-712 signature over `(pairId, price, timestamp)` is what authorises an update, not the caller — so callers may push a signed price in the same transaction that consumes it.
- **Strict-timestamp replay defence.** An update applies only if its timestamp is strictly newer than the stored one. A not-strictly-newer payload is a **no-op returning `false`** (never a revert), so a lost update race can't brick a surrounding call. A **future-dated payload reverts `PriceFuture`** — accepting it would strand `price()` behind an arithmetic underflow, blocking every consumer and every honest lower-timestamped update until wall-clock catches up. An invalid signature on an otherwise-fresh payload reverts `PriceUpdateInvalidSignature`.
- **`price(id)` reverts `PriceUnset`** (no update ever landed) **and `PriceStale`** (stored timestamp aged past the global `timeout`). `pairPrice(id)` exposes raw state without the staleness check for publishers and monitoring.
- **Chain-agnostic EIP-712 domain — deliberate.** The domain binds name + version only (no chainId, no verifyingContract) and there is no nonce, so one signed payload is valid on every deployment sharing the global signer. That's the multi-chain fan-out model, not an oversight; it's pinned by a dedicated cross-chain replay test.

**Roles:** `DEFAULT_ADMIN_ROLE` administers roles only; `ORACLE_ADMIN_ROLE` gates the global `setSigner` / `setTimeout` — deliberately two separate functions so a signer rotation can never race a timeout change in one calldata blob.

### `MorphoPairOracle` — Morpho Blue `IOracle` adapter

Thin beacon-proxied adapter binding one Morpho market to one pair: `price()` forwards `iCentral.price(sPairId)` verbatim, reverts included. The central store is an implementation immutable (chain-constant, shared by all proxies); only `sPairId` is per-proxy storage. One shared-beacon upgrade retargets every deployed adapter at once.

Also vendors Morpho Blue's `IOracle` interface (`src/interface/IOracle.sol`).

## Deployment model

Both contracts are beacon-proxy implementations with `_disableInitializers()` in their constructors — deploy an implementation, wrap it in an `UpgradeableBeacon`, and stand up `BeaconProxy` instances initialised via `initialize(...)`, matching the repo's existing beacon pattern.

## Tests

29 new tests across two suites (`test/src/concrete/oracle/`):

- `ST0xPriceOracleTest` (24): deterministic `pairId` derivation, initialize guards/events, applied-vs-no-op-vs-revert `updatePrice` matrix (equal/older timestamp no-ops with garbage signatures, invalid-signature revert, permissionless push, **cross-chain replay of the same signature on a second deployment**, **future-timestamp rejection + exact `block.timestamp` boundary**), constant-derivation pins for the hardcoded domain separator / typehash / ERC-7201 slot, `price()` unset + staleness boundary, signer rotation semantics, role gating (incl. `DEFAULT_ADMIN_ROLE` NOT carrying `ORACLE_ADMIN_ROLE`).
- `MorphoPairOracleTest` (5): verbatim forwarding incl. revert passthrough, constructor/initializer guards, and a shared-beacon upgrade test proving one `upgradeTo` retargets all deployed adapter proxies with per-proxy state and the implementation immutable intact.

## Housekeeping

- New soldeer dep `@openzeppelin-contracts-upgradeable = "5.6.1"` (lock + remappings regenerated via soldeer).
- Adds the missing `LICENSES/MIT.txt` for the vendored `IDIAOracleV2.sol` — `rainix-sol-legal` (reuse lint) was failing on main without it.
- All four rainix tasks pass locally: `rainix-sol-prelude`, `rainix-sol-test` (122/122), `rainix-sol-static` (slither, 0 findings — `timestamp` detector suppressed inline with justifications, matching existing convention), `rainix-sol-legal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MDFiiWV1nmCkCb76mKhhi
