### PR TITLE
fix(test): repair main — point #281's new tests at the deduped EIP-712 helpers

### DIFF
--- a/test/src/concrete/oracle/ST0xPriceOracle.t.sol
+++ b/test/src/concrete/oracle/ST0xPriceOracle.t.sol
@@ -293,7 +293,7 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     /// (e.g. Morpho collateral priced at zero). Guarded symmetrically with the
     /// other degenerate-value reverts, and the pair stays unset.
     function test_UpdatePrice_ZeroPrice_Reverts() public {
-        bytes memory sig = _sign(PAIR_A, 0, block.timestamp);
+        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 0, block.timestamp);
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceZero.selector, PAIR_A));
         oracle.updatePrice(PAIR_A, 0, block.timestamp, sig);
 
@@ -311,7 +311,7 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     function test_UpdatePrice_WronglySignedFuturePayload_RevertsInvalidSignatureNotFuture() public {
         uint256 wrongPk = uint256(keccak256("wrong-signer"));
         uint256 future = block.timestamp + 1 hours;
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, _digest(PAIR_A, 42e18, future));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, digestFor(oracle, PAIR_A, 42e18, future));
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUpdateInvalidSignature.selector, PAIR_A));
         oracle.updatePrice(PAIR_A, 42e18, future, abi.encodePacked(r, s, v));
     }


### PR DESCRIPTION
main has not compiled since #281 merged at 53a4253; Rainix CI has been red
on main ever since (green through 365f9ee).

Semantic merge conflict, not a textual one. #288 moved the EIP-712 signing
helpers into SignedPriceTestBase as digestFor(store, ...) /
signPriceUpdate(store, pk, ...) and deleted the local _digest/_sign from
ST0xPriceOracle.t.sol. #281 was branched before that and added two tests
calling the old local names. Each PR was green on its own base; git merged
both without conflict because they touch different regions of the file, and
the result does not compile:

  ST0xPriceOracle.t.sol:296  _sign(...)    undeclared
  ST0xPriceOracle.t.sol:314  _digest(...)  undeclared

Repointed both at the shared base helpers. The substitution is exactly
semantics-preserving — the deleted _sign was
vm.sign(SIGNER_PK, _digest(id, price, timestamp)) against the oracle under
test, which is signPriceUpdate(oracle, SIGNER_PK, id, price, timestamp)
verbatim, and _digest is digestFor(oracle, ...) verbatim.

Both repaired tests were mutation-verified to still discriminate rather than
merely compile: removing the PriceZero guard fails
test_UpdatePrice_ZeroPrice_Reverts, and reordering the future check ahead of
the signature check fails
test_UpdatePrice_WronglySignedFuturePayload_RevertsInvalidSignatureNotFuture
(it gets PriceFuture instead of PriceUpdateInvalidSignature).

Test-only change; src/ untouched. 168 tests green, fmt/slither/reuse clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013hi8wq9YkjWPcGACXCEKeL

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788948756&installation_model_id=19370&pr_number=290&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F290&signature=129fa604851175191969e8b8b1530364e5f3d59d23a75e5b096f6cda5f7de453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated oracle tests to use the current price-signing and digest-generation methods.
  * Removed reliance on outdated helper methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->