### PR TITLE
audit: MorphoPairAdapter decimals safety + rounding (#254, #265, #266, #275)

### DIFF
--- a/src/concrete/adapter/MorphoPairAdapter.sol
+++ b/src/concrete/adapter/MorphoPairAdapter.sol
@@ -104,7 +104,18 @@ contract MorphoPairAdapter is Initializable, IOracle {
     /// @dev Reads both tokens' `decimals()` and precomputes the Morpho scale
     /// factors. A token whose `decimals()` is absurdly large makes the
     /// `10 ** ...` overflow and reverts here — fail-closed at init rather than
-    /// minting an always-reverting adapter.
+    /// minting an always-reverting adapter. The exact fail-closed boundaries
+    /// are `quoteDecimals >= 42` (numerator `10^(36 + quoteDecimals)` exceeds
+    /// `2^256`) and `baseDecimals >= 60` (denominator `10^(baseDecimals + 18)`
+    /// exceeds `2^256`); both surface as an arithmetic-overflow panic.
+    /// @dev Surviving init does NOT guarantee `price()` can never overflow.
+    /// A quote token with e.g. 41 decimals passes here (`10^77 < 2^256`) but
+    /// leaves `scaleNumerator ~= 1e77`, and `price()`'s
+    /// `mulDiv(central, scaleNumerator, scaleDenominator)` can then exceed
+    /// `2^256` for a normal central value when `scaleDenominator` is small —
+    /// bricking that market (fail-closed revert, never a wrong price). This is
+    /// only reachable with pathological 40+ decimal tokens; operators MUST bind
+    /// only real, sane-decimal (`<= ~18`) tokens.
     function initialize(address base, address quote) external initializer {
         if (base == address(0) || quote == address(0)) revert ZeroToken();
         if (base == quote) revert IdenticalTokens();
@@ -139,6 +150,11 @@ contract MorphoPairAdapter is Initializable, IOracle {
     /// @dev Reads the publisher-signed 18-decimal value from the central store
     /// (which enforces staleness / unset reverts) and rescales it into Morpho
     /// Blue's `1e36 * 10^loanDec / 10^collDec` convention.
+    /// @dev `Math.mulDiv` floors (rounds DOWN). This is deliberate and MUST NOT
+    /// change: the result is the Morpho *collateral* price, and under-stating
+    /// collateral is the conservative direction (less borrowing power, earlier
+    /// liquidation) that favours the lender/protocol. A `Ceil` variant would
+    /// silently reverse this safety property.
     function price() external view returns (uint256) {
         MainStorage storage $ = _main();
         return Math.mulDiv(iCentral.price($.pairId), $.scaleNumerator, $.scaleDenominator);

--- a/test/src/concrete/adapter/MorphoPairAdapter.t.sol
+++ b/test/src/concrete/adapter/MorphoPairAdapter.t.sol
@@ -2,6 +2,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
+// `Test` itself arrives via SignedPriceTestBase (which is `is Test`); only
+// `stdError` needs naming here, for the arithmetic-revert expectations below.
+import {stdError} from "forge-std-1.16.1/src/Test.sol";
 import {SignedPriceTestBase} from "../../lib/SignedPriceTestBase.sol";
 
 import {UpgradeableBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/UpgradeableBeacon.sol";
@@ -111,6 +114,42 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
         _deployAdapter(address(base), address(base));
     }
 
+    /// @notice Fail-closed at init: a quote (loan) token with absurdly large
+    /// `decimals()` makes `scaleNumerator = 10 ** (36 + quoteDecimals)`
+    /// overflow uint256, reverting init with an arithmetic panic rather than
+    /// minting an always-reverting adapter. The boundary is `quoteDecimals >=
+    /// 42` (`10^78 > 2^256`); pins the NatSpec "fail-closed" safety claim.
+    function test_MorphoPairAdapter_AbsurdQuoteDecimals_RevertsAtInit() public {
+        MockERC20Decimals hugeQuote = new MockERC20Decimals(42);
+        vm.expectRevert(stdError.arithmeticError);
+        _deployAdapter(address(base), address(hugeQuote));
+    }
+
+    /// @notice Fail-closed at init on the denominator side: a base (collateral)
+    /// token with absurdly large `decimals()` makes `scaleDenominator = 10 **
+    /// (baseDecimals + 18)` overflow uint256. The boundary is `baseDecimals >=
+    /// 60` (`10^78 > 2^256`).
+    function test_MorphoPairAdapter_AbsurdBaseDecimals_RevertsAtInit() public {
+        MockERC20Decimals hugeBase = new MockERC20Decimals(60);
+        vm.expectRevert(stdError.arithmeticError);
+        _deployAdapter(address(hugeBase), address(quote));
+    }
+
+    /// @notice Rounding-direction pin (#265). When the net Morpho exponent is
+    /// negative the rescale divides, and `Math.mulDiv` MUST floor (round DOWN)
+    /// — the conservative direction for a Morpho collateral price. base=30dec
+    /// (collateral), quote=6dec (loan) ⇒ net exponent 36 + 6 - 30 - 18 = -6, so
+    /// price() = floor(central / 1e6). A non-divisible central value that would
+    /// give 1 flooring vs 2 ceiling discriminates the direction.
+    function test_MorphoPairAdapter_PriceFloorsDown() public {
+        MockERC20Decimals base30 = new MockERC20Decimals(30);
+        MorphoPairAdapter adapter = _deployAdapter(address(base30), address(quote));
+        bytes32 id = oracle.pairId(address(base30), address(quote));
+        // 1_999_999 / 1e6 = 1.999999 → floors to 1 (ceil would be 2).
+        _push(id, 1_999_999, block.timestamp);
+        assertEq(adapter.price(), 1, "mulDiv must floor (round DOWN), not ceil");
+    }
+
     function test_MorphoPairAdapter_InitializeOnlyOnce() public {
         MorphoPairAdapter adapter = _deployAdapter(address(base), address(quote));
         vm.expectRevert(Initializable.InvalidInitialization.selector);
@@ -162,6 +201,15 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
         assertEq(address(adapterA.iCentral()), address(oracle), "central immutable intact");
         _push(PAIR_A, 42e18, block.timestamp);
         assertEq(adapterA.price(), 42e24, "still rescales the central price");
+
+        // Known-answer for the only 8-dec-collateral / 6-dec-loan pair in the
+        // suite. Publisher signs the whole-token ratio 42.0 as 42e18; the
+        // adapter rescales by num/denom = 10^(36+6) / 10^(8+18), so
+        // price() = 42e18 * 10^42 / 10^26 = 42 * 10^34. Catches an exponent
+        // sign error that only shows when baseDecimals is neither 18 nor equal
+        // to quoteDecimals.
+        _push(pairB, 42e18, block.timestamp);
+        assertEq(adapterB.price(), 42 * 10 ** 34, "8-dec collateral / 6-dec loan rescale");
     }
 
     // -------- Helpers --------


### PR DESCRIPTION
Audit-fix group for the Morpho adapter. Closes #254, #265, #266, #275.

- **#254 (MEDIUM)** — tests pinning the fail-closed init-overflow on absurd `decimals()` (quoteDecimals=42, baseDecimals=60 → `stdError.arithmeticError`).
- **#265 (LOW)** — NatSpec on `price()` documenting that `mulDiv` floors DOWN (conservative for a Morpho collateral price), plus a floor-vs-ceil discriminating test.
- **#266 (LOW)** — known-answer rescale assertion for the 8-dec/6-dec adapter in the beacon-upgrade test. Note: the value in the issue's proposed fix was wrong (`42e16`); corrected to `42 * 10^34`, consistent with the existing 18/6 case.
- **#275 (INFO)** — documented the fail-closed boundaries and that surviving init doesn't guarantee `price()` can't overflow for pathological 40+ decimal tokens. Chose a NatSpec note over an explicit decimals cap **on purpose**: a cap would revert before the arithmetic panic that #254 asserts.

All new tests verified to discriminate. Full suite 145 passing; single-contract + reuse green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified and validated decimal handling during adapter initialization, including rejection of excessively large token decimal values.
  * Confirmed price calculations consistently round down when rescaling values with negative decimal differences.
  * Added coverage for price scaling across tokens with different decimal configurations.

* **Documentation**
  * Expanded documentation describing decimal overflow boundaries and intentional rounding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->