### PR TITLE
fix(deploy): make signed-price-stack deployable via CI + guard admin keys

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -22,6 +22,26 @@ on:
         description: 'Beacon owner (governance multisig, checksummed). Must NOT be the deploy key.'
         required: true
         type: string
+      st0x-admin:
+        description: 'signed-price-stack ONLY: DEFAULT_ADMIN_ROLE holder (governance, checksummed). Must NOT be the deploy key.'
+        required: false
+        type: string
+        default: ''
+      st0x-oracle-admin:
+        description: 'signed-price-stack ONLY: ORACLE_ADMIN_ROLE holder (governance, checksummed). Must NOT be the deploy key.'
+        required: false
+        type: string
+        default: ''
+      st0x-signer:
+        description: 'signed-price-stack ONLY: global publisher signer address (checksummed).'
+        required: false
+        type: string
+        default: ''
+      st0x-timeout:
+        description: 'signed-price-stack ONLY: global staleness timeout in seconds (must be <= 30 days).'
+        required: false
+        type: string
+        default: ''
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -59,6 +79,12 @@ jobs:
         env:
           DEPLOYMENT_SUITE: ${{ inputs.suite }}
           BEACON_INITIAL_OWNER: ${{ inputs.beacon-initial-owner }}
+          # Required by the signed-price-stack suite only; the dia-vault-oracle
+          # suite never reads them, so empty defaults are harmless there.
+          ST0X_ADMIN: ${{ inputs.st0x-admin }}
+          ST0X_ORACLE_ADMIN: ${{ inputs.st0x-oracle-admin }}
+          ST0X_SIGNER: ${{ inputs.st0x-signer }}
+          ST0X_TIMEOUT: ${{ inputs.st0x-timeout }}
           DEPLOY_BROADCAST: '1'
           DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
           ETH_RPC_URL: ${{ secrets[env.rpc_secret_name] || vars[env.rpc_secret_name] || '' }}

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -86,13 +86,23 @@ contract Deploy is Script {
     /// env: `ST0X_ADMIN`, `ST0X_ORACLE_ADMIN`, `ST0X_SIGNER` (addresses) and
     /// `ST0X_TIMEOUT` (uint64).
     /// @param beaconInitialOwner Initial owner of both beacons.
-    function deploySignedPriceStack(address beaconInitialOwner) internal {
+    function deploySignedPriceStack(address beaconInitialOwner, address deployer) internal {
         address admin = vm.envAddress("ST0X_ADMIN");
         address oracleAdmin = vm.envAddress("ST0X_ORACLE_ADMIN");
         address signer = vm.envAddress("ST0X_SIGNER");
         uint256 timeoutRaw = vm.envUint("ST0X_TIMEOUT");
         require(timeoutRaw <= type(uint64).max, "ST0X_TIMEOUT overflows uint64");
         uint64 timeout = uint64(timeoutRaw);
+
+        // ST0X_ADMIN holds DEFAULT_ADMIN_ROLE, the role-admin for
+        // ORACLE_ADMIN_ROLE — so it can grant itself ORACLE_ADMIN_ROLE and
+        // rotate the publisher signer/timeout, i.e. fully control every served
+        // price. It (and ST0X_ORACLE_ADMIN, which rotates them directly) must
+        // therefore be governance, never the hot CI deploy key — the same
+        // separation the beacon owner enforces. Fail the deploy loudly rather
+        // than silently leaving the feed under the deploy key's control.
+        require(admin != deployer, "ST0X_ADMIN must not be the deploy key");
+        require(oracleAdmin != deployer, "ST0X_ORACLE_ADMIN must not be the deploy key");
 
         ST0xPriceOracle oracleImpl = new ST0xPriceOracle();
         ST0xPriceOracleBeaconSetDeployer oracleBSD = new ST0xPriceOracleBeaconSetDeployer(
@@ -159,7 +169,7 @@ contract Deploy is Script {
             vm.stopBroadcast();
         } else if (suite == DEPLOYMENT_SUITE_SIGNED_PRICE_STACK) {
             vm.startBroadcast(deploymentKey);
-            deploySignedPriceStack(beaconInitialOwner);
+            deploySignedPriceStack(beaconInitialOwner, deployer);
             vm.stopBroadcast();
         } else {
             revert("Unknown deployment suite");

--- a/test/src/script/Deploy.t.sol
+++ b/test/src/script/Deploy.t.sol
@@ -16,6 +16,7 @@ contract DeployTest is Test {
     DeployExposed internal deploy;
 
     address internal constant BEACON_OWNER = address(0x6074E12);
+    address internal constant DEPLOYER = address(0xDEB10E);
 
     function setUp() public {
         deploy = new DeployExposed();
@@ -36,22 +37,35 @@ contract DeployTest is Test {
     }
 
     /// @notice The signed-price helper reads its config from env, mints the
-    /// singleton central store through its beacon-set deployer, and owns BOTH
-    /// beacons with the requested owner. Asserts the security postconditions
-    /// `deploySignedPriceStack` require()s: the singleton carries the requested
-    /// signer, `oracleAdmin` holds `ORACLE_ADMIN_ROLE`, and both beacons are
-    /// owned by the requested owner (never the deploy key).
-    function testDeploySignedPriceStackWiresOracleAndBeacons() external {
-        address stAdmin = address(0x57ADAD);
-        address stOracleAdmin = address(0x57ADDD);
-        address stSigner = address(0x57516E);
-        uint64 stTimeout = 1 hours;
-        vm.setEnv("ST0X_ADMIN", vm.toString(stAdmin));
-        vm.setEnv("ST0X_ORACLE_ADMIN", vm.toString(stOracleAdmin));
-        vm.setEnv("ST0X_SIGNER", vm.toString(stSigner));
-        vm.setEnv("ST0X_TIMEOUT", vm.toString(uint256(stTimeout)));
+    /// singleton central store through its beacon-set deployer, and enforces the
+    /// deploy-key-separation guards. All three scenarios live in ONE test
+    /// function on purpose: `deploySignedPriceStack` reads its config from
+    /// PROCESS env (`vm.setEnv`), which is global and not rolled back per test,
+    /// so splitting the scenarios into separate test functions lets forge's
+    /// concurrent test execution race the shared `ST0X_*` vars and flake. Kept
+    /// sequential here, the env mutations are deterministic.
+    function testDeploySignedPriceStackEnvConfigAndKeySeparation() external {
+        vm.setEnv("ST0X_ADMIN", vm.toString(address(0x57ADAD)));
+        vm.setEnv("ST0X_ORACLE_ADMIN", vm.toString(address(0x57ADDD)));
+        vm.setEnv("ST0X_SIGNER", vm.toString(address(0x57516E)));
+        vm.setEnv("ST0X_TIMEOUT", vm.toString(uint256(1 hours)));
 
-        deploy.exposedDeploySignedPriceStack(BEACON_OWNER);
+        // Happy path: admin/oracleAdmin both distinct from the deploy key, so
+        // the guards pass and the stack deploys (internal require()s enforce the
+        // signer/role/beacon-owner postconditions).
+        deploy.exposedDeploySignedPriceStack(BEACON_OWNER, DEPLOYER);
+
+        // Guard: ST0X_ADMIN holds DEFAULT_ADMIN_ROLE (can rotate the publisher
+        // signer), so it must never be the hot deploy key.
+        vm.setEnv("ST0X_ADMIN", vm.toString(DEPLOYER));
+        vm.expectRevert("ST0X_ADMIN must not be the deploy key");
+        deploy.exposedDeploySignedPriceStack(BEACON_OWNER, DEPLOYER);
+
+        // Guard: ST0X_ORACLE_ADMIN rotates signer/timeout directly — same rule.
+        vm.setEnv("ST0X_ADMIN", vm.toString(address(0x57ADAD)));
+        vm.setEnv("ST0X_ORACLE_ADMIN", vm.toString(DEPLOYER));
+        vm.expectRevert("ST0X_ORACLE_ADMIN must not be the deploy key");
+        deploy.exposedDeploySignedPriceStack(BEACON_OWNER, DEPLOYER);
     }
 
     /// @notice `run()` REQUIRES `BEACON_INITIAL_OWNER != deploy key`: the beacon

--- a/test/src/script/DeployExposed.sol
+++ b/test/src/script/DeployExposed.sol
@@ -15,7 +15,7 @@ contract DeployExposed is Deploy {
         return deployDIAStackInfra(beaconInitialOwner);
     }
 
-    function exposedDeploySignedPriceStack(address beaconInitialOwner) external {
-        deploySignedPriceStack(beaconInitialOwner);
+    function exposedDeploySignedPriceStack(address beaconInitialOwner, address deployer) external {
+        deploySignedPriceStack(beaconInitialOwner, deployer);
     }
 }


### PR DESCRIPTION
Audit HIGH: manual-sol-artifacts.yaml (the only deploy path) never passed the
four ST0X_* env vars that script/Deploy.sol's signed-price-stack suite reads,
so selecting that suite reverted at the first vm.envAddress('ST0X_ADMIN'). Add
st0x-admin / st0x-oracle-admin / st0x-signer / st0x-timeout workflow_dispatch
inputs (optional; the dia-vault-oracle suite ignores them) and wire them into
the deploy step's env block.

Also fold in the coupled deploy-key-separation guard (#257): ST0X_ADMIN holds
DEFAULT_ADMIN_ROLE — the role-admin for ORACLE_ADMIN_ROLE — so it can rotate
the publisher signer/timeout and fully control every served price. Making the
path deployable without this guard would ship exactly the footgun the beacon
-owner guard exists to prevent. deploySignedPriceStack now require()s that
ST0X_ADMIN and ST0X_ORACLE_ADMIN differ from the deploy key, mirroring the
BEACON_INITIAL_OWNER guard.

Tests: the three ST0X_*-env scenarios (happy path + both guard reverts) live in
one test function on purpose — vm.setEnv mutates PROCESS env (global, not
rolled back per test), so separate functions race under forge's concurrent
execution and flake. Kept sequential, they're deterministic.

Closes #257.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016cakZwdXx1U2yczfFHwVV1