### PR TITLE
audit: per-release deployment record + codehash verification (#259)

### DIFF
--- a/src/generated/DeployRecordBase.sol
+++ b/src/generated/DeployRecordBase.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+/// @title DeployRecordBase
+/// @notice Committed, per-release deployment record for the DIA oracle stack on
+/// Base (chainId 8453) — the durable, in-repo freeze the audit (#259) asks for.
+///
+/// The deploy script (`script/Deploy.sol`) mints the beacon-set deployer, the
+/// implementation and the per-vault proxies. Their addresses are
+/// CREATE/nonce-dependent (or, for proxies, CREATE2-salted off a runtime beacon
+/// address), so they are NOT reproducible from committed source alone. Without a
+/// record, the only trace of a deploy is the CI workflow log, which expires —
+/// leaving nobody able to confirm the live infra is the code this repo built,
+/// and letting a re-deploy silently fork a divergent second set.
+///
+/// This library freezes, per deployed contract, its address AND the runtime
+/// codehash (`keccak256(address.code)`) observed on-chain. The check
+/// (see `DeployRecordLibBase.verifyCodehash`) asserts the live code at each
+/// recorded address still hashes to the recorded value — i.e. the live infra is
+/// byte-identical to what was frozen at record time and nobody has swapped it.
+///
+/// @dev RELEASE PROVENANCE — READ BEFORE PINNING TO CURRENT SOURCE.
+/// The recorded DIA stack below is the FIRST Base release ("pre-fold"). It was
+/// recovered from the deploy broadcast (the record's whole point: it outlives
+/// the CI logs it was parsed from) and re-read on-chain via a Base archive fork
+/// to capture the live codehashes verbatim. That release predates the
+/// architecture change that FOLDED the corporate-action pause wrapper INTO
+/// `DIAVaultOracle` and deleted the separate `PausableOracleWrapper` (commit
+/// e0a355e), plus the ERC-7201 storage + hardening sweep. So the recorded
+/// implementation/deployer codehashes DO NOT equal the artifacts the current
+/// source tree builds, and they are NOT supposed to — this is a record of the
+/// LIVE release, not of `forge build` HEAD. The codehash check is a
+/// "has the live code changed since we froze it" guard, not a "does the live
+/// code match current source" guard. When the stack is redeployed onto the
+/// current (folded, ERC-7201) implementations, ADD a new record block for that
+/// release rather than mutating these values.
+///
+/// The signed-price stack (`ST0xPriceOracle` + its beacon-set deployer + the
+/// `MorphoPairAdapterBeaconSetDeployer`) is NOT yet deployed on Base; its record
+/// is intentionally EMPTY (address(0) / bytes32(0)) — populate at first deploy.
+library DeployRecordBase {
+    /// @notice The chain this record pins.
+    uint256 internal constant CHAIN_ID = 8453;
+
+    // -------------------------------------------------------------------------
+    // DIA stack — FIRST ("pre-fold") Base release. Addresses recovered from the
+    // deploy broadcast; codehashes re-read on-chain (Base) at record time.
+    // These are the SUPERSEDED-architecture impls (separate wrapper); see the
+    // library-level PROVENANCE note. The check verifies the live code has not
+    // changed since it was frozen, NOT that it matches current source.
+    // -------------------------------------------------------------------------
+
+    /// @notice `DIAVaultOracleBeaconSetDeployer` — owns the upgradeable beacon
+    /// and mints DIA oracle proxies. Non-deterministic (plain `new`) address.
+    address internal constant DIA_VAULT_ORACLE_BEACON_SET_DEPLOYER = 0x8B8cc6db58E5bb9F507FFce893246958c7Ca9F6d;
+    bytes32 internal constant DIA_VAULT_ORACLE_BEACON_SET_DEPLOYER_CODEHASH =
+        0x2ac9292ab325265fada5a4c160b6cfe480eb78236698bc8e31e1189f441b1217;
+
+    /// @notice `DIAVaultOracle` implementation behind the beacon.
+    address internal constant DIA_VAULT_ORACLE_IMPLEMENTATION = 0x2e5ddDFbe97f1421e4ccEf0c423374379502a132;
+    bytes32 internal constant DIA_VAULT_ORACLE_IMPLEMENTATION_CODEHASH =
+        0x5b660e31453047e65e5114dcf09480d7ea41272f4203c3d25225824e641a8f52;
+
+    /// @notice The one live DIA oracle proxy (wtCOIN). CREATE2-salted off the
+    /// beacon address + `keccak256(abi.encode(config))`.
+    address internal constant DIA_WTCOIN_ORACLE_PROXY = 0xef31D3E7c6a60e0725758Cd318603c7864b3278A;
+    bytes32 internal constant DIA_WTCOIN_ORACLE_PROXY_CODEHASH =
+        0x576541507f08b924e100efe6730152cead62ad86776e05e207d32699bc79f510;
+
+    // -------------------------------------------------------------------------
+    // Signed-price stack — NOT deployed on Base. EMPTY: populate at first deploy.
+    // -------------------------------------------------------------------------
+
+    address internal constant ST0X_PRICE_ORACLE_BEACON_SET_DEPLOYER = address(0);
+    bytes32 internal constant ST0X_PRICE_ORACLE_BEACON_SET_DEPLOYER_CODEHASH = bytes32(0);
+
+    address internal constant ST0X_PRICE_ORACLE_IMPLEMENTATION = address(0);
+    bytes32 internal constant ST0X_PRICE_ORACLE_IMPLEMENTATION_CODEHASH = bytes32(0);
+
+    address internal constant ST0X_PRICE_ORACLE_SINGLETON_PROXY = address(0);
+    bytes32 internal constant ST0X_PRICE_ORACLE_SINGLETON_PROXY_CODEHASH = bytes32(0);
+
+    address internal constant MORPHO_PAIR_ADAPTER_BEACON_SET_DEPLOYER = address(0);
+    bytes32 internal constant MORPHO_PAIR_ADAPTER_BEACON_SET_DEPLOYER_CODEHASH = bytes32(0);
+}

--- a/src/generated/DeployRecordLib.sol
+++ b/src/generated/DeployRecordLib.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+import {BeaconProxy} from "@openzeppelin-contracts-5.6.1/proxy/beacon/BeaconProxy.sol";
+
+/// @dev Raised when the live runtime code at a recorded address does not hash to
+/// the recorded codehash — i.e. the live infra has diverged from the frozen
+/// release (swapped, self-destructed, or never deployed there).
+/// @param account The recorded address whose live code was checked.
+/// @param expected The codehash frozen in the deployment record.
+/// @param actual The codehash of the code currently at `account`.
+error DeployRecordCodehashMismatch(address account, bytes32 expected, bytes32 actual);
+
+/// @dev Raised when a CREATE2 proxy's actual address does not equal the address
+/// deterministically derived from its deployer, beacon and config salt — i.e.
+/// the proxy is NOT the deterministic commitment to that config.
+/// @param expected The CREATE2-derived address.
+/// @param actual The address the proxy actually deployed at.
+error DeployRecordAddressMismatch(address expected, address actual);
+
+/// @title DeployRecordLib
+/// @notice The check that makes a `DeployRecordBase`-style freeze verifiable:
+/// pure/`view` helpers asserting (a) the live runtime codehash at a recorded
+/// address equals the recorded codehash and (b) a CREATE2 beacon-proxy landed at
+/// its deterministically-derived address. Kept free of any specific record so
+/// both the local self-test and the live fork test drive the SAME logic.
+library DeployRecordLib {
+    /// @notice Assert the code currently at `account` hashes to `expected`.
+    /// Reverts `DeployRecordCodehashMismatch` on any divergence (including the
+    /// no-code case, whose codehash is `keccak256("")`, distinct from a real
+    /// recorded hash). `bytes32(0)` (unset record slot) is treated as
+    /// "nothing to check" and skipped so an empty record no-ops rather than
+    /// asserting against `address(0)`.
+    /// @param account The recorded address to verify.
+    /// @param expected The recorded codehash.
+    function verifyCodehash(address account, bytes32 expected) internal view {
+        if (expected == bytes32(0)) {
+            return;
+        }
+        bytes32 actual = account.codehash;
+        if (actual != expected) {
+            revert DeployRecordCodehashMismatch(account, expected, actual);
+        }
+    }
+
+    /// @notice The CREATE2 address a `DIA*BeaconSetDeployer`-style contract mints
+    /// a `BeaconProxy(beacon, "")` to, for a given salt. Empty init-data means
+    /// the salt is the sole source of address uniqueness — this mirrors the
+    /// exact derivation the deployer performs.
+    /// @param deployer The contract executing the CREATE2 (the beacon-set deployer).
+    /// @param beacon The beacon address baked into the proxy constructor args.
+    /// @param salt The CREATE2 salt (`keccak256(abi.encode(config))`).
+    /// @return The deterministically-derived proxy address.
+    function deriveBeaconProxyAddress(address deployer, address beacon, bytes32 salt) internal pure returns (address) {
+        bytes32 initCodeHash =
+            keccak256(abi.encodePacked(type(BeaconProxy).creationCode, abi.encode(beacon, bytes(""))));
+        return address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, initCodeHash)))));
+    }
+
+    /// @notice Assert a beacon proxy landed at its deterministically-derived
+    /// address. Reverts `DeployRecordAddressMismatch` otherwise.
+    /// @param actual The proxy's actual address.
+    /// @param deployer The beacon-set deployer that minted it.
+    /// @param beacon The beacon baked into the proxy.
+    /// @param salt The CREATE2 salt used.
+    function verifyBeaconProxyAddress(address actual, address deployer, address beacon, bytes32 salt) internal pure {
+        address expected = deriveBeaconProxyAddress(deployer, beacon, salt);
+        if (actual != expected) {
+            revert DeployRecordAddressMismatch(expected, actual);
+        }
+    }
+}

