### PR TITLE
audit: repo hygiene — dead dep, CI double-run, secret docs, interface pragmas (#270, #273, #277, #272)

### DIFF
--- a/.github/workflows/soldeer-lock-check.yaml
+++ b/.github/workflows/soldeer-lock-check.yaml
@@ -1,6 +1,12 @@
 name: Soldeer lock check
 on:
+  # Same-repo branch pushes are covered by the pull_request event, so scope
+  # push to main only (post-merge validation). This avoids the identical
+  # nix-heavy job running twice concurrently on every push to a branch with an
+  # open PR. pull_request still fires so fork PRs are validated in the base
+  # repo, not only after merge.
   push:
+    branches: [main]
   pull_request:
 # Audit finding #9: every CI/deploy job runs `forge soldeer install` and
 # proceeds, but nothing verifies the committed soldeer.lock / remappings.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,18 @@ Per-network secrets/vars follow the `CI_DEPLOY_<NETWORK>_<SUFFIX>` pattern:
 - `CI_DEPLOY_BASE_VERIFIER_URL` (use
   `https://api.etherscan.io/v2/api?chainid=8453`)
 
+`manual-sol-artifacts.yaml` offers four network choices — `base`,
+`base_sepolia`, `ethereum`, `sepolia` — and derives every secret name
+dynamically as `CI_DEPLOY_${network^^}_<SUFFIX>`. The same five suffixes above
+(`RPC_URL`, `ETHERSCAN_API_KEY`, `VERIFY`, `VERIFIER`, `VERIFIER_URL`) must be
+provisioned per network you dispatch to — substitute the uppercased network in,
+e.g. `CI_DEPLOY_ETHEREUM_RPC_URL`, `CI_DEPLOY_SEPOLIA_VERIFIER_URL`,
+`CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY`. **Hazard:** a missing secret
+resolves to empty (`''`) and the deploy proceeds anyway — unverified rather than
+erroring — so confirm all five exist before dispatching a non-`base` network.
+Use the etherscan v2 verifier URL with each network's chainid (`?chainid=<id>`):
+Base 8453, Base Sepolia 84532, Ethereum 1, Sepolia 11155111.
+
 ## Architecture
 
 Two stacks share the repo — see `README.md` for the full picture.

--- a/foundry.toml
+++ b/foundry.toml
@@ -30,7 +30,6 @@ forge-std = "1.16.1"
 "@openzeppelin-contracts-upgradeable" = "5.6.1"
 "rain-factory" = "0.1.1"
 "rain-math-float" = "0.1.1"
-"rain-intorastring" = "0.1.0"
 "st0x-deploy" = "0.1.1"
 "rain-vats" = "0.1.5"
 # Transitive dep of st0x-deploy (LibStockSplit uses LibTOFUTokenDecimals).

--- a/remappings.txt
+++ b/remappings.txt
@@ -2,7 +2,6 @@
 @openzeppelin-contracts-upgradeable-5.6.1/=dependencies/@openzeppelin-contracts-upgradeable-5.6.1/
 forge-std-1.16.1/=dependencies/forge-std-1.16.1/
 rain-factory-0.1.1/=dependencies/rain-factory-0.1.1/
-rain-intorastring-0.1.0/=dependencies/rain-intorastring-0.1.0/
 rain-math-float-0.1.1/=dependencies/rain-math-float-0.1.1/
 rain-tofu-erc20-decimals-0.1.1/=dependencies/rain-tofu-erc20-decimals-0.1.1/
 rain-vats-0.1.5/=dependencies/rain-vats-0.1.5/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -27,13 +27,6 @@ checksum = "6b02e2b87983e196bc88cb8fb802a2720b252783429567864cd13336167c369d"
 integrity = "be6a3343d0ea247d8b495b584cd21c3bf64f0a1396ca21aaa8ce31715df29842"
 
 [[dependencies]]
-name = "rain-intorastring"
-version = "0.1.0"
-url = "https://soldeer-revisions.s3.amazonaws.com/rain-intorastring/0_1_0_12-05-2026_19:21:48_rain.zip"
-checksum = "6cd4b0e5ea0a7ffc8adef762b3687d180e4c1408ec4ff8bf8d88d5f9712bf5af"
-integrity = "cad9d7a463dd388f73b1f2cf85dd212fd46320203f8d39cb0938ffb451295384"
-
-[[dependencies]]
 name = "rain-math-float"
 version = "0.1.1"
 url = "https://soldeer-revisions.s3.amazonaws.com/rain-math-float/0_1_1_13-05-2026_13:48:34_rain.math.zip"

--- a/src/interface/IDIAOracleV2.sol
+++ b/src/interface/IDIAOracleV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) 2024 DIA Foundation
-pragma solidity =0.8.25;
+pragma solidity ^0.8.25;
 
 // SYNC NOTE: This interface mirrors DIA Data Association's canonical
 // `IDIAOracleV2` (the on-chain feed surface exposed by their oracle

--- a/src/interface/IOracle.sol
+++ b/src/interface/IOracle.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-DCL-1.0
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity =0.8.25;
+pragma solidity ^0.8.25;
 
 /// @title IOracle
 /// @notice Morpho Blue oracle interface, vendored from Morpho's published


### PR DESCRIPTION
Additive repo-hygiene group. Closes #270, #273, #277; partially addresses #272.

- **#270 (LOW)** — remove the dead `rain-intorastring` dependency (zero importers, zero transitive refs) from `foundry.toml`, `remappings.txt`, and `soldeer.lock`. `forge soldeer install` does not re-add it — lock stays consistent.
- **#273 (LOW)** — scope the `soldeer-lock-check` workflow to `push:{branches:[main]}` + `pull_request:{}` so same-repo PRs stop double-running; fork-PR support preserved.
- **#277 (INFO)** — `AGENTS.md`: per-network secret guidance (`CI_DEPLOY_<NETWORK>_<SUFFIX>` for all four networks, empty-secret hazard, verifier chainids).
- **#272 (part, LOW)** — float `IDIAOracleV2.sol` and `IOracle.sol` pragmas to `^0.8.25` (vendored interfaces float). `IAggregatorV2V3.sol` is handled in the DIA-oracle PR.

Full suite 142 passing; single-contract + reuse green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)