### PR TITLE
audit: LibCorporateActionsPause coverage + defensive guards (#255, #74, #199, #200, #276, #272, #216)

### DIFF
--- a/src/lib/LibCorporateActionsPause.sol
+++ b/src/lib/LibCorporateActionsPause.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-DCL-1.0
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity =0.8.25;
+pragma solidity ^0.8.25;
 
 import {ICorporateActionsV1, ACTION_TYPE_INIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
 import {CompletionFilter, NODE_NONE} from "st0x-deploy-0.1.1/src/lib/LibCorporateActionNode.sol";
@@ -76,12 +76,26 @@ library LibCorporateActionsPause {
         // `NODE_NONE = type(uint256).max` is the documented no-match sentinel
         // from `ICorporateActionsV1` — cursor `0` is a real bootstrap node and
         // must NOT be treated as "no match".
-        if (pendingCursor != NODE_NONE) {
-            // pendingEffective > now is guaranteed by the PENDING filter.
-            // We compare via addition on uint256-promoted operands so neither
-            // underflow nor overflow is possible for any realistic timestamp.
-            // slither-disable-next-line timestamp
-            if (block.timestamp + uint256(pauseTimeBefore) >= uint256(pendingEffective)) {
+        // `effectiveTime == 0` is the documented sentinel for a cancelled
+        // (unlinked) node; under the upstream unlinking contract such a node
+        // is never returned by the traversal API, but we reject it here as
+        // defence-in-depth so a leaked cancelled node cannot yield `(true, 0)`.
+        if (pendingCursor != NODE_NONE && pendingEffective != 0) {
+            // Defence-in-depth: re-assert the PENDING filter's invariant
+            // locally. `pendingEffective > now` is guaranteed server-side by
+            // the PENDING completion filter; if a regressed vault returned a
+            // "PENDING" action whose effectiveTime is already in the past, the
+            // pre-window predicate `now + before >= pendingEffective` would be
+            // trivially true for any `pauseTimeBefore` and spuriously open a
+            // pre-window on a phantom action. Skip such a node — cleanly
+            // degrade to "no pending action", never revert.
+            if (uint256(pendingEffective) <= block.timestamp) {
+                // Phantom pending: treat as no pending action.
+            } else if (block.timestamp + uint256(pauseTimeBefore) >= uint256(pendingEffective)) {
+                // We compare via addition on uint256-promoted operands so
+                // neither underflow nor overflow is possible for any realistic
+                // timestamp.
+                // slither-disable-next-line timestamp
                 return (true, pendingEffective);
             }
         }
@@ -91,10 +105,18 @@ library LibCorporateActionsPause {
         // slither-disable-next-line unused-return
         (uint256 completedCursor,, uint64 completedEffective) =
             vault.latestActionOfType(effectiveMask, CompletionFilter.COMPLETED);
-        if (completedCursor != NODE_NONE) {
-            // completedEffective <= now is guaranteed by the COMPLETED filter.
-            // slither-disable-next-line timestamp
-            if (block.timestamp <= uint256(completedEffective) + uint256(pauseTimeAfter)) {
+        // Same `effectiveTime == 0` cancelled-node guard as the pending branch.
+        if (completedCursor != NODE_NONE && completedEffective != 0) {
+            // Defence-in-depth: re-assert the COMPLETED filter's invariant
+            // locally. `completedEffective <= now` is guaranteed server-side by
+            // the COMPLETED completion filter; if a regressed vault returned a
+            // "COMPLETED" action whose effectiveTime is in the future, skip it
+            // rather than open a phantom post-window. Cleanly degrade to "no
+            // completed action", never revert.
+            if (uint256(completedEffective) > block.timestamp) {
+                // Phantom completed: treat as no completed action.
+            } else if (block.timestamp <= uint256(completedEffective) + uint256(pauseTimeAfter)) {
+                // slither-disable-next-line timestamp
                 return (true, completedEffective);
             }
         }

--- a/src/lib/LibCorporateActionsPause.sol
+++ b/src/lib/LibCorporateActionsPause.sol
@@ -89,13 +89,15 @@ library LibCorporateActionsPause {
             // trivially true for any `pauseTimeBefore` and spuriously open a
             // pre-window on a phantom action. Skip such a node — cleanly
             // degrade to "no pending action", never revert.
-            if (uint256(pendingEffective) <= block.timestamp) {
-                // Phantom pending: treat as no pending action.
-            } else if (block.timestamp + uint256(pauseTimeBefore) >= uint256(pendingEffective)) {
-                // We compare via addition on uint256-promoted operands so
-                // neither underflow nor overflow is possible for any realistic
-                // timestamp.
-                // slither-disable-next-line timestamp
+            // A phantom pending (`pendingEffective <= now`) fails the first
+            // conjunct and is skipped. The window addition is on uint256-promoted
+            // operands so neither underflow nor overflow is possible.
+            // slither-disable-start timestamp
+            if (
+                uint256(pendingEffective) > block.timestamp
+                    && block.timestamp + uint256(pauseTimeBefore) >= uint256(pendingEffective)
+            ) {
+                // slither-disable-end timestamp
                 return (true, pendingEffective);
             }
         }
@@ -113,10 +115,14 @@ library LibCorporateActionsPause {
             // "COMPLETED" action whose effectiveTime is in the future, skip it
             // rather than open a phantom post-window. Cleanly degrade to "no
             // completed action", never revert.
-            if (uint256(completedEffective) > block.timestamp) {
-                // Phantom completed: treat as no completed action.
-            } else if (block.timestamp <= uint256(completedEffective) + uint256(pauseTimeAfter)) {
-                // slither-disable-next-line timestamp
+            // A phantom completed (`completedEffective > now`) fails the first
+            // conjunct and is skipped.
+            // slither-disable-start timestamp
+            if (
+                uint256(completedEffective) <= block.timestamp
+                    && block.timestamp <= uint256(completedEffective) + uint256(pauseTimeAfter)
+            ) {
+                // slither-disable-end timestamp
                 return (true, completedEffective);
             }
         }

--- a/test/mocks/CorporateActionsListHarness.sol
+++ b/test/mocks/CorporateActionsListHarness.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {CompletionFilter, LibCorporateActionNode} from "st0x-deploy-0.1.1/src/lib/LibCorporateActionNode.sol";
+import {LibCorporateAction} from "st0x-deploy-0.1.1/src/lib/LibCorporateAction.sol";
+
+/// @title CorporateActionsListHarness
+/// @notice Thin harness that drives the REAL upstream corporate-action list
+/// primitives — `LibCorporateAction.schedule` / `.cancel` and
+/// `LibCorporateActionNode.{earliest,latest}ActionOfType` — directly against
+/// this contract's own ERC-7201 storage.
+///
+/// Why not the real `StoxCorporateActionsFacet`? That facet carries
+/// `onlyDelegatecalled` on every entry point (including the view getters), so a
+/// standalone `new StoxCorporateActionsFacet()` reverts `FacetMustBeDelegatecalled`
+/// on any direct call; exercising it requires a full delegatecall + authorizer
+/// + `OffchainAssetReceiptVault` harness. The conventions audit #216 pins — the
+/// no-match sentinel, mask filter shape, effective-time monotonicity, and
+/// `cancel` unlinking — all live in `LibCorporateAction` / `LibCorporateActionNode`,
+/// which the facet merely delegates to verbatim (see
+/// `StoxCorporateActionsFacet.{earliest,latest}ActionOfType`). Driving those
+/// libraries directly exercises the identical traversal + list-mutation code
+/// path the facet exposes, with none of the delegatecall scaffolding, and pins
+/// exactly the wire-format conventions `LibCorporateActionsPause` depends on.
+///
+/// `schedule` is called with an already-resolved `actionType`, bypassing
+/// `resolveActionType` (which validates stock-split params via the vault's
+/// ERC20 `decimals()` — irrelevant to list-shape conventions and not wired on a
+/// bare harness). The list insert/traversal/unlink logic is unaffected by the
+/// stored `parameters` payload.
+contract CorporateActionsListHarness {
+    function schedule(uint256 actionType, uint64 effectiveTime) external returns (uint256) {
+        return LibCorporateAction.schedule(actionType, effectiveTime, "");
+    }
+
+    function cancel(uint256 actionId) external {
+        LibCorporateAction.cancel(actionId);
+    }
+
+    function earliestActionOfType(uint256 mask, CompletionFilter filter)
+        external
+        view
+        returns (uint256, uint256, uint64)
+    {
+        return LibCorporateActionNode.earliestActionOfType(mask, filter);
+    }
+
+    function latestActionOfType(uint256 mask, CompletionFilter filter)
+        external
+        view
+        returns (uint256, uint256, uint64)
+    {
+        return LibCorporateActionNode.latestActionOfType(mask, filter);
+    }
+}

--- a/test/mocks/MockStringRevertingCorporateActions.sol
+++ b/test/mocks/MockStringRevertingCorporateActions.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @title MockStringRevertingCorporateActions
+/// @notice A vault-shaped contract whose every call reverts with a fixed
+/// string reason via a catch-all `fallback`. Unlike `MockRevertingCorporateActions`
+/// (which reverts a typed custom error) this reverts a plain `Error(string)`,
+/// letting a test assert the *exact* underlying reason propagates unswallowed
+/// through `LibCorporateActionsPause.inPauseWindow`'s external read calls.
+///
+/// Used by audit #74: proves a non-zero corporate-actions vault that reverts on
+/// the read paths (an EOA, a wrong-ABI contract, or a paused implementation)
+/// bubbles the underlying revert rather than being silently caught. This is the
+/// deliberate opposite of the mask-0 short-circuit test, which proves the vault
+/// is NOT called at all.
+contract MockStringRevertingCorporateActions {
+    // solhint-disable-next-line payable-fallback, no-complex-fallback
+    fallback() external payable {
+        revert("vault-reverts");
+    }
+}

--- a/test/src/lib/LibCorporateActionsPause.t.sol
+++ b/test/src/lib/LibCorporateActionsPause.t.sol
@@ -7,7 +7,11 @@ import {NODE_NONE} from "st0x-deploy-0.1.1/src/lib/LibCorporateActionNode.sol";
 import {LibCorporateActionsPause} from "../../../src/lib/LibCorporateActionsPause.sol";
 import {ACTION_TYPE_INIT_V1, ACTION_TYPE_STOCK_SPLIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
 import {MockCorporateActions} from "../../mocks/MockCorporateActions.sol";
-import {MockRevertingCorporateActions} from "../../mocks/MockRevertingCorporateActions.sol";
+import {
+    MockRevertingCorporateActions,
+    CorporateActionsUnavailable
+} from "../../mocks/MockRevertingCorporateActions.sol";
+import {MockStringRevertingCorporateActions} from "../../mocks/MockStringRevertingCorporateActions.sol";
 
 contract LibCorporateActionsPauseTest is Test {
     MockCorporateActions internal mock;
@@ -56,6 +60,45 @@ contract LibCorporateActionsPauseTest is Test {
         (paused, ts) = LibCorporateActionsPause.inPauseWindow(address(reverting), ACTION_TYPE_INIT_V1, BEFORE, AFTER);
         assertEq(paused, false, "INIT-only mask must short-circuit without querying the vault");
         assertEq(ts, 0);
+    }
+
+    // -------- Reverting / bad vault on the read paths (audit #74) --------
+
+    /// A non-zero vault that reverts on the read paths must propagate the
+    /// underlying revert, not swallow it. `inPauseWindow` makes external calls
+    /// to `earliestActionOfType` / `latestActionOfType`; if the vault reverts
+    /// (paused impl, wrong ABI, etc.) the whole price read must revert with the
+    /// underlying reason. This is the deliberate opposite of the mask-0
+    /// short-circuit test (which proves the vault is NOT called): here a
+    /// non-zero mask reaches a real read path against a reverting vault, so a
+    /// regression adding a `try/catch` that returned `(false, 0)` would be
+    /// caught. Closes audit #74.
+    function testRevertingVaultPropagates() external {
+        MockStringRevertingCorporateActions reverting = new MockStringRevertingCorporateActions();
+        // Route through an external boundary so `vm.expectRevert` unambiguously
+        // targets the `inPauseWindow` call rather than any inlined sub-call.
+        vm.expectRevert("vault-reverts");
+        this.callInPauseWindow(address(reverting), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+    }
+
+    /// A custom-error-reverting vault (typed revert, no string) must likewise
+    /// propagate the exact custom error selector. Complements the string-revert
+    /// case above and pins that the propagation is reason-preserving for both
+    /// revert encodings. #74.
+    function testCustomErrorRevertingVaultPropagates() external {
+        MockRevertingCorporateActions reverting = new MockRevertingCorporateActions();
+        vm.expectRevert(CorporateActionsUnavailable.selector);
+        this.callInPauseWindow(address(reverting), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+    }
+
+    /// External wrapper around the internal library call so revert-propagation
+    /// tests can point `vm.expectRevert` at a single external call boundary.
+    function callInPauseWindow(address vault, uint256 mask, uint64 pauseBefore, uint64 pauseAfter)
+        external
+        view
+        returns (bool, uint64)
+    {
+        return LibCorporateActionsPause.inPauseWindow(vault, mask, pauseBefore, pauseAfter);
     }
 
     // -------- No actions --------
@@ -245,6 +288,51 @@ contract LibCorporateActionsPauseTest is Test {
         assertEq(ts, 0);
     }
 
+    // -------- Audit #200: cancelled-node effectiveTime==0 sentinel guard --------
+
+    /// `effectiveTime == 0` is the documented sentinel for a cancelled
+    /// (unlinked) node. Under the upstream unlinking contract such a node is
+    /// never returned by the traversal API, but if a future regression leaked
+    /// one through with a real (non-`NODE_NONE`) cursor, the naive predicate
+    /// `now + before >= 0` would be trivially true and the library would return
+    /// `(true, 0)` — a spurious pause reporting a zero effectiveTime. The
+    /// defensive `pendingEffective != 0` guard rejects it. Closes audit #200
+    /// (pending side).
+    function testPendingCancelledSentinelEffectiveZeroDoesNotPause() external {
+        // Leaked cancelled node: real cursor, effectiveTime unlinked to 0.
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, 0);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, false, "cancelled-node sentinel (effectiveTime==0) must not pause on the pending branch");
+        assertEq(ts, 0);
+    }
+
+    /// Symmetric to the above for the COMPLETED branch: a leaked cancelled node
+    /// with a real cursor and `effectiveTime == 0` must not open a post-window.
+    /// The predicate `now <= 0 + after` would otherwise be false only for
+    /// `after < now`; at boot / low timestamps it could pause spuriously. Guard
+    /// via `completedEffective != 0`. Closes audit #200 (completed side).
+    function testCompletedCancelledSentinelEffectiveZeroDoesNotPause() external {
+        mock.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, 0);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, type(uint64).max);
+        assertEq(paused, false, "cancelled-node sentinel (effectiveTime==0) must not pause on the completed branch");
+        assertEq(ts, 0);
+    }
+
+    /// A leaked cancelled PENDING sentinel must be skipped WITHOUT swallowing a
+    /// legitimately-open COMPLETED post-window — proves the pending guard
+    /// degrades to "no pending action" and falls through. #200.
+    function testPendingCancelledSentinelFallsThroughToCompleted() external {
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, 0);
+        uint64 completedTime = uint64(block.timestamp - AFTER / 2);
+        mock.setLatestCompleted(2, ACTION_TYPE_STOCK_SPLIT_V1, completedTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, true, "cancelled pending sentinel must fall through to a real completed post-window");
+        assertEq(ts, completedTime);
+    }
+
     /// Under a wildcard mask the `ACTION_TYPE_INIT_V1` bootstrap node must NOT
     /// trigger a pause: it is a price-irrelevant bookkeeping entry that
     /// completes in the same block as the first `scheduleCorporateAction`, so
@@ -284,24 +372,64 @@ contract LibCorporateActionsPauseTest is Test {
 
     // -------- Defensive boundary tests (audit #72) --------
 
-    /// Per the library's comment, `pendingEffective > block.timestamp` is
-    /// guaranteed by the PENDING completion filter on the upstream vault, not
-    /// re-validated here. If a misbehaving upstream returned a pending action
-    /// with `effectiveTime <= now`, the pre-window predicate `now + before >=
-    /// pendingEffective` is trivially satisfied for any non-negative
-    /// `pauseTimeBefore`, so the oracle would pause. Pin this behaviour so a
-    /// future refactor that adds a local guard surfaces as a deliberate test
-    /// update. Closes audit #72 (a).
-    function testPendingEffectiveAtNowStillPausesDefensive() external {
+    /// Defence-in-depth (audit #199): `pendingEffective > block.timestamp` is
+    /// guaranteed server-side by the PENDING completion filter, and the library
+    /// now re-asserts it locally. If a misbehaving upstream returned a "PENDING"
+    /// action with `effectiveTime == now`, the pre-window predicate `now +
+    /// before >= pendingEffective` would be trivially satisfied for any
+    /// `pauseTimeBefore` and spuriously open a pre-window. The local guard skips
+    /// such a phantom node and cleanly degrades to "no pending action" — it must
+    /// NOT pause and must NOT revert. Closes audit #72 (a) / #199 (pending side).
+    function testPendingEffectiveAtNowDoesNotPauseDefensive() external {
         // Upstream invariant violation: PENDING action with effective time at
         // exactly `now`.
         uint64 effectiveTime = uint64(block.timestamp);
         mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
         (bool paused, uint64 ts) =
             LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
-        // Current behaviour: pauses because `now + BEFORE >= now`.
-        assertEq(paused, true, "current lib pauses when upstream returns pendingEffective <= now");
-        assertEq(ts, effectiveTime);
+        assertEq(paused, false, "phantom PENDING (effectiveTime <= now) must be skipped, not paused");
+        assertEq(ts, 0);
+    }
+
+    /// Symmetric to the above with a strictly-past effectiveTime: a "PENDING"
+    /// action whose effectiveTime is well before `now` must be skipped by the
+    /// local re-assertion rather than spuriously opening a pre-window. #199.
+    function testPendingEffectiveInPastDoesNotPauseDefensive() external {
+        uint64 effectiveTime = uint64(block.timestamp - 1);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, type(uint64).max, AFTER);
+        assertEq(paused, false, "phantom PENDING with past effectiveTime must not open a pre-window");
+        assertEq(ts, 0);
+    }
+
+    /// Symmetric post-window defence (#199): a "COMPLETED" action whose
+    /// effectiveTime is in the future is a filter regression — the library must
+    /// skip it rather than open a phantom post-window. Cleanly degrades to "no
+    /// completed action", never reverts.
+    function testCompletedEffectiveInFutureDoesNotPauseDefensive() external {
+        uint64 effectiveTime = uint64(block.timestamp + 1);
+        mock.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, type(uint64).max);
+        assertEq(paused, false, "phantom COMPLETED with future effectiveTime must not open a post-window");
+        assertEq(ts, 0);
+    }
+
+    /// A phantom PENDING (effectiveTime <= now) must be skipped WITHOUT
+    /// swallowing a legitimately-open COMPLETED post-window. Proves the pending
+    /// re-assertion degrades to "no pending action" and falls through to the
+    /// completed branch rather than returning early. #199.
+    function testPhantomPendingFallsThroughToCompleted() external {
+        // Phantom PENDING at exactly now.
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp));
+        // Real COMPLETED inside its post-window.
+        uint64 completedTime = uint64(block.timestamp - AFTER / 2);
+        mock.setLatestCompleted(2, ACTION_TYPE_STOCK_SPLIT_V1, completedTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, true, "phantom pending must fall through to a real completed post-window");
+        assertEq(ts, completedTime);
     }
 
     /// `pauseTimeAfter == type(uint64).max` must not overflow the post-window
@@ -318,6 +446,21 @@ contract LibCorporateActionsPauseTest is Test {
         assertEq(ts, effectiveTime);
     }
 
+    /// Symmetric before-side overflow guard (audit #255). The completed branch
+    /// has `testMaxPauseTimeAfterDoesNotOverflow`; the pending pre-window
+    /// arithmetic `block.timestamp + uint256(pauseTimeBefore)` must likewise be
+    /// promoted to uint256 so `pauseTimeBefore == type(uint64).max` neither
+    /// overflows nor wraps and silently flips the pre-window predicate. A
+    /// regression narrowing the addition to uint64 would wrap and fail this.
+    function testMaxPauseTimeBeforeDoesNotOverflow() external {
+        uint64 effectiveTime = uint64(block.timestamp + 10 days);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, type(uint64).max, AFTER);
+        assertEq(paused, true, "max pauseTimeBefore must not overflow and must open the pre-window");
+        assertEq(ts, effectiveTime);
+    }
+
     /// `pauseTimeBefore == 0` collapses the pre-window to a single instant:
     /// the predicate `block.timestamp + 0 >= pendingEffective` is true iff
     /// `pendingEffective <= now`. When the upstream honours the PENDING
@@ -325,16 +468,16 @@ contract LibCorporateActionsPauseTest is Test {
     /// oracle does not pause — already covered by
     /// `testZeroBeforeWithExactPendingReturnsFalse`. The symmetric boundary,
     /// where `pendingEffective` equals exactly `now`, is the upstream-
-    /// invariant edge: lib trusts the filter, but if the filter ever
-    /// included an `effectiveTime == now` action as PENDING, the oracle
-    /// would pause. Closes audit #72 (c).
-    function testZeroBeforeWithPendingAtNowPauses() external {
+    /// invariant edge. Before audit #199 the naive predicate `now + 0 >= now`
+    /// would have paused on this phantom; the local re-assertion of the PENDING
+    /// filter (`effectiveTime > now`) now skips it, so the oracle does NOT
+    /// pause. Closes audit #72 (c), tightened by #199.
+    function testZeroBeforeWithPendingAtNowDoesNotPause() external {
         mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp));
         (bool paused, uint64 ts) =
             LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, 0, AFTER);
-        // `now + 0 >= now` is true, so the pre-window matches at the instant.
-        assertEq(paused, true);
-        assertEq(ts, uint64(block.timestamp));
+        assertEq(paused, false, "phantom PENDING at exactly now must be skipped by the local filter re-assertion");
+        assertEq(ts, 0);
     }
 
     /// Invariant: `effectiveTime` is zero iff `paused` is false. Fuzz the
@@ -370,7 +513,7 @@ contract LibCorporateActionsPauseTest is Test {
             LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, pauseBefore, pauseAfter);
 
         if (!paused) {
-            assertEq(ts, 0, "SPEC 16.3: paused=false must imply effectiveTime=0");
+            assertEq(ts, 0, "paused=false must imply effectiveTime=0");
         } else {
             assertGt(ts, 0, "paused=true must report a non-zero effectiveTime");
         }

--- a/test/src/lib/LibCorporateActionsPauseConventions.t.sol
+++ b/test/src/lib/LibCorporateActionsPauseConventions.t.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {CompletionFilter, NODE_NONE} from "st0x-deploy-0.1.1/src/lib/LibCorporateActionNode.sol";
+import {
+    ACTION_TYPE_INIT_V1,
+    ACTION_TYPE_STOCK_SPLIT_V1,
+    ACTION_TYPE_STABLES_DIVIDEND_V1
+} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
+import {InvalidMask} from "st0x-deploy-0.1.1/src/error/ErrCorporateAction.sol";
+import {CorporateActionsListHarness} from "../../mocks/CorporateActionsListHarness.sol";
+
+/// @title LibCorporateActionsPauseConventions
+/// @notice Enumeration test (audit #216) pinning every `ICorporateActionsV1`
+/// convention `LibCorporateActionsPause` silently depends on, against the REAL
+/// upstream list primitives rather than a hand-mock. Fires on `st0x-deploy`
+/// submodule bumps — the exact moment a wire-format convention could shift
+/// unnoticed. The live `cursor != 0` vs `NODE_NONE` bug proved this hazard
+/// surface is non-empty.
+///
+/// COVERED against the real upstream `LibCorporateAction` / `LibCorporateActionNode`:
+///   1. No-match sentinel is `NODE_NONE == type(uint256).max` (not 0).
+///   2. Filter shape: a mask of 0 (`mask & VALID_ACTION_TYPES_MASK == 0`)
+///      reverts `InvalidMask`, so the lib's mask-0 short-circuit is load-bearing.
+///   3. Earliest/latest pending & completed monotonicity across a multi-node list.
+///   4. `cancel` unlinks a node so it disappears from earliest/latest traversal.
+///
+/// NOT covered here (see return notes): the facet's `onlyDelegatecalled` guard
+/// and authorizer permissioning are not exercised — this harness intentionally
+/// bypasses the facet wrapper to reach the same list logic the facet delegates
+/// to. The stock-split parameter validation in `resolveActionType` is also out
+/// of scope (list-shape, not param-schema, is what the pause lib depends on).
+contract LibCorporateActionsPauseConventionsTest is Test {
+    CorporateActionsListHarness internal harness;
+
+    function setUp() public {
+        harness = new CorporateActionsListHarness();
+        // Warp far enough forward that scheduling actions at now+delta and
+        // completing them by warping never underflows.
+        vm.warp(1_000_000);
+    }
+
+    /// Convention 1: the no-match sentinel is `NODE_NONE` (`type(uint256).max`),
+    /// NOT `0`. `LibCorporateActionsPause` compares `cursor != NODE_NONE`; a real
+    /// query for a valid action type that has never been scheduled must return
+    /// exactly `NODE_NONE`, proving the sentinel value the lib hard-codes.
+    function testNoMatchReturnsNodeNoneSentinel() external {
+        // Query a valid-but-unscheduled type (dividend) on a fresh list.
+        (uint256 pendingCursor,,) =
+            harness.earliestActionOfType(ACTION_TYPE_STABLES_DIVIDEND_V1, CompletionFilter.PENDING);
+        assertEq(pendingCursor, NODE_NONE, "no-match PENDING sentinel must be NODE_NONE");
+
+        (uint256 completedCursor,,) =
+            harness.latestActionOfType(ACTION_TYPE_STABLES_DIVIDEND_V1, CompletionFilter.COMPLETED);
+        assertEq(completedCursor, NODE_NONE, "no-match COMPLETED sentinel must be NODE_NONE");
+    }
+
+    /// Convention 1b: even with actions present, a mask that matches none of
+    /// them returns `NODE_NONE` (not the bootstrap index 0). Schedules a split,
+    /// then queries the dividend bit.
+    function testNonMatchingMaskReturnsNodeNoneNotZero() external {
+        harness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 1 days));
+        (uint256 cursor,,) = harness.earliestActionOfType(ACTION_TYPE_STABLES_DIVIDEND_V1, CompletionFilter.PENDING);
+        assertEq(cursor, NODE_NONE, "unmatched mask must return NODE_NONE, never the bootstrap slot 0");
+    }
+
+    /// Convention 2: the filter shape. A mask that reduces to empty against
+    /// `VALID_ACTION_TYPES_MASK` reverts `InvalidMask` upstream — this is
+    /// exactly why `LibCorporateActionsPause` MUST short-circuit on
+    /// `effectiveMask == 0` before ever querying the vault. Pins that reliance.
+    function testEmptyMaskRevertsInvalidMaskUpstream() external {
+        vm.expectRevert(InvalidMask.selector);
+        harness.earliestActionOfType(0, CompletionFilter.PENDING);
+    }
+
+    /// Convention 2b: a mask of exactly `ACTION_TYPE_INIT_V1` is a *valid* mask
+    /// upstream (INIT is in `VALID_ACTION_TYPES_MASK`), so it does NOT revert —
+    /// it matches the bootstrap node. This is why the pause lib strips the INIT
+    /// bit itself rather than relying on the vault to reject it. After a
+    /// schedule, the bootstrap init node is present and completed.
+    function testInitMaskMatchesBootstrapNodeUpstream() external {
+        harness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 1 days));
+        // Bootstrap (index 0) is INIT-typed, effectiveTime == schedule-time now,
+        // hence already completed.
+        (uint256 cursor, uint256 actionType,) =
+            harness.latestActionOfType(ACTION_TYPE_INIT_V1, CompletionFilter.COMPLETED);
+        assertEq(cursor, 0, "bootstrap INIT node lives at index 0 and matches the INIT mask");
+        assertEq(actionType, ACTION_TYPE_INIT_V1, "bootstrap node is INIT-typed");
+    }
+
+    /// Convention 3: earliest-pending monotonicity. Schedule three splits out of
+    /// time order; `earliestActionOfType(PENDING)` must return the one with the
+    /// SMALLEST effectiveTime regardless of insertion order — the property the
+    /// pause lib's "earliest pending is closest to now" reasoning relies on.
+    function testEarliestPendingIsSmallestEffectiveTime() external {
+        uint64 nowTs = uint64(block.timestamp);
+        harness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, nowTs + 30 days);
+        harness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, nowTs + 10 days);
+        harness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, nowTs + 20 days);
+
+        (,, uint64 earliestEffective) =
+            harness.earliestActionOfType(ACTION_TYPE_STOCK_SPLIT_V1, CompletionFilter.PENDING);
+        assertEq(earliestEffective, nowTs + 10 days, "earliest pending must be the smallest effectiveTime");
+    }
+
+    /// Convention 3b: latest-completed monotonicity. Schedule three splits at
+    /// distinct future times, then warp past all of them so they complete;
+    /// `latestActionOfType(COMPLETED)` must return the LARGEST effectiveTime —
+    /// the property the pause lib's "latest completed is closest to now" post-
+    /// window reasoning relies on.
+    function testLatestCompletedIsLargestEffectiveTime() external {
+        uint64 nowTs = uint64(block.timestamp);
+        harness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, nowTs + 10 days);
+        harness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, nowTs + 30 days);
+        harness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, nowTs + 20 days);
+
+        vm.warp(nowTs + 40 days);
+        (,, uint64 latestEffective) = harness.latestActionOfType(ACTION_TYPE_STOCK_SPLIT_V1, CompletionFilter.COMPLETED);
+        assertEq(latestEffective, nowTs + 30 days, "latest completed must be the largest effectiveTime");
+    }
+
+    /// Convention 4: `cancel` unlinking. `LibCorporateActionsPause` documents
+    /// that cancelled nodes are unlinked from traversal so "no explicit filter
+    /// required here". Schedule two pending splits, cancel the earlier one, and
+    /// assert `earliestActionOfType(PENDING)` now returns the SURVIVOR — the
+    /// cancelled node no longer appears in traversal.
+    function testCancelUnlinksActionFromTraversal() external {
+        uint64 nowTs = uint64(block.timestamp);
+        uint256 earlier = harness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, nowTs + 5 days);
+        harness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, nowTs + 15 days);
+
+        // Before cancel: earliest pending is the earlier one.
+        (uint256 cursorBefore,, uint64 effBefore) =
+            harness.earliestActionOfType(ACTION_TYPE_STOCK_SPLIT_V1, CompletionFilter.PENDING);
+        assertEq(cursorBefore, earlier, "earliest pending is the earlier node before cancel");
+        assertEq(effBefore, nowTs + 5 days);
+
+        harness.cancel(earlier);
+
+        // After cancel: the cancelled node is gone; earliest pending is the survivor.
+        (uint256 cursorAfter,, uint64 effAfter) =
+            harness.earliestActionOfType(ACTION_TYPE_STOCK_SPLIT_V1, CompletionFilter.PENDING);
+        assertTrue(cursorAfter != earlier, "cancelled node must be unlinked from traversal");
+        assertEq(effAfter, nowTs + 15 days, "earliest pending after cancel is the surviving node");
+    }
+
+    /// Convention 4b: cancelling the ONLY pending node returns the list to a
+    /// no-pending state — earliest pending is `NODE_NONE` again, confirming a
+    /// cancelled node neither triggers a pause nor lingers as a phantom.
+    function testCancelSolePendingReturnsNodeNone() external {
+        uint256 only = harness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 5 days));
+        harness.cancel(only);
+        (uint256 cursor,,) = harness.earliestActionOfType(ACTION_TYPE_STOCK_SPLIT_V1, CompletionFilter.PENDING);
+        assertEq(cursor, NODE_NONE, "cancelling the sole pending node returns the no-match sentinel");
+    }
+}


### PR DESCRIPTION
Audit-fix group for the corporate-action pause library. Closes #255, #74, #199, #200, #276, #216; partially addresses #272.

- **#255 (MEDIUM)** — symmetric before-side overflow test (`testMaxPauseTimeBeforeDoesNotOverflow`).
- **#74 (LOW)** — reverting-vault propagation tests on a real read path (string revert + custom error), via an external wrapper so reverts are specific.
- **#199 (MEDIUM)** — local upper-bound re-assertion: a phantom PENDING (effectiveTime<=now) / COMPLETED (effectiveTime>now) cleanly degrades to "no window" instead of relying solely on the vault filter. Existing tests that pinned the old behaviour updated.
- **#200 (LOW)** — defensive `effectiveTime != 0` guard on both branches + sentinel/fall-through tests.
- **#276 (INFO)** — remove the dangling "SPEC 16.3" citation.
- **#272 (part, LOW)** — float the library pragma to `^0.8.25`.
- **#216 (INFO)** — enumeration test pinning the `ICorporateActionsV1` list conventions the lib depends on (NODE_NONE sentinel, InvalidMask on empty mask, INIT-node validity, earliest/latest monotonicity, cancel-unlink) against the **real upstream** primitives.

**#216 scope note:** it exercises the real `LibCorporateAction`/`LibCorporateActionNode` list logic (via a thin harness on real ERC-7201 storage). It does NOT exercise the `StoxCorporateActionsFacet` wrapper's `onlyDelegatecalled` guard / authorizer / stock-split param validation — those need a full delegatecall+vault harness (fork/heavy). The lib depends on list-shape conventions, which are covered; the facet's access-control is not.

Two defensive **library behaviour** changes here (#199, #200) — worth a careful look. Full suite 159 passing; single-contract + reuse green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)