### PR TITLE
audit: dedup EIP-712 test helpers into a shared base (#271)

### DIFF
--- a/test/src/concrete/adapter/MorphoPairAdapter.t.sol
+++ b/test/src/concrete/adapter/MorphoPairAdapter.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {SignedPriceTestBase} from "../../lib/SignedPriceTestBase.sol";
 
 import {UpgradeableBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/UpgradeableBeacon.sol";
 import {BeaconProxy} from "@openzeppelin-contracts-5.6.1/proxy/beacon/BeaconProxy.sol";
@@ -18,7 +18,7 @@ import {MockERC20Decimals} from "../../../mocks/MockERC20Decimals.sol";
 /// the publisher-scale → Morpho-convention rescale (known-answer), central
 /// staleness/unset passthrough, constructor / initializer guards, and the
 /// shared beacon upgrade retargeting every deployed adapter proxy at once.
-contract MorphoPairAdapterTest is Test {
+contract MorphoPairAdapterTest is SignedPriceTestBase {
     uint256 constant SIGNER_PK = uint256(keccak256("st0x.price-oracle.signer.test"));
     address SIGNER;
 
@@ -176,17 +176,7 @@ contract MorphoPairAdapterTest is Test {
         );
     }
 
-    function _digest(bytes32 id, uint256 price, uint256 timestamp) internal view returns (bytes32) {
-        bytes32 structHash = keccak256(abi.encode(oracle.PRICE_UPDATE_TYPEHASH(), id, price, timestamp));
-        return keccak256(abi.encodePacked("\x19\x01", oracle.domainSeparator(), structHash));
-    }
-
-    function _sign(bytes32 id, uint256 price, uint256 timestamp) internal view returns (bytes memory) {
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PK, _digest(id, price, timestamp));
-        return abi.encodePacked(r, s, v);
-    }
-
     function _push(bytes32 id, uint256 price, uint256 timestamp) internal {
-        assertTrue(oracle.updatePrice(id, price, timestamp, _sign(id, price, timestamp)));
+        assertTrue(oracle.updatePrice(id, price, timestamp, signPriceUpdate(oracle, SIGNER_PK, id, price, timestamp)));
     }
 }

--- a/test/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.t.sol
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {Vm} from "forge-std-1.16.1/src/Vm.sol";
+import {SignedPriceTestBase} from "../../lib/SignedPriceTestBase.sol";
 import {UpgradeableBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/UpgradeableBeacon.sol";
 import {BeaconProxy} from "@openzeppelin-contracts-5.6.1/proxy/beacon/BeaconProxy.sol";
 import {ST0xPriceOracle} from "../../../../src/concrete/oracle/ST0xPriceOracle.sol";
@@ -16,7 +16,7 @@ import {
 import {MorphoPairAdapterV2} from "../../../mocks/MorphoPairAdapterV2.sol";
 import {MockERC20Decimals} from "../../../mocks/MockERC20Decimals.sol";
 
-contract MorphoPairAdapterBeaconSetDeployerTest is Test {
+contract MorphoPairAdapterBeaconSetDeployerTest is SignedPriceTestBase {
     uint256 internal constant SIGNER_PK = uint256(keccak256("st0x.price-oracle.signer.test"));
     address internal SIGNER;
 
@@ -192,17 +192,7 @@ contract MorphoPairAdapterBeaconSetDeployerTest is Test {
 
     // -------- Helpers --------
 
-    function _digest(bytes32 id, uint256 price, uint256 timestamp) internal view returns (bytes32) {
-        bytes32 structHash = keccak256(abi.encode(central.PRICE_UPDATE_TYPEHASH(), id, price, timestamp));
-        return keccak256(abi.encodePacked("\x19\x01", central.domainSeparator(), structHash));
-    }
-
-    function _sign(bytes32 id, uint256 price, uint256 timestamp) internal view returns (bytes memory) {
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PK, _digest(id, price, timestamp));
-        return abi.encodePacked(r, s, v);
-    }
-
     function _push(bytes32 id, uint256 price, uint256 timestamp) internal {
-        assertTrue(central.updatePrice(id, price, timestamp, _sign(id, price, timestamp)));
+        assertTrue(central.updatePrice(id, price, timestamp, signPriceUpdate(central, SIGNER_PK, id, price, timestamp)));
     }
 }

--- a/test/src/concrete/oracle/ST0xPriceOracle.t.sol
+++ b/test/src/concrete/oracle/ST0xPriceOracle.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {SignedPriceTestBase} from "../../lib/SignedPriceTestBase.sol";
 
 import {UpgradeableBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/UpgradeableBeacon.sol";
 import {BeaconProxy} from "@openzeppelin-contracts-5.6.1/proxy/beacon/BeaconProxy.sol";
@@ -16,7 +16,7 @@ import {ST0xPriceOracle} from "../../../../src/concrete/oracle/ST0xPriceOracle.s
 /// timeout config, the strict-timestamp no-op-vs-revert semantics of
 /// `updatePrice` (no registration, no nonce), `price()` unset/staleness
 /// reverts, and the deterministic `pairId` derivation.
-contract ST0xPriceOracleTest is Test {
+contract ST0xPriceOracleTest is SignedPriceTestBase {
     uint256 constant SIGNER_PK = uint256(keccak256("st0x.price-oracle.signer.test"));
     address SIGNER;
 
@@ -181,7 +181,9 @@ contract ST0xPriceOracleTest is Test {
     function test_UpdatePrice_FirstUpdateOnBrandNewPair_AppliesAndEmits() public {
         vm.expectEmit(true, false, false, true, address(oracle));
         emit ST0xPriceOracle.PriceUpdated(PAIR_A, 42e18, block.timestamp);
-        bool applied = oracle.updatePrice(PAIR_A, 42e18, block.timestamp, _sign(PAIR_A, 42e18, block.timestamp));
+        bool applied = oracle.updatePrice(
+            PAIR_A, 42e18, block.timestamp, signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, block.timestamp)
+        );
         assertTrue(applied, "fresh update should apply");
 
         (uint256 storedPrice, uint256 storedTs) = oracle.pairPrice(PAIR_A);
@@ -225,7 +227,7 @@ contract ST0xPriceOracleTest is Test {
     /// a strictly-newer payload is malformed input — that DOES revert.
     function test_UpdatePrice_InvalidSignatureOnFreshTimestamp_Reverts() public {
         uint256 wrongPk = uint256(keccak256("wrong-signer"));
-        bytes32 digest = _digest(PAIR_A, 42e18, block.timestamp);
+        bytes32 digest = digestFor(oracle, PAIR_A, 42e18, block.timestamp);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, digest);
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUpdateInvalidSignature.selector, PAIR_A));
         oracle.updatePrice(PAIR_A, 42e18, block.timestamp, abi.encodePacked(r, s, v));
@@ -234,7 +236,7 @@ contract ST0xPriceOracleTest is Test {
     /// @notice `updatePrice` is permissionless — any caller with a validly
     /// signed fresh payload succeeds.
     function test_UpdatePrice_Permissionless() public {
-        bytes memory sig = _sign(PAIR_A, 42e18, block.timestamp);
+        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, block.timestamp);
         vm.prank(RANDO);
         assertTrue(oracle.updatePrice(PAIR_A, 42e18, block.timestamp, sig), "rando can push a signed price");
     }
@@ -245,7 +247,7 @@ contract ST0xPriceOracleTest is Test {
     /// different oracle deployment — one publisher signature fans out to a
     /// multi-chain deployment.
     function test_UpdatePrice_CrossChainReplay_SameSignatureAppliesOnOtherDeployment() public {
-        bytes memory sig = _sign(PAIR_A, 42e18, block.timestamp);
+        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, block.timestamp);
         assertTrue(oracle.updatePrice(PAIR_A, 42e18, block.timestamp, sig), "applies on the home chain");
 
         // A second deployment (fresh proxy → different verifyingContract)
@@ -275,7 +277,7 @@ contract ST0xPriceOracleTest is Test {
     /// an un-serveable price.
     function test_UpdatePrice_FutureTimestamp_Rejected() public {
         uint256 future = block.timestamp + 1 hours;
-        bytes memory sig = _sign(PAIR_A, 42e18, future);
+        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, future);
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceFuture.selector, PAIR_A));
         oracle.updatePrice(PAIR_A, 42e18, future, sig);
 
@@ -290,7 +292,9 @@ contract ST0xPriceOracleTest is Test {
     /// is the accepted region.)
     function test_UpdatePrice_CurrentTimestamp_Applies() public {
         assertTrue(
-            oracle.updatePrice(PAIR_A, 42e18, block.timestamp, _sign(PAIR_A, 42e18, block.timestamp)),
+            oracle.updatePrice(
+                PAIR_A, 42e18, block.timestamp, signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, block.timestamp)
+            ),
             "now is not the future"
         );
         assertEq(oracle.price(PAIR_A), 42e18, "current-timestamp price is servable");
@@ -431,12 +435,12 @@ contract ST0xPriceOracleTest is Test {
 
         // Old key no longer authorises a fresh payload...
         vm.warp(block.timestamp + 1);
-        bytes memory oldKeySig = _sign(PAIR_A, 43e18, block.timestamp);
+        bytes memory oldKeySig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 43e18, block.timestamp);
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUpdateInvalidSignature.selector, PAIR_A));
         oracle.updatePrice(PAIR_A, 43e18, block.timestamp, oldKeySig);
 
         // ...the new key does.
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(newPk, _digest(PAIR_A, 43e18, block.timestamp));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(newPk, digestFor(oracle, PAIR_A, 43e18, block.timestamp));
         assertTrue(oracle.updatePrice(PAIR_A, 43e18, block.timestamp, abi.encodePacked(r, s, v)), "new key applies");
 
         // Rotation preserved the previously stored state until then.
@@ -497,17 +501,7 @@ contract ST0xPriceOracleTest is Test {
 
     // -------- Helpers --------
 
-    function _digest(bytes32 id, uint256 price, uint256 timestamp) internal view returns (bytes32) {
-        bytes32 structHash = keccak256(abi.encode(oracle.PRICE_UPDATE_TYPEHASH(), id, price, timestamp));
-        return keccak256(abi.encodePacked("\x19\x01", oracle.domainSeparator(), structHash));
-    }
-
-    function _sign(bytes32 id, uint256 price, uint256 timestamp) internal view returns (bytes memory) {
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PK, _digest(id, price, timestamp));
-        return abi.encodePacked(r, s, v);
-    }
-
     function _push(bytes32 id, uint256 price, uint256 timestamp) internal {
-        assertTrue(oracle.updatePrice(id, price, timestamp, _sign(id, price, timestamp)));
+        assertTrue(oracle.updatePrice(id, price, timestamp, signPriceUpdate(oracle, SIGNER_PK, id, price, timestamp)));
     }
 }

--- a/test/src/lib/SignedPriceTestBase.sol
+++ b/test/src/lib/SignedPriceTestBase.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+
+import {ST0xPriceOracle} from "../../../src/concrete/oracle/ST0xPriceOracle.sol";
+
+/// @title SignedPriceTestBase
+/// @notice Shared test base holding the single canonical EIP-712 signing
+/// implementation for `ST0xPriceOracle` price updates. Every concrete test
+/// that needs to forge a signed `updatePrice` payload inherits this so the
+/// digest derivation (`PRICE_UPDATE_TYPEHASH` struct hash + `\x19\x01`
+/// domain-separator packing) lives in exactly one place. If the signing
+/// scheme ever changes, this is the only helper to update and every inheriting
+/// suite recompiles against it — no silent per-file drift.
+abstract contract SignedPriceTestBase is Test {
+    /// @notice Recreates the EIP-712 digest an off-chain signer would sign for
+    /// a price update against `store`, taking the oracle store as a parameter
+    /// so the derivation is not tied to any one test's local variable name.
+    /// @param store The oracle whose domain separator and typehash are used.
+    /// @param id The pair id.
+    /// @param price The price being pushed.
+    /// @param timestamp The observation timestamp.
+    /// @return The 32-byte EIP-712 digest.
+    function digestFor(ST0xPriceOracle store, bytes32 id, uint256 price, uint256 timestamp)
+        internal
+        view
+        returns (bytes32)
+    {
+        bytes32 structHash = keccak256(abi.encode(store.PRICE_UPDATE_TYPEHASH(), id, price, timestamp));
+        return keccak256(abi.encodePacked("\x19\x01", store.domainSeparator(), structHash));
+    }
+
+    /// @notice Signs a price update for `store` with `pk`, producing the
+    /// packed `(r, s, v)` signature `updatePrice` expects.
+    /// @param store The oracle the signature is for.
+    /// @param pk The private key to sign with.
+    /// @param id The pair id.
+    /// @param price The price being pushed.
+    /// @param timestamp The observation timestamp.
+    /// @return The `abi.encodePacked(r, s, v)` signature.
+    function signPriceUpdate(ST0xPriceOracle store, uint256 pk, bytes32 id, uint256 price, uint256 timestamp)
+        internal
+        view
+        returns (bytes memory)
+    {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digestFor(store, id, price, timestamp));
+        return abi.encodePacked(r, s, v);
+    }
+}


### PR DESCRIPTION
Closes #271. Pure test refactor — no behaviour change. **Stacked on #287** (it renamed the deployer immutables next to one of the copies).

The identical EIP-712 `_digest`/`_sign` helper pair was copy-pasted across three test files. Extracted one shared abstract base `test/src/lib/SignedPriceTestBase.sol` exposing `digestFor(store, id, price, ts)` and `signPriceUpdate(store, pk, id, price, ts)` (store passed as a param); the three suites now inherit it and their local copies are deleted, so a signing-scheme change breaks compile everywhere at once.

143 tests passing (unchanged); slither clean; single-contract + reuse green.

Note: the independent PRs #281/#282 add new test functions elsewhere in two of these files — different regions, should merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)