--- a/src/generated/DeployRecordLib.sol
+++ b/src/generated/DeployRecordLib.sol
@@ -53,9 +53,14 @@ library DeployRecordLib {
     /// @param salt The CREATE2 salt (`keccak256(abi.encode(config))`).
     /// @return The deterministically-derived proxy address.
     function deriveBeaconProxyAddress(address deployer, address beacon, bytes32 salt) internal pure returns (address) {
+        // `type(BeaconProxy).creationCode` inlines the proxy bytecode; slither's
+        // too-many-digits detector flags the embedded literal. This is the
+        // canonical CREATE2 init-code-hash derivation, not a magic number.
+        // slither-disable-start too-many-digits
         bytes32 initCodeHash =
             keccak256(abi.encodePacked(type(BeaconProxy).creationCode, abi.encode(beacon, bytes(""))));
         return address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, initCodeHash)))));
+        // slither-disable-end too-many-digits
     }
 
     /// @notice Assert a beacon proxy landed at its deterministically-derived

--- a/test/src/deploy/DeployRecordForkBase.t.sol
+++ b/test/src/deploy/DeployRecordForkBase.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test, console2} from "forge-std-1.16.1/src/Test.sol";
+import {DeployRecordBase} from "../../../src/generated/DeployRecordBase.sol";
+import {DeployRecordLib} from "../../../src/generated/DeployRecordLib.sol";
+
+/// @title DeployRecordForkBaseTest
+/// @notice Fork test proving the LIVE code on Base at each recorded DIA-stack
+/// address still hashes to the codehash frozen in `DeployRecordBase` — the
+/// verification the audit (#259) asks for: after this passes, anyone can confirm
+/// the live infra has not been silently swapped since the release was frozen.
+///
+/// Forks Base from `BASE_RPC_URL`. Mirrors the repo's fork-test convention: the
+/// dedicated `fork-tests.yaml` workflow wires the RPC and runs it for real; the
+/// per-push rainix job does not inject an RPC, so when `BASE_RPC_URL` is unset
+/// this loudly logs and RETURNS rather than erroring — `no-ignored-tests` bans
+/// `vm.skip`, and a hard `createSelectFork` failure would red every per-push
+/// run. Locally, export `BASE_RPC_URL=https://mainnet.base.org` to run it.
+///
+/// @dev The recorded DIA impls are the FIRST ("pre-fold") release; their
+/// codehashes intentionally differ from what current source builds (see the
+/// PROVENANCE note in `DeployRecordBase`). This test therefore asserts the live
+/// code equals the RECORDED codehash — proving the live release is unchanged —
+/// NOT that it equals a fresh `forge build`. The empty signed-price record
+/// (`bytes32(0)`) is skipped by `verifyCodehash`, so this test needs no edit
+/// when that stack is deployed and its record populated.
+contract DeployRecordForkBaseTest is Test {
+    function testForkLiveDIAStackMatchesRecordedCodehashes() external {
+        string memory rpc = vm.envOr("BASE_RPC_URL", string(""));
+        if (bytes(rpc).length == 0) {
+            console2.log("SKIP testForkLiveDIAStackMatchesRecordedCodehashes: BASE_RPC_URL unset");
+            return;
+        }
+        vm.createSelectFork(rpc);
+
+        assertEq(block.chainid, DeployRecordBase.CHAIN_ID, "forked chain is the recorded chain (Base)");
+
+        // Each recorded DIA-stack address must still carry code hashing to its
+        // frozen codehash. A swap, self-destruct, or wrong record reverts
+        // DeployRecordCodehashMismatch inside verifyCodehash.
+        DeployRecordLib.verifyCodehash(
+            DeployRecordBase.DIA_VAULT_ORACLE_BEACON_SET_DEPLOYER,
+            DeployRecordBase.DIA_VAULT_ORACLE_BEACON_SET_DEPLOYER_CODEHASH
+        );
+        DeployRecordLib.verifyCodehash(
+            DeployRecordBase.DIA_VAULT_ORACLE_IMPLEMENTATION, DeployRecordBase.DIA_VAULT_ORACLE_IMPLEMENTATION_CODEHASH
+        );
+        DeployRecordLib.verifyCodehash(
+            DeployRecordBase.DIA_WTCOIN_ORACLE_PROXY, DeployRecordBase.DIA_WTCOIN_ORACLE_PROXY_CODEHASH
+        );
+
+        // The signed-price stack is not deployed on Base; its record is empty
+        // (bytes32(0)) and verifyCodehash skips it. Exercised here so the test
+        // stays correct the day the record is populated.
+        DeployRecordLib.verifyCodehash(
+            DeployRecordBase.ST0X_PRICE_ORACLE_BEACON_SET_DEPLOYER,
+            DeployRecordBase.ST0X_PRICE_ORACLE_BEACON_SET_DEPLOYER_CODEHASH
+        );
+        DeployRecordLib.verifyCodehash(
+            DeployRecordBase.MORPHO_PAIR_ADAPTER_BEACON_SET_DEPLOYER,
+            DeployRecordBase.MORPHO_PAIR_ADAPTER_BEACON_SET_DEPLOYER_CODEHASH
+        );
+
+        console2.log("Live Base DIA stack matches all recorded codehashes");
+    }
+}

--- a/test/src/deploy/DeployRecordHarness.sol
+++ b/test/src/deploy/DeployRecordHarness.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {DeployRecordLib} from "../../../src/generated/DeployRecordLib.sol";
+
+/// @title DeployRecordHarness
+/// @dev Test-only wrapper exposing the `internal` `DeployRecordLib` checks as
+/// EXTERNAL functions. `vm.expectRevert` only catches reverts one call-frame
+/// below the cheatcode; an inlined internal library call reverts at the same
+/// depth ("call didn't revert at a lower depth"). Routing through this harness
+/// gives the revert its own frame so the specific-error expectation works.
+contract DeployRecordHarness {
+    function verifyCodehash(address account, bytes32 expected) external view {
+        DeployRecordLib.verifyCodehash(account, expected);
+    }
+
+    function verifyBeaconProxyAddress(address actual, address deployer, address beacon, bytes32 salt) external pure {
+        DeployRecordLib.verifyBeaconProxyAddress(actual, deployer, beacon, salt);
+    }
+}

--- a/test/src/deploy/DeployRecordSelfTest.t.sol
+++ b/test/src/deploy/DeployRecordSelfTest.t.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {IDIAOracleV2} from "../../../src/interface/IDIAOracleV2.sol";
+import {DIAVaultOracle, DIAVaultOracleConfig} from "../../../src/concrete/oracle/DIAVaultOracle.sol";
+import {
+    DIAVaultOracleBeaconSetDeployer,
+    DIAVaultOracleBeaconSetDeployerConfig
+} from "../../../src/concrete/deploy/DIAVaultOracleBeaconSetDeployer.sol";
+import {
+    DeployRecordLib,
+    DeployRecordCodehashMismatch,
+    DeployRecordAddressMismatch
+} from "../../../src/generated/DeployRecordLib.sol";
+import {DeployRecordHarness} from "./DeployRecordHarness.sol";
+import {MockDIAOracle} from "../../mocks/MockDIAOracle.sol";
+import {MockERC4626} from "../../mocks/MockERC4626.sol";
+import {MockCorporateActions} from "../../mocks/MockCorporateActions.sol";
+import {ACTION_TYPE_STOCK_SPLIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
+
+/// @title DeployRecordSelfTest
+/// @notice Proves the deployment-record CHECK MECHANISM works, independently of
+/// any real prod record (which may be empty pending a deploy). It deploys the
+/// DIA stack locally exactly as `script/Deploy.sol` does (impl → beacon-set
+/// deployer → CREATE2 proxy), snapshots each resulting address and its
+/// `address.code` codehash — i.e. builds a record the same way a real deploy
+/// would — and then asserts the check logic against that fresh record:
+///   * `verifyCodehash` passes when the recorded codehash equals the live one
+///     and reverts `DeployRecordCodehashMismatch` when the code has changed;
+///   * `verifyBeaconProxyAddress` confirms the proxy sits at its deterministic
+///     CREATE2 address and reverts `DeployRecordAddressMismatch` on a wrong salt.
+/// If this harness is correct, an empty prod record is a matter of populating
+/// constants at next deploy — the verification path is already proven sound.
+contract DeployRecordSelfTest is Test {
+    address internal constant BEACON_OWNER = address(0xB6ACD0);
+
+    DIAVaultOracleBeaconSetDeployer internal sBsd;
+    MockDIAOracle internal sDiaOracle;
+    MockERC4626 internal sVault;
+    MockCorporateActions internal sActions;
+    DeployRecordHarness internal sHarness;
+
+    function setUp() public {
+        sHarness = new DeployRecordHarness();
+        sDiaOracle = new MockDIAOracle();
+        sVault = new MockERC4626();
+        sActions = new MockCorporateActions();
+        sVault.setAsset(address(sActions));
+        vm.warp(1_000_000);
+
+        // Mirror `deployDIAStackInfra`: fresh implementation, then the
+        // beacon-set deployer that owns the beacon over it.
+        DIAVaultOracle implementation = new DIAVaultOracle();
+        sBsd = new DIAVaultOracleBeaconSetDeployer(
+            DIAVaultOracleBeaconSetDeployerConfig({
+                initialOwner: BEACON_OWNER, initialDIAVaultOracleImplementation: address(implementation)
+            })
+        );
+    }
+
+    function _config() internal view returns (DIAVaultOracleConfig memory) {
+        return DIAVaultOracleConfig({
+            diaOracle: IDIAOracleV2(address(sDiaOracle)),
+            symbol: "COIN",
+            vault: address(sVault),
+            maxAge: 1 hours,
+            actionTypeMask: ACTION_TYPE_STOCK_SPLIT_V1,
+            pauseTimeBefore: 3600,
+            pauseTimeAfter: 3600
+        });
+    }
+
+    /// @notice Record-then-verify round trip: deploy the stack, freeze each
+    /// address + `address.code` codehash into a local record, and prove
+    /// `verifyCodehash` accepts every recorded entry against its live code. This
+    /// is the exact check the fork test runs against the live chain, so its
+    /// passing here proves the check logic is sound.
+    function testSelfRecordedCodehashesVerify() external {
+        DIAVaultOracle proxy = sBsd.newDIAVaultOracle(_config());
+
+        address beacon = address(sBsd.I_DIA_VAULT_ORACLE_BEACON());
+
+        // "Record" = the address + keccak256(address.code) a real deploy freezes.
+        address[3] memory accounts = [address(sBsd), beacon, address(proxy)];
+        for (uint256 i = 0; i < accounts.length; i++) {
+            bytes32 recorded = accounts[i].codehash;
+            assertTrue(recorded != bytes32(0), "recorded account has code");
+            // Passes: recorded codehash == live codehash at the recorded address.
+            DeployRecordLib.verifyCodehash(accounts[i], recorded);
+        }
+    }
+
+    /// @notice `verifyCodehash` MUST reject a record whose codehash no longer
+    /// matches the live code — the whole point of the freeze is to catch a
+    /// silent code swap under a recorded address.
+    function testVerifyCodehashRevertsOnDivergence() external {
+        DIAVaultOracle proxy = sBsd.newDIAVaultOracle(_config());
+        address account = address(proxy);
+        bytes32 live = account.codehash;
+        bytes32 tampered = keccak256("not the recorded code");
+
+        vm.expectRevert(abi.encodeWithSelector(DeployRecordCodehashMismatch.selector, account, tampered, live));
+        sHarness.verifyCodehash(account, tampered);
+    }
+
+    /// @notice An unset record slot (`bytes32(0)`) is a no-op: an EMPTY prod
+    /// record must not assert against `address(0)`. Proves the empty
+    /// signed-price record in `DeployRecordBase` is safely skipped.
+    function testVerifyCodehashSkipsEmptyRecord() external view {
+        // No revert despite address(0) carrying no code.
+        DeployRecordLib.verifyCodehash(address(0), bytes32(0));
+    }
+
+    /// @notice The CREATE2 proxy MUST sit at the address derived from
+    /// `salt = keccak256(abi.encode(config))`, deployer and beacon — the
+    /// deterministic commitment that makes a re-run collide instead of forking.
+    /// Proves `verifyBeaconProxyAddress` accepts the real proxy.
+    function testSelfProxyAddressIsDeterministic() external {
+        DIAVaultOracleConfig memory cfg = _config();
+        bytes32 salt = keccak256(abi.encode(cfg));
+        address beacon = address(sBsd.I_DIA_VAULT_ORACLE_BEACON());
+
+        DIAVaultOracle proxy = sBsd.newDIAVaultOracle(cfg);
+
+        DeployRecordLib.verifyBeaconProxyAddress(address(proxy), address(sBsd), beacon, salt);
+        assertEq(
+            address(proxy),
+            DeployRecordLib.deriveBeaconProxyAddress(address(sBsd), beacon, salt),
+            "proxy at deterministic CREATE2 address"
+        );
+    }
+
+    /// @notice `verifyBeaconProxyAddress` MUST reject a proxy that is NOT at its
+    /// derived address (here: wrong salt) — catching a proxy that is not the
+    /// deterministic commitment to its config.
+    function testVerifyBeaconProxyAddressRevertsOnWrongSalt() external {
+        DIAVaultOracleConfig memory cfg = _config();
+        address beacon = address(sBsd.I_DIA_VAULT_ORACLE_BEACON());
+        DIAVaultOracle proxy = sBsd.newDIAVaultOracle(cfg);
+
+        bytes32 wrongSalt = keccak256("wrong salt");
+        address wrongExpected = DeployRecordLib.deriveBeaconProxyAddress(address(sBsd), beacon, wrongSalt);
+
+        vm.expectRevert(abi.encodeWithSelector(DeployRecordAddressMismatch.selector, wrongExpected, address(proxy)));
+        sHarness.verifyBeaconProxyAddress(address(proxy), address(sBsd), beacon, wrongSalt);
+    }
+}


### PR DESCRIPTION
Closes #259. The repo deployed the DIA/signed-price stacks but froze no verifiable per-release record — nobody could confirm the live infra is the code this repo built, and a re-deploy could silently fork a divergent set.

**Mechanism (5 new `.sol` files, per AGENTS.md `.sol`-constants convention — no JSON registry):**
- `src/generated/DeployRecordBase.sol` — the record: per deployed contract, address + on-chain runtime codehash.
- `src/generated/DeployRecordLib.sol` — `verifyCodehash` (live `address.codehash` == recorded; empty slots no-op) + `verifyBeaconProxyAddress` (CREATE2 derivation for salted proxies), typed reverts.
- `test/src/deploy/DeployRecordSelfTest.t.sol` — deploys the DIA stack locally, records address+codehash, proves the checks accept a true record and revert on a tampered codehash / wrong salt.
- `test/src/deploy/DeployRecordForkBase.t.sol` — fork-gated: asserts live Base code at each recorded address matches its recorded codehash; early-returns (no `vm.skip`) when `BASE_RPC_URL` is unset.
- `test/src/deploy/DeployRecordHarness.sol` — external wrapper for `vm.expectRevert` on the internal library.

**Live addresses recovered** from the deleted `deployments/base.json` (git history) and codehashes re-read live via a Base fork — the fork test passes against live Base. The signed-price stack isn't deployed, so its record is intentionally empty with a "populate at first deploy" note.

⚠️ **Provenance nuance (reviewer must read):** the recorded DIA impls are the **currently-live FIRST ("pre-fold") release** — they predate folding the pause wrapper into `DIAVaultOracle`. So the recorded codehashes intentionally differ from what current `forge build` produces. The check is deliberately "has the live code changed since we froze it," NOT "live == HEAD." On redeploy onto the current (folded) impls, add a new record block rather than mutating these.

Full suite 148 passing (incl. both fork tests against live Base); single-contract + reuse green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)