### PR TITLE
test: adversarial mutation-test coverage sweep (15 discriminating tests)

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -14,6 +14,7 @@ path = [
   "soldeer.lock",
   "AGENTS.md",
   "CLAUDE.md",
+  "audit/**",
   "slither.config.json",
 ]
 SPDX-FileCopyrightText = "Copyright (c) 2020 Rain Open Source Software Ltd"

--- a/audit/mutation-test-scans.json
+++ b/audit/mutation-test-scans.json
@@ -1,0 +1,19 @@
+[
+  {
+    "timestamp": "2026-07-24T20:57:17Z",
+    "commit": "31441bb47015b13ab9a8a5e004e601a51522a32e",
+    "publishedTag": null,
+    "commitsAheadOfTag": null,
+    "scope": "whole repo (src/)",
+    "tool": "adversarial-mutation-test",
+    "skillVersion": "0.26.0",
+    "summary": {
+      "behaviours": 141,
+      "existingCoverageValidated": 121,
+      "gapsFilled": 15,
+      "candidates": 0,
+      "confirmed": 0,
+      "filed": []
+    }
+  }
+]

--- a/test/src/concrete/deploy/DIADeployerSaltDerivation.t.sol
+++ b/test/src/concrete/deploy/DIADeployerSaltDerivation.t.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {BeaconProxy} from "@openzeppelin-contracts-5.6.1/proxy/beacon/BeaconProxy.sol";
+import {IDIAOracleV2} from "../../../../src/interface/IDIAOracleV2.sol";
+import {DIAVaultOracle, DIAVaultOracleConfig} from "../../../../src/concrete/oracle/DIAVaultOracle.sol";
+import {
+    DIAVaultOracleBeaconSetDeployer,
+    DIAVaultOracleBeaconSetDeployerConfig
+} from "../../../../src/concrete/deploy/DIAVaultOracleBeaconSetDeployer.sol";
+import {MockDIAOracle} from "../../../mocks/MockDIAOracle.sol";
+import {MockERC4626} from "../../../mocks/MockERC4626.sol";
+import {MockCorporateActions} from "../../../mocks/MockCorporateActions.sol";
+import {ACTION_TYPE_STOCK_SPLIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
+
+/// @title DIADeployerSaltDerivationTest
+/// @notice The DIA beacon-set deployer mints proxies with EMPTY init-code
+/// (`BeaconProxy(..., "")`), so the CREATE2 salt is the SOLE source of address
+/// uniqueness — unlike the Morpho/ST0x deployers whose init-code carries the
+/// config. `keccak256(abi.encode(config))` must therefore fold in EVERY config
+/// field. These tests independently recompute the CREATE2 address from the whole
+/// config and prove that two configs differing in ONLY ONE field (here `symbol`)
+/// land at DISTINCT addresses — catching a salt that silently omits a field.
+contract DIADeployerSaltDerivationTest is Test {
+    DIAVaultOracle internal implementation;
+    MockDIAOracle internal diaOracle;
+    MockERC4626 internal vault;
+    MockCorporateActions internal actions;
+    address internal constant BEACON_OWNER = address(0xBEEF);
+    uint256 internal constant MAX_AGE = 1 hours;
+
+    function setUp() public {
+        implementation = new DIAVaultOracle();
+        diaOracle = new MockDIAOracle();
+        vault = new MockERC4626();
+        actions = new MockCorporateActions();
+        vault.setAsset(address(actions));
+        vm.warp(1_000_000);
+    }
+
+    function _deployBSD() internal returns (DIAVaultOracleBeaconSetDeployer) {
+        return new DIAVaultOracleBeaconSetDeployer(
+            DIAVaultOracleBeaconSetDeployerConfig({
+                initialOwner: BEACON_OWNER, initialDIAVaultOracleImplementation: address(implementation)
+            })
+        );
+    }
+
+    function _config(string memory symbol) internal view returns (DIAVaultOracleConfig memory) {
+        return DIAVaultOracleConfig({
+            diaOracle: IDIAOracleV2(address(diaOracle)),
+            symbol: symbol,
+            vault: address(vault),
+            maxAge: MAX_AGE,
+            actionTypeMask: ACTION_TYPE_STOCK_SPLIT_V1,
+            pauseTimeBefore: 3600,
+            pauseTimeAfter: 3600
+        });
+    }
+
+    function _predict(address deployer, bytes32 salt, address beacon) internal pure returns (address) {
+        bytes32 initCodeHash =
+            keccak256(abi.encodePacked(type(BeaconProxy).creationCode, abi.encode(beacon, bytes(""))));
+        return address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, initCodeHash)))));
+    }
+
+    /// @notice The deployed DIA proxy MUST land at the CREATE2 address predicted
+    /// from `salt = keccak256(abi.encode(config))`. Empty init-code means the
+    /// salt is the only thing that moves the address, so this pins the exact
+    /// salt formula.
+    function testDIASaltIsKeccakWholeConfig() external {
+        DIAVaultOracleBeaconSetDeployer bsd = _deployBSD();
+        DIAVaultOracleConfig memory cfg = _config("COIN");
+
+        bytes32 expectedSalt = keccak256(abi.encode(cfg));
+        address predicted = _predict(address(bsd), expectedSalt, address(bsd.I_DIA_VAULT_ORACLE_BEACON()));
+
+        DIAVaultOracle oracle = bsd.newDIAVaultOracle(cfg);
+        assertEq(address(oracle), predicted, "DIA proxy must land at keccak256(config) CREATE2 address");
+    }
+
+    /// @notice Two configs differing in ONLY `symbol` must mint to DISTINCT
+    /// addresses. If the salt omits `symbol`, they collide and the second deploy
+    /// reverts — this asserts that never happens.
+    function testDIASymbolOnlyDifferenceGivesDistinctAddress() external {
+        DIAVaultOracleBeaconSetDeployer bsd = _deployBSD();
+
+        DIAVaultOracle a = bsd.newDIAVaultOracle(_config("COIN"));
+        DIAVaultOracle b = bsd.newDIAVaultOracle(_config("AMZN"));
+
+        assertTrue(address(a) != address(b), "symbol-only difference must yield distinct addresses");
+        assertEq(a.symbol(), "COIN", "proxy a symbol");
+        assertEq(b.symbol(), "AMZN", "proxy b symbol");
+    }
+}

--- a/test/src/concrete/deploy/DeployerSaltDerivation.t.sol
+++ b/test/src/concrete/deploy/DeployerSaltDerivation.t.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {UpgradeableBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/UpgradeableBeacon.sol";
+import {BeaconProxy} from "@openzeppelin-contracts-5.6.1/proxy/beacon/BeaconProxy.sol";
+import {ST0xPriceOracle} from "../../../../src/concrete/oracle/ST0xPriceOracle.sol";
+import {MorphoPairAdapter} from "../../../../src/concrete/adapter/MorphoPairAdapter.sol";
+import {
+    MorphoPairAdapterBeaconSetDeployer,
+    MorphoPairAdapterBeaconSetDeployerConfig
+} from "../../../../src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.sol";
+import {
+    ST0xPriceOracleBeaconSetDeployer,
+    ST0xPriceOracleBeaconSetDeployerConfig
+} from "../../../../src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.sol";
+import {MockERC20Decimals} from "../../../mocks/MockERC20Decimals.sol";
+
+/// @title DeployerSaltDerivationTest
+/// @notice Pins the CREATE2 salt derivation of the Morpho and ST0x beacon-set
+/// deployers to their documented formulas. The idempotence tests only prove two
+/// DISTINCT configs land at DISTINCT addresses — but for these two deployers the
+/// proxy init-code already carries the full config, so distinctness holds even if
+/// the salt drops config fields. These tests independently recompute the CREATE2
+/// address from `salt = keccak256(<documented args>)` and assert the deployed
+/// proxy lands EXACTLY there, so the salt formula cannot silently drift.
+contract DeployerSaltDerivationTest is Test {
+    address internal constant BEACON_OWNER = address(0xBEEF);
+    address internal constant ADMIN = address(0xC0DE);
+    address internal constant ORACLE_ADMIN = address(0xADDD);
+    address internal constant SIGNER = address(0x516E);
+    uint64 internal constant TIMEOUT = 1 hours;
+
+    function setUp() public {
+        vm.warp(1_000_000);
+    }
+
+    /// @dev CREATE2 address predicted from the deployer, a salt, and the full
+    /// BeaconProxy init-code (creation code ++ encoded (beacon, data)).
+    function _predict(address deployer, bytes32 salt, address beacon, bytes memory data)
+        internal
+        pure
+        returns (address)
+    {
+        bytes32 initCodeHash = keccak256(abi.encodePacked(type(BeaconProxy).creationCode, abi.encode(beacon, data)));
+        return address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, initCodeHash)))));
+    }
+
+    /// @notice Morpho salt MUST be keccak256(abi.encode(base, quote)). If the
+    /// deployer drops `quote` (or otherwise changes the salt args), the deployed
+    /// address will not match this independent prediction.
+    function testMorphoSaltIsKeccakBaseQuote() external {
+        ST0xPriceOracle central;
+        {
+            ST0xPriceOracle impl = new ST0xPriceOracle();
+            UpgradeableBeacon beacon = new UpgradeableBeacon(address(impl), ADMIN);
+            central = ST0xPriceOracle(
+                address(
+                    new BeaconProxy(
+                        address(beacon), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ADMIN, SIGNER, TIMEOUT))
+                    )
+                )
+            );
+        }
+        MockERC20Decimals base = new MockERC20Decimals(18);
+        MockERC20Decimals quote = new MockERC20Decimals(6);
+
+        MorphoPairAdapterBeaconSetDeployer bsd = new MorphoPairAdapterBeaconSetDeployer(
+            MorphoPairAdapterBeaconSetDeployerConfig({initialOwner: BEACON_OWNER, central: central})
+        );
+
+        bytes32 expectedSalt = keccak256(abi.encode(address(base), address(quote)));
+        address predicted = _predict(
+            address(bsd),
+            expectedSalt,
+            address(bsd.I_MORPHO_PAIR_ADAPTER_BEACON()),
+            abi.encodeCall(MorphoPairAdapter.initialize, (address(base), address(quote)))
+        );
+
+        MorphoPairAdapter adapter = bsd.newMorphoPairAdapter(address(base), address(quote));
+        assertEq(address(adapter), predicted, "Morpho proxy must land at keccak256(base,quote) CREATE2 address");
+    }
+
+    /// @notice ST0x salt MUST be keccak256(abi.encode(admin, oracleAdmin, signer,
+    /// timeout)). If the deployer drops any arg (e.g. timeout) from the salt, the
+    /// deployed address will not match this independent prediction.
+    function testST0xSaltIsKeccakAllArgs() external {
+        ST0xPriceOracle implementation = new ST0xPriceOracle();
+        ST0xPriceOracleBeaconSetDeployer bsd = new ST0xPriceOracleBeaconSetDeployer(
+            ST0xPriceOracleBeaconSetDeployerConfig({
+                initialOwner: BEACON_OWNER, initialST0xPriceOracleImplementation: address(implementation)
+            })
+        );
+
+        bytes32 expectedSalt = keccak256(abi.encode(ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT));
+        address predicted = _predict(
+            address(bsd),
+            expectedSalt,
+            address(bsd.I_ST0X_PRICE_ORACLE_BEACON()),
+            abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT))
+        );
+
+        ST0xPriceOracle oracle = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT);
+        assertEq(address(oracle), predicted, "ST0x proxy must land at keccak256(all-args) CREATE2 address");
+    }
+}

--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -125,6 +125,34 @@ contract DIAVaultOracleTest is Test {
         oracle.initialize(abi.encode(config));
     }
 
+    /// @notice Per config NatSpec, at least ONE of before/after must be
+    /// non-zero — a single-sided window is a valid config. Init must SUCCEED
+    /// with only a pre-window (`pauseTimeAfter == 0`) and, symmetrically, with
+    /// only a post-window (`pauseTimeBefore == 0`). Guards the reject predicate
+    /// `before == 0 && after == 0`: a regression to `before == 0 || after == 0`
+    /// would wrongly reject these valid single-sided configs.
+    function testInitSucceedsWithOnlyPreWindow() external {
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.pauseTimeBefore = PAUSE_BEFORE;
+        config.pauseTimeAfter = 0;
+        DIAVaultOracle oracle = _deployUninit();
+        bytes32 ok = oracle.initialize(abi.encode(config));
+        assertEq(ok, ICLONEABLE_V2_SUCCESS, "pre-window-only config must be accepted");
+        assertEq(oracle.pauseTimeBefore(), PAUSE_BEFORE);
+        assertEq(oracle.pauseTimeAfter(), 0);
+    }
+
+    function testInitSucceedsWithOnlyPostWindow() external {
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.pauseTimeBefore = 0;
+        config.pauseTimeAfter = PAUSE_AFTER;
+        DIAVaultOracle oracle = _deployUninit();
+        bytes32 ok = oracle.initialize(abi.encode(config));
+        assertEq(ok, ICLONEABLE_V2_SUCCESS, "post-window-only config must be accepted");
+        assertEq(oracle.pauseTimeBefore(), 0);
+        assertEq(oracle.pauseTimeAfter(), PAUSE_AFTER);
+    }
+
     /// @notice A corporate-actions vault whose facet reverts must fail the
     /// DEPLOY transaction (via the init probe), not every future read.
     function testInitProbesVaultRevertsOnBrokenFacet() external {
@@ -238,6 +266,32 @@ contract DIAVaultOracleTest is Test {
         assertEq(oracle.symbol(), SYMBOL);
         assertEq(oracle.vault(), address(vault));
         assertEq(oracle.maxAge(), MAX_AGE);
+        // The auto-pause config must be persisted verbatim — a stored mask or
+        // window that drifts from config silently changes the pause behaviour.
+        assertEq(
+            oracle.corporateActionsVault(), address(actions), "corporate-actions vault must be the derived asset()"
+        );
+        assertEq(oracle.actionTypeMask(), ACTION_TYPE_STOCK_SPLIT_V1, "actionTypeMask must be stored verbatim");
+        assertEq(oracle.pauseTimeBefore(), PAUSE_BEFORE, "pauseTimeBefore must be stored verbatim");
+        assertEq(oracle.pauseTimeAfter(), PAUSE_AFTER, "pauseTimeAfter must be stored verbatim");
+    }
+
+    /// @notice The stored `actionTypeMask` must be the ONE applied to the
+    /// auto-pause: a completed action whose type is NOT in the configured mask
+    /// must NOT pause the oracle, even inside its post-window. Guards against a
+    /// stored mask that silently broadens to the wildcard (`type(uint256).max`)
+    /// — under which an unrelated action type would spuriously pause reads.
+    function testConfiguredMaskExcludesNonMatchingActionType() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        diaOracle.setValue(SYMBOL, 100e18, uint64(block.timestamp));
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+        // A completed action of a DIFFERENT type, squarely inside its
+        // post-window. The configured mask is STOCK_SPLIT only, so this must
+        // NOT pause — the oracle prices normally.
+        uint256 unrelatedType = 1 << 5;
+        actions.setLatestCompleted(1, unrelatedType, uint64(block.timestamp - PAUSE_AFTER / 2));
+        assertEq(oracle.latestAnswer(), 100e8, "action outside the configured mask must not pause");
     }
 
     // -------- Typed overload reverts --------
@@ -310,6 +364,41 @@ contract DIAVaultOracleTest is Test {
 
         int256 answer = oracle.latestAnswer();
         assertEq(answer, int256(100e8));
+    }
+
+    /// @notice `_readDIAChecked` reverts `DIAPriceNotSet` when the DIA value is
+    /// zero even if the timestamp is non-zero — the value-zero and timestamp-zero
+    /// terms of the not-set check are independent, so a mutant dropping the
+    /// value-zero term would price off a zero value.
+    function testLatestAnswerRevertsDIAValueZeroTimestampNonZero() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        diaOracle.setValue(SYMBOL, 0, uint128(block.timestamp)); // value 0, ts non-zero
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+        vm.expectRevert(DIAPriceNotSet.selector);
+        oracle.latestAnswer();
+    }
+
+    /// @notice Symmetric to the above: a zero timestamp reverts `DIAPriceNotSet`
+    /// (never-published), NOT `DIAPriceStale`, even when the value is non-zero.
+    function testLatestAnswerRevertsDIAValueNonZeroTimestampZero() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        diaOracle.setValue(SYMBOL, 100e18, 0); // value non-zero, ts 0
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+        vm.expectRevert(DIAPriceNotSet.selector);
+        oracle.latestAnswer();
+    }
+
+    /// @notice A very large but in-range 8dp price (5e76 < int256.max ~5.79e76)
+    /// is RETURNED, not rejected by the overflow guard — pins the non-revert
+    /// side of the `price8 > int256.max` boundary.
+    function testLatestAnswerLargePriceBelowIntMaxReturns() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        diaOracle.setValue(SYMBOL, 1e38, uint128(block.timestamp));
+        vault.setTotalAssets(5e48);
+        vault.setTotalSupply(1);
+        assertEq(oracle.latestAnswer(), int256(5e76));
     }
 
     // -------- latestAnswer zero supply --------

--- a/test/src/concrete/oracle/ST0xPriceOracle.t.sol
+++ b/test/src/concrete/oracle/ST0xPriceOracle.t.sol
@@ -358,6 +358,29 @@ contract ST0xPriceOracleTest is Test {
         );
     }
 
+    /// @notice `MAX_TIMEOUT` is the documented 30-day upper bound on the
+    /// global staleness `timeout`. Pin the exact value: a widened bound would
+    /// silently let `price()` serve staler data than the spec permits, and no
+    /// other test asserts it (the range-reject tests read `MAX_TIMEOUT()`
+    /// dynamically, so they float with the constant).
+    function test_MaxTimeout_IsThirtyDays() public view {
+        assertEq(oracle.MAX_TIMEOUT(), 30 days, "MAX_TIMEOUT must be exactly 30 days");
+        assertEq(oracle.MAX_TIMEOUT(), 2592000, "30 days in seconds");
+    }
+
+    /// @notice `ORACLE_ADMIN_ROLE` is the public role identifier off-chain
+    /// tooling and Safe bundles reference. Pin it to its normative
+    /// `keccak256("ORACLE_ADMIN")` derivation so a changed role string
+    /// (which stays internally consistent and passes every behavioural test)
+    /// can never silently break external role grants.
+    function test_OracleAdminRole_MatchesNormativeDerivation() public view {
+        assertEq(
+            oracle.ORACLE_ADMIN_ROLE(),
+            keccak256("ORACLE_ADMIN"),
+            "ORACLE_ADMIN_ROLE must equal keccak256(\"ORACLE_ADMIN\")"
+        );
+    }
+
     /// @notice The ERC-7201 `MainStorage` slot constant is a hardcoded hex
     /// literal with no getter. Pin it to the normative derivation by proving
     /// storage actually lands there: after `initialize`, the first field

--- a/test/src/lib/LibCorporateActionsPause.t.sol
+++ b/test/src/lib/LibCorporateActionsPause.t.sol
@@ -7,6 +7,7 @@ import {NODE_NONE} from "st0x-deploy-0.1.1/src/lib/LibCorporateActionNode.sol";
 import {LibCorporateActionsPause} from "../../../src/lib/LibCorporateActionsPause.sol";
 import {ACTION_TYPE_INIT_V1, ACTION_TYPE_STOCK_SPLIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
 import {MockCorporateActions} from "../../mocks/MockCorporateActions.sol";
+import {MockRevertingCorporateActions} from "../../mocks/MockRevertingCorporateActions.sol";
 
 contract LibCorporateActionsPauseTest is Test {
     MockCorporateActions internal mock;
@@ -33,6 +34,27 @@ contract LibCorporateActionsPauseTest is Test {
         mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 60));
         (bool paused, uint64 ts) = LibCorporateActionsPause.inPauseWindow(address(mock), 0, BEFORE, AFTER);
         assertEq(paused, false);
+        assertEq(ts, 0);
+    }
+
+    /// The `effectiveMask == 0` short-circuit must fire BEFORE any vault call.
+    /// A mask of 0 (or exactly `ACTION_TYPE_INIT_V1`, which strips to 0) means
+    /// a real vault would revert `InvalidMask`, so the lib MUST NOT query it —
+    /// it must return `(false, 0)` without touching the vault. Proven against a
+    /// vault that reverts on every read: if the short-circuit is dropped, the
+    /// call reaches the reverting vault and the whole call reverts instead of
+    /// returning false. The `MockCorporateActions`-based tests can't catch this
+    /// because that mock returns no-match (not a revert) on mask 0.
+    function testEmptyEffectiveMaskShortCircuitsBeforeVaultCall() external {
+        MockRevertingCorporateActions reverting = new MockRevertingCorporateActions();
+        // mask == 0 → effectiveMask == 0 → must short-circuit.
+        (bool paused, uint64 ts) = LibCorporateActionsPause.inPauseWindow(address(reverting), 0, BEFORE, AFTER);
+        assertEq(paused, false, "mask 0 must short-circuit without querying the vault");
+        assertEq(ts, 0);
+
+        // mask == ACTION_TYPE_INIT_V1 → strips to 0 → must also short-circuit.
+        (paused, ts) = LibCorporateActionsPause.inPauseWindow(address(reverting), ACTION_TYPE_INIT_V1, BEFORE, AFTER);
+        assertEq(paused, false, "INIT-only mask must short-circuit without querying the vault");
         assertEq(ts, 0);
     }
 
@@ -176,6 +198,34 @@ contract LibCorporateActionsPauseTest is Test {
             LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, 0);
         assertEq(paused, true);
         assertEq(ts, uint64(block.timestamp));
+    }
+
+    /// Cursor `0` is a REAL node (the bootstrap slot), not the no-match
+    /// sentinel — the sentinel is `NODE_NONE = type(uint256).max`. A COMPLETED
+    /// matching action whose cursor happens to be `0` and whose post-window
+    /// contains `now` MUST pause. Guards the completed-branch sentinel check
+    /// `completedCursor != NODE_NONE`: a regression to `completedCursor != 0`
+    /// would treat the legitimate bootstrap-slot node as no-match and fail to
+    /// pause. Uses a real STOCK_SPLIT type (not INIT) so the strip is irrelevant.
+    function testCompletedCursorZeroRealActionStillPauses() external {
+        uint64 effectiveTime = uint64(block.timestamp - AFTER / 2);
+        mock.setLatestCompleted(0, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, true, "completed action with cursor 0 (real bootstrap slot) must pause");
+        assertEq(ts, effectiveTime);
+    }
+
+    /// Symmetric to the above for the PENDING branch: a matching pending action
+    /// with cursor `0` inside its pre-window MUST pause. Guards
+    /// `pendingCursor != NODE_NONE` against a regression to `!= 0`.
+    function testPendingCursorZeroRealActionStillPauses() external {
+        uint64 effectiveTime = uint64(block.timestamp + BEFORE / 2);
+        mock.setEarliestPending(0, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, true, "pending action with cursor 0 (real bootstrap slot) must pause");
+        assertEq(ts, effectiveTime);
     }
 
     // -------- Audit regression: NODE_NONE no-match sentinel --------


### PR DESCRIPTION
Ran the adversarial-mutation-test skill (v0.26.0) over the whole src/ tree as
a 4-worker clone-isolated campaign: 141 behaviours probed, 121 existing tests
validated as real coverage by mutation, and 15 surviving-mutant gaps closed
with new discriminating tests (each: passes baseline, fails under its target
mutation — re-verified in this checkout). No source changes; tests only.

Zero bugs: the code was correct per NatSpec in every surviving case. The
adversarial pass confirmed the DIA oracle and Morpho adapter both round the
price DOWN (conservative for a lending oracle — never over-values collateral),
the signed-store cross-pair/cross-chain replay defence is sound, and there is
no cross-namespace isolation surface.

Gaps closed:
- DIAVaultOracle: single-sided pause windows accepted (before/after zero-OR
  invariant); DIAPriceNotSet independent of value-zero vs timestamp-zero;
  in-range large price returned (overflow-guard non-revert side).
- LibCorporateActionsPause: effectiveMask==0 short-circuits BEFORE any vault
  call (proven against a reverting vault); cursor 0 is a real bootstrap node,
  not the NODE_NONE sentinel (both pending + completed branches).
- Auto-pause: stored actionTypeMask is the one applied — an unrelated action
  type must not pause; config persisted verbatim.
- ST0xPriceOracle: MAX_TIMEOUT pinned to 30 days; ORACLE_ADMIN_ROLE pinned to
  keccak256("ORACLE_ADMIN") (external tooling/Safe reference).
- Deployers: CREATE2 salt formulas pinned by independent address prediction —
  critically the DIA deployer mints EMPTY-init-code proxies, so the salt is the
  sole uniqueness source and must fold in every config field (symbol isolation).

Adds audit/mutation-test-scans.json for org-wide scan-recency tracking.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016cakZwdXx1U2yczfFHwVV1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for oracle validation, auto-pause configurations, action-type filtering, and boundary values.
  * Added regression tests for pause-window behavior, including empty masks and valid zero cursors.
  * Added verification of deterministic deployment addresses and distinct addresses for differing configurations.
  * Added checks for key oracle constants and role identifiers.

* **Documentation**
  * Extended licensing annotation coverage to include audit scan records.

* **Chores**
  * Added a recorded adversarial mutation-test scan result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->