### PR TITLE
audit: ST0xPriceOracle hardening (#253, #263, #264)

### DIFF
--- a/src/concrete/oracle/ST0xPriceOracle.sol
+++ b/src/concrete/oracle/ST0xPriceOracle.sol
@@ -38,7 +38,13 @@ import {MessageHashUtils} from "@openzeppelin-contracts-5.6.1/utils/cryptography
 /// so the same signed price payload is valid on every deployment sharing
 /// the global signer. One publisher signature fans out to every chain the
 /// oracle is deployed on; that is a feature for multi-chain deployment, not
-/// an oversight.
+/// an oversight. NOTE the precondition: because `pairId` binds the base and
+/// quote token ADDRESSES (`keccak256(abi.encodePacked(baseToken,
+/// quoteToken))`), a signature only replays to deployments where the pair's
+/// token addresses are IDENTICAL (e.g. deterministic CREATE2 addresses).
+/// Pairs whose token addresses differ per chain resolve to different
+/// `pairId`s and therefore require a per-chain signature; a publisher must
+/// not assume one signature covers a pair whose addresses vary by chain.
 ///
 /// Roles:
 ///  - `DEFAULT_ADMIN_ROLE` — role administration only (granted to `admin`
@@ -107,6 +113,13 @@ contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
     error PriceUnset(bytes32 pairId);
     error PriceStale(bytes32 pairId);
     error PriceFuture(bytes32 pairId);
+    /// @dev Raised when a signed update carries a zero `price`. A zero is the
+    /// uninitialized default of the signing pipeline and, if served, values a
+    /// pair at nothing downstream (e.g. Morpho collateral priced at zero).
+    /// Rejected at the update boundary, symmetric with the other
+    /// degenerate-value guards, per the fail-closed rule.
+    /// @param pairId The pair whose update carried a zero price.
+    error PriceZero(bytes32 pairId);
     error PriceUpdateInvalidSignature(bytes32 pairId);
 
     event SignerSet(address indexed signer);
@@ -195,8 +208,11 @@ contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
     /// NO-OP, so a lost update race can never revert a surrounding call. A
     /// strictly-newer payload timestamped in the FUTURE (`> block.timestamp`)
     /// reverts `PriceFuture` — it would strand `price()` behind an arithmetic
-    /// underflow. An invalid signature on an otherwise-valid payload is
-    /// malformed input and reverts `PriceUpdateInvalidSignature`.
+    /// underflow. A strictly-newer payload carrying a zero `price` reverts
+    /// `PriceZero`. An invalid signature on a strictly-newer payload is
+    /// malformed input and reverts `PriceUpdateInvalidSignature`; the
+    /// signature is verified before the future/zero content checks, so an
+    /// unauthenticated payload always reverts the signature error.
     function updatePrice(bytes32 id, uint256 newPrice, uint256 newTimestamp, bytes calldata signature)
         external
         returns (bool applied)
@@ -208,6 +224,18 @@ contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
         // signature so stale replays are cheap and never brick a caller.
         if (newTimestamp <= stored.timestamp) {
             return false;
+        }
+
+        // Verify the publisher signature BEFORE any content validation of the
+        // payload, so an unauthenticated payload always reverts
+        // `PriceUpdateInvalidSignature` — never a content-check selector
+        // (`PriceFuture` / `PriceZero`) that would misreport an unsigned probe
+        // as an operator/clock fault to off-chain monitoring. The stale/no-op
+        // short-circuit above stays first: it is intentionally cheap and
+        // signature-free so a lost update race can never brick a caller.
+        bytes32 structHash = keccak256(abi.encode(PRICE_UPDATE_TYPEHASH, id, newPrice, newTimestamp));
+        if (ECDSA.recover(MessageHashUtils.toTypedDataHash(DOMAIN_SEPARATOR, structHash), signature) != $.signer) {
+            revert PriceUpdateInvalidSignature(id);
         }
 
         // A future timestamp is out-of-model input: `price()` computes
@@ -223,9 +251,11 @@ contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
             revert PriceFuture(id);
         }
 
-        bytes32 structHash = keccak256(abi.encode(PRICE_UPDATE_TYPEHASH, id, newPrice, newTimestamp));
-        if (ECDSA.recover(MessageHashUtils.toTypedDataHash(DOMAIN_SEPARATOR, structHash), signature) != $.signer) {
-            revert PriceUpdateInvalidSignature(id);
+        // A zero price is the uninitialized default of the signing pipeline;
+        // serving it would value the pair at nothing downstream. Reject it,
+        // symmetric with the future-timestamp guard.
+        if (newPrice == 0) {
+            revert PriceZero(id);
         }
 
         stored.price = newPrice;

--- a/test/src/concrete/oracle/ST0xPriceOracle.t.sol
+++ b/test/src/concrete/oracle/ST0xPriceOracle.t.sol
@@ -285,6 +285,35 @@ contract ST0xPriceOracleTest is Test {
         oracle.price(PAIR_A);
     }
 
+    /// @notice A strictly-newer, validly-signed payload carrying a ZERO price
+    /// is rejected with `PriceZero`. A zero is the uninitialized default of the
+    /// signing pipeline; serving it values the pair at nothing downstream
+    /// (e.g. Morpho collateral priced at zero). Guarded symmetrically with the
+    /// other degenerate-value reverts, and the pair stays unset.
+    function test_UpdatePrice_ZeroPrice_Reverts() public {
+        bytes memory sig = _sign(PAIR_A, 0, block.timestamp);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceZero.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 0, block.timestamp, sig);
+
+        // Nothing was stored — price() reverts the normal unset revert.
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUnset.selector, PAIR_A));
+        oracle.price(PAIR_A);
+    }
+
+    /// @notice The signature is verified BEFORE the content checks: a
+    /// future-dated payload carrying a WRONG-key signature reverts
+    /// `PriceUpdateInvalidSignature`, NOT `PriceFuture`. An unauthenticated
+    /// payload must always surface as a signature fault so off-chain
+    /// monitoring keyed on the revert selector is never misled, and an
+    /// unauthenticated party cannot probe the future-vs-accept boundary.
+    function test_UpdatePrice_WronglySignedFuturePayload_RevertsInvalidSignatureNotFuture() public {
+        uint256 wrongPk = uint256(keccak256("wrong-signer"));
+        uint256 future = block.timestamp + 1 hours;
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, _digest(PAIR_A, 42e18, future));
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUpdateInvalidSignature.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 42e18, future, abi.encodePacked(r, s, v));
+    }
+
     /// @notice The boundary: a payload timestamped at EXACTLY block.timestamp
     /// is not in the future and applies. (`newTimestamp <= block.timestamp`
     /// is the accepted region.)


### PR DESCRIPTION
Audit-fix group for the signed-price store. Closes #253, #263, #264.

- **#253 (MEDIUM)** — reject a signed price of `0`. New `PriceZero(bytes32 pairId)` error + guard in `updatePrice`, symmetric with the existing `PriceFuture` degenerate-value guard. A validly-signed zero price could otherwise be stored and served, valuing collateral at nothing downstream in Morpho.
- **#263 (LOW)** — verify the ECDSA signature **before** the future-timestamp check (the cheap stale/no-op short-circuit stays first). An unauthenticated payload now reverts `PriceUpdateInvalidSignature` rather than leaking a content-check selector.
- **#264 (LOW)** — tighten the cross-chain-replay NatSpec: `pairId` binds per-chain token addresses, so a signature only replays where those addresses are identical.

Tests: `test_UpdatePrice_ZeroPrice_Reverts` and `test_UpdatePrice_WronglySignedFuturePayload_RevertsInvalidSignatureNotFuture` — both verified to discriminate (fail if the fix is reverted). Full suite 144 passing; single-contract + reuse green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)