### PR TITLE
audit: DIAVaultOracle correctness + docs (#261, #262, #274, #272)

### DIFF
--- a/src/concrete/oracle/DIAVaultOracle.sol
+++ b/src/concrete/oracle/DIAVaultOracle.sol
@@ -141,6 +141,48 @@ struct DIAVaultOracleConfig {
 /// space throughout so neither operand can overflow uint256; the conversion to
 /// fixed-point 8dp happens only at the final return.
 ///
+/// Vault trust model (donation / share-price inflation): the priced `vault` is
+/// a `wtStock` wrapper whose `totalAssets()` IS raw
+/// `IERC20(asset()).balanceOf(vault)` — `StoxWrappedTokenVault` overrides only
+/// `name()`/`symbol()` and inherits the OZ ERC-4626 default. Direct transfers
+/// into the vault ("donations") therefore DO move the share ratio, and the
+/// transfer path is permissionless: the upstream authorizer allows any
+/// `TRANSFER_SHARES` while certification is valid (it only fails closed on a
+/// system-wide certification lapse), so anyone holding tStock can donate.
+///
+/// This is deliberate and is NOT a manipulation surface, because a donation is
+/// value-additive and irreversible:
+///
+/// - The assets are really in the vault. Every share genuinely redeems for
+///   more. A borrower's collateral is not phantom — it is worth what the
+///   oracle says it is worth. NAV bumps (dividend reinvestment, post-action
+///   rebalances) are delivered as exactly such transfers, so this is the
+///   normal mechanism, not an attack.
+/// - A donor gets nothing back. A bare ERC-20 transfer mints no shares, so the
+///   value spreads pro-rata across existing holders and cannot be withdrawn.
+///   Donating `D` buys at most `LTV * yourShareOfSupply * D` of extra
+///   borrowing power against a cost of `D` — strictly negative-EV unless you
+///   already own essentially the whole supply, in which case it is circular.
+///
+/// The classic ERC-4626 donation attack is a ROUNDING attack on depositors (a
+/// near-empty vault plus a donation makes the next depositor's shares round to
+/// zero). It lives in the vault's own share accounting, harms depositors
+/// rather than price consumers, and is not addressable from an oracle — no
+/// check here would prevent it. It is out of scope for this contract.
+///
+/// Deliberately NOT mitigated here: no sanity band, drift limit or ratio
+/// anchor gates reads. Such a gate would fail closed on a legitimate NAV move
+/// (a large dividend or redemption), and an oracle that stops answering is
+/// strictly worse for a lending market than one that answers correctly —
+/// liquidations halt while positions keep moving, which accrues bad debt. The
+/// real stale-ratio risk is the corporate-action rebalance, and that is
+/// handled by the mandatory auto-pause below.
+///
+/// Pointing this oracle at an arbitrary third-party ERC-4626 remains
+/// unsupported — not because of donations, but because nothing outside the
+/// ST0x stack guarantees the corporate-action wiring the auto-pause depends
+/// on. See `_vaultSharePrice` for the per-function note.
+///
 /// Auto-pause: on every read the oracle consults `ICorporateActionsV1` on the
 /// corporate-actions vault — derived as the priced vault's `asset()`, i.e. the
 /// tStock the wtStock wraps — via `LibCorporateActionsPause`, and reverts
@@ -334,6 +376,12 @@ contract DIAVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable 
     }
 
     /// @inheritdoc AggregatorV2V3Interface
+    /// @dev Deliberate deviation from the Chainlink-style pair-string
+    /// convention: this returns the BARE DIA feed symbol (e.g. `"COIN"`), NOT
+    /// a `"SYMBOL / USD"` pair string, because DIA keys its feeds by the bare
+    /// symbol and that is the single source of truth here. Integrators that
+    /// expect a Chainlink-formatted pair string must adjust. The interface
+    /// NatSpec is worded so it does not contradict this.
     function description() external view override returns (string memory) {
         return _main().symbol;
     }
@@ -404,23 +452,48 @@ contract DIAVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable 
         MainStorage storage $ = _main();
         (value, timestamp) = $.diaOracle.getValue($.symbol);
         if (value == 0 || timestamp == 0) revert DIAPriceNotSet();
-        // Comparing block.timestamp against the DIA push timestamp is the whole
-        // point of the staleness check; sub-maxAge miner drift is immaterial
-        // against a maxAge measured in hours. This is not a false-positive
-        // dependence on block.timestamp for value/authorisation. The edge
-        // instant fails closed (`>=`): a push exactly `maxAge` old is STALE.
-        // This is deliberate — it is what makes the cross-epoch invariant
+        // Slither `timestamp` is a FALSE POSITIVE here: the detector flags
+        // block.timestamp comparisons because miner-influenceable time can be
+        // gamed for value or authorisation. Neither applies — block.timestamp
+        // is used purely as the local clock to age a DIA push, which is the
+        // entire purpose of a staleness check, and the seconds of drift a
+        // proposer can induce are immaterial against a maxAge measured in
+        // hours. No value or permission decision reads the clock.
+        //
+        // A push timestamped at or before `now` applies the `maxAge` window. A
+        // push timestamped in the FUTURE (a feed running slightly ahead, or a
+        // chain-time regression / reorg) is treated as fresh (age 0), never
+        // stale: the `<= block.timestamp` guard short-circuits the subtraction
+        // so it can never underflow into a bare `Panic(0x11)` that integrators
+        // cannot disambiguate from `DIAPriceStale` / `DIAPriceNotSet`.
+        //
+        // The staleness edge fails closed (`>=`): a push exactly `maxAge` old is
+        // STALE. This is deliberate — it makes the cross-epoch invariant
         // (`pauseTimeAfter >= maxAge`, see the contract NatSpec) airtight at the
-        // exact-equality boundary, and it matches the fail-closed staleness
+        // exact-equality boundary, and matches the fail-closed staleness
         // convention (the edge counts as stale).
         // slither-disable-next-line timestamp
-        if (block.timestamp - uint256(timestamp) >= $.maxAge) revert DIAPriceStale(uint256(timestamp));
+        if (uint256(timestamp) <= block.timestamp && block.timestamp - uint256(timestamp) >= $.maxAge) {
+            revert DIAPriceStale(uint256(timestamp));
+        }
     }
 
     /// @dev Compute vault share price from a DIA reading via Rain float math
     /// so neither operand can overflow uint256. DIA prices are 18-decimal
     /// `uint128`. The vault ratio is `totalAssets / totalSupply`. Output is
     /// 8-decimal `int256` per Chainlink `latestAnswer` convention.
+    ///
+    /// Donation / share-inflation: this reads `totalAssets()` directly, and on
+    /// the production `wtStock` that IS raw `IERC20(asset()).balanceOf(vault)`,
+    /// so a direct transfer into the vault does move the ratio. That is
+    /// intentional and not a manipulation surface — a donation adds real assets
+    /// the shares genuinely redeem for, mints the donor nothing, and cannot be
+    /// withdrawn, so it is value-additive and negative-EV for the donor. No
+    /// sanity band gates this read; halting the oracle on an unexpected ratio
+    /// would stop liquidations, which is worse for a lending market than
+    /// pricing the (real) NAV. See the contract NatSpec ("Vault trust model")
+    /// for the full argument and for what IS mitigated — the corporate-action
+    /// rebalance, via the mandatory auto-pause.
     function _vaultSharePrice(uint128 diaPrice) internal view returns (int256) {
         // DIA's value is 18-decimal uint128 — pack as a float with decimal
         // count 18 to recover the natural quantity.

--- a/src/interface/IAggregatorV2V3.sol
+++ b/src/interface/IAggregatorV2V3.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-DCL-1.0
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity =0.8.25;
+pragma solidity ^0.8.25;
 
 /// @title AggregatorV2V3Interface
 /// @notice Hybrid of Chainlink's `AggregatorInterface` (v2 — `latestAnswer`)
@@ -16,7 +16,11 @@ interface AggregatorV2V3Interface {
     /// @notice Number of decimals the answer is scaled to.
     function decimals() external view returns (uint8);
 
-    /// @notice Human-readable description of the feed (e.g. "AAPL / USD").
+    /// @notice Human-readable description of the feed. Chainlink feeds
+    /// conventionally use a pair string (e.g. `"AAPL / USD"`), but the exact
+    /// format is implementation-defined — a DIA-backed implementation may
+    /// return the bare feed symbol (e.g. `"COIN"`) instead. Consumers should
+    /// treat it as an opaque label, not parse it for the quote asset.
     function description() external view returns (string memory);
 
     /// @notice Aggregator version. Chainlink convention is `1` for v1 and

--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -340,6 +340,23 @@ contract DIAVaultOracleTest is Test {
         assertEq(oracle.version(), 1);
     }
 
+    /// @notice `description()` deliberately returns the BARE DIA feed symbol
+    /// (e.g. `"COIN"`), NOT a Chainlink-style `"SYMBOL / USD"` pair string
+    /// (issue #274). This pins that intentional deviation: the value must be
+    /// the raw configured symbol byte-for-byte, and must NOT equal the
+    /// pair-formatted `"COIN / USD"` a Chainlink consumer might assume. A
+    /// regression that pair-formatted the description would fail here, and the
+    /// interface NatSpec is worded to permit this so the two don't clash.
+    function testDescriptionReturnsBareSymbolNotPairString() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        string memory desc = oracle.description();
+        assertEq(desc, SYMBOL, "description must be the bare DIA symbol");
+        assertTrue(
+            keccak256(bytes(desc)) != keccak256(bytes(string.concat(SYMBOL, " / USD"))),
+            "description must NOT be a Chainlink-style pair string"
+        );
+    }
+
     // -------- latestAnswer happy path --------
 
     function testLatestAnswerHappyPath() external {
@@ -353,6 +370,42 @@ contract DIAVaultOracleTest is Test {
         // 100 * 2 / 1 = 200, scaled to 8dp = 200e8.
         int256 answer = oracle.latestAnswer();
         assertEq(answer, int256(200e8));
+    }
+
+    /// @notice Donations move the ratio and ARE served — the decided behaviour
+    /// for issue #262, pinned so it cannot be silently reverted.
+    ///
+    /// The production `wtStock`'s `totalAssets()` is raw
+    /// `IERC20(asset()).balanceOf(vault)`, so a direct transfer in moves the
+    /// share ratio. Here `setTotalAssets` stands in for that balance growing.
+    /// The oracle must price the new ratio straight through: a donation adds
+    /// real assets the shares genuinely redeem for, so the higher price is
+    /// CORRECT, not inflated — there is no phantom collateral to defend
+    /// against, and the donor cannot withdraw what they gave.
+    ///
+    /// The assertion that matters is the absence of a gate. Any sanity band,
+    /// drift limit or ratio anchor added to the read path would reject this
+    /// jump and fail this test. That is deliberate: halting the oracle on an
+    /// unexpected-but-real ratio stops liquidations while positions keep
+    /// moving, which is worse for a lending market than pricing the true NAV.
+    /// See the contract NatSpec ("Vault trust model").
+    function testDonationMovesRatioAndIsServed() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        diaOracle.setValue(SYMBOL, 100e18, uint128(block.timestamp));
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+        assertEq(oracle.latestAnswer(), int256(100e8), "baseline 1 asset per share");
+
+        // A donation doubles the vault's holdings against an unchanged supply.
+        // Supply is unchanged because a bare transfer mints the donor nothing.
+        vault.setTotalAssets(2e18);
+
+        // Served, not rejected, and priced at the true new ratio.
+        assertEq(oracle.latestAnswer(), int256(200e8), "donation must be priced through, not gated");
+
+        // The same read path through latestRoundData agrees.
+        (, int256 roundAnswer,,,) = oracle.latestRoundData();
+        assertEq(roundAnswer, int256(200e8), "latestRoundData must agree with latestAnswer");
     }
 
     // -------- latestAnswer DIA not set --------
@@ -378,6 +431,24 @@ contract DIAVaultOracleTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(DIAPriceStale.selector, uint256(staleTimestamp)));
         oracle.latestAnswer();
+    }
+
+    /// @notice A DIA push timestamped in the FUTURE (feed running ahead, or a
+    /// chain-time regression / reorg) must NOT underflow-panic in the staleness
+    /// subtraction. A future timestamp is fresh by construction (age 0), so the
+    /// read resolves to the priced value, never a bare `Panic(0x11)`. Guards
+    /// the `uint256(timestamp) <= block.timestamp` short-circuit in
+    /// `_readDIAChecked`; a regression dropping that guard would revert here
+    /// with an arithmetic panic instead of returning `100e8`.
+    function testLatestAnswerFutureTimestampNotStale() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        // Timestamp 100s in the future relative to `now`.
+        diaOracle.setValue(SYMBOL, 100e18, uint128(block.timestamp + 100));
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+
+        int256 answer = oracle.latestAnswer();
+        assertEq(answer, int256(100e8), "future-timestamped push is fresh, not stale");
     }
 
     /// @notice The staleness edge fails closed: a push aged EXACTLY `maxAge`


### PR DESCRIPTION
Audit-fix group for the DIA oracle. Closes #261, #262, #274; partially addresses #272.

Rebased onto `main` now that [#280](https://app.graphite.com/github/pr/ST0x-Technology/st0x.oracle/280) (the cross-epoch invariant fix) has merged. Single commit.

- **#261 (LOW)** — guard the staleness subtraction so a future-dated DIA push resolves to the fresh branch instead of an underflow `Panic(0x11)`.
- **#262 (LOW)** — document the donation / share-price trust model. **The finding asked for the analysis; the analysis concludes no mitigation is warranted.** See below.
- **#274 (INFO)** — document the deliberate bare-symbol `description()` deviation and soften the interface NatSpec so they no longer contradict.
- **#272 (part, LOW)** — float `IAggregatorV2V3.sol` pragma to `^0.8.25`.

### On #262 — what changed and why

An earlier revision of this PR claimed the priced vault's `totalAssets()` was an *accounted* quantity that donations could not move, and pinned that with a test. **Both were false assurance**, and a later revision over-corrected by adding a drift-band mitigation. Neither survives; here is the corrected position.

**The facts, verified against source:**

- `StoxWrappedTokenVault` (st0x.deploy) overrides only `name()` and `symbol()`. It inherits OpenZeppelin ERC-4626's default `totalAssets()`, which is raw `IERC20(asset()).balanceOf(address(this))`. Donations **do** move the share ratio.
- The transfer path is **permissionless**, not KYC-gated. `OffchainAssetReceiptVaultAuthorizerV1.authorize()` returns unconditionally for `TRANSFER_SHARES` while certification is valid — the only gate is a system-wide freeze on certification lapse.

**Why that is not a manipulation surface:**

A donation adds real assets that the shares genuinely redeem for, so there is no phantom collateral — a borrower's wtStock really is worth more. A bare ERC-20 transfer mints the donor nothing and cannot be withdrawn, so the value spreads pro-rata across existing holders. Donating `D` buys at most `LTV × yourShareOfSupply × D` of extra borrowing power at a cost of `D` — strictly negative-EV unless you already own essentially the whole supply, at which point it is circular.

The classic ERC-4626 donation attack is a **rounding** attack on depositors (a near-empty vault plus a donation makes the next depositor's shares round to zero). It lives in the vault's own share accounting, harms depositors rather than price consumers, and is not addressable from an oracle.

**Deliberately not mitigated.** No sanity band, drift limit or ratio anchor gates reads. Such a gate fails closed on a legitimate NAV move (a large dividend or redemption), and an oracle that stops answering is worse for a lending market than one that answers correctly — liquidations halt while positions keep moving, which accrues bad debt. The real stale-ratio risk is the corporate-action rebalance, and that is already handled by the mandatory auto-pause.

`testDonationMovesRatioAndIsServed` pins this: a donation is priced straight through at the true new ratio, so any band added to the read path fails the test.

### Verification

167 tests passing (including the fork test against live Base); `forge fmt --check`, `slither` (0 findings), `rainix-sol-single-contract` and `reuse lint` all green locally before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
