### PR TITLE
test: mutation-test coverage sweep at c371a23 (18 discriminating tests)

### DIFF
--- a/test/mocks/MockMalformedCorporateActions.sol
+++ b/test/mocks/MockMalformedCorporateActions.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {ICorporateActionsV1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
+import {CompletionFilter} from "st0x-deploy-0.1.1/src/lib/LibCorporateActionNode.sol";
+
+/// @title MockMalformedCorporateActions
+/// @notice A vault-shaped stub that returns caller-supplied traversal tuples
+/// VERBATIM, with no internal consistency enforced between the cursor and the
+/// effectiveTime.
+///
+/// `MockCorporateActions` deliberately models a well-behaved vault: it derives
+/// "no match" from the cursor and therefore can only ever emit the coherent
+/// pair `(NODE_NONE, 0, 0)`. That makes it structurally incapable of expressing
+/// a *malformed* return such as `(NODE_NONE, type, futureTime)` — a no-match
+/// cursor paired with a live-looking effectiveTime. This mock exists purely to
+/// express those incoherent tuples so tests can pin which of the two fields
+/// `LibCorporateActionsPause` treats as authoritative: the CURSOR is the
+/// no-match sentinel, so a `NODE_NONE` cursor must be rejected regardless of
+/// what effectiveTime came back alongside it.
+///
+/// The completion filter is NOT validated here (unlike `MockCorporateActions`)
+/// because these tests are about the cursor/effectiveTime pair, not the filter
+/// wiring, which is pinned separately.
+contract MockMalformedCorporateActions is ICorporateActionsV1 {
+    uint256 private _earliestCursor;
+    uint256 private _earliestType;
+    uint64 private _earliestEffective;
+
+    uint256 private _latestCursor;
+    uint256 private _latestType;
+    uint64 private _latestEffective;
+
+    function setEarliestRaw(uint256 cursor, uint256 actionType, uint64 effectiveTime) external {
+        _earliestCursor = cursor;
+        _earliestType = actionType;
+        _earliestEffective = effectiveTime;
+    }
+
+    function setLatestRaw(uint256 cursor, uint256 actionType, uint64 effectiveTime) external {
+        _latestCursor = cursor;
+        _latestType = actionType;
+        _latestEffective = effectiveTime;
+    }
+
+    function earliestActionOfType(uint256, CompletionFilter) external view override returns (uint256, uint256, uint64) {
+        return (_earliestCursor, _earliestType, _earliestEffective);
+    }
+
+    function latestActionOfType(uint256, CompletionFilter) external view override returns (uint256, uint256, uint64) {
+        return (_latestCursor, _latestType, _latestEffective);
+    }
+
+    function scheduleCorporateAction(bytes32, uint64, bytes calldata) external pure override returns (uint256) {
+        revert("mock: not implemented");
+    }
+
+    function cancelCorporateAction(uint256) external pure override {
+        revert("mock: not implemented");
+    }
+
+    function completedActionCount() external pure override returns (uint256) {
+        revert("mock: not implemented");
+    }
+
+    function nextOfType(uint256, uint256, CompletionFilter) external pure override returns (uint256, uint256, uint64) {
+        revert("mock: not implemented");
+    }
+
+    function prevOfType(uint256, uint256, CompletionFilter) external pure override returns (uint256, uint256, uint64) {
+        revert("mock: not implemented");
+    }
+
+    function getActionParameters(uint256) external pure override returns (bytes memory) {
+        revert("mock: not implemented");
+    }
+}

--- a/test/src/concrete/adapter/MorphoPairAdapter.t.sol
+++ b/test/src/concrete/adapter/MorphoPairAdapter.t.sol
@@ -150,6 +150,60 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
         assertEq(adapter.price(), 1, "mulDiv must floor (round DOWN), not ceil");
     }
 
+    /// @notice The NatSpec pins the rescale as `mulDiv(signed, 10^(36 +
+    /// quoteDecimals), 10^(baseDecimals + 18))` and claims the form "does the
+    /// division last (no precision loss beyond the final integer floor)". That
+    /// is only true because `Math.mulDiv` carries a FULL-WIDTH (512-bit)
+    /// intermediate: a plain `(signed * numerator) / denominator` reverts
+    /// whenever the product exceeds `2^256`, even when the quotient fits
+    /// comfortably. base=18dec / quote=6dec ⇒ numerator 10^42, denominator
+    /// 10^36. A central value of 1e40 makes the product 1e82 — far past `2^256`
+    /// (~1.16e77) — while the true quotient 1e40 * 10^(36+6-18-18) = 1e46 is a
+    /// perfectly ordinary uint256. Serving it proves the intermediate is not
+    /// truncated to 256 bits.
+    function test_MorphoPairAdapter_MulDivCarriesFullWidthIntermediate() public {
+        MorphoPairAdapter adapter = _deployAdapter(address(base), address(quote));
+        _push(PAIR_A, 1e40, block.timestamp);
+        assertEq(adapter.price(), 1e46, "product overflows 256 bits; the quotient must still be served");
+    }
+
+    /// @notice Fail-closed at READ time, the counterpart to the init-time
+    /// decimals guards. The NatSpec is explicit that surviving `initialize`
+    /// does not guarantee `price()` can never overflow, and that when it does
+    /// the market is "bricked (fail-closed revert, never a wrong price)". Pin
+    /// the revert: base=18dec / quote=6dec rescales by 10^6, so a central value
+    /// of 1e72 implies 1e78 — past `2^256`. `Math.mulDiv` must panic rather
+    /// than wrap and hand Morpho a silently-truncated collateral price.
+    function test_MorphoPairAdapter_PriceOverflow_FailsClosedNotWrapped() public {
+        MorphoPairAdapter adapter = _deployAdapter(address(base), address(quote));
+        _push(PAIR_A, 1e72, block.timestamp);
+        vm.expectRevert(stdError.arithmeticError);
+        adapter.price();
+    }
+
+    /// @notice The NatSpec states the EXACT fail-closed decimals boundaries as
+    /// `quoteDecimals >= 42` and `baseDecimals >= 60`. The two
+    /// `AbsurdDecimals` tests pin the rejected side (42 / 60); this pins the
+    /// ACCEPTED side, so a boundary that silently tightens to 41 / 59 (or a
+    /// wrong exponent constant on either side) is caught. Both known answers
+    /// are re-derived from Morpho's convention, not from the implementation:
+    ///  - base 18dec, quote 41dec: 1.0 signed as 1e18 ⇒ 1e18 * 10^(36+41-18-18)
+    ///    = 10^59.
+    ///  - base 59dec, quote 6dec: central 1e40 ⇒ 1e40 * 10^(36+6-59-18) = 1e5.
+    function test_MorphoPairAdapter_DecimalsAcceptanceBoundary() public {
+        MockERC20Decimals quote41 = new MockERC20Decimals(41);
+        MorphoPairAdapter maxQuote = _deployAdapter(address(base), address(quote41));
+        bytes32 idQ = oracle.pairId(address(base), address(quote41));
+        _push(idQ, 1e18, block.timestamp);
+        assertEq(maxQuote.price(), 10 ** 59, "quoteDecimals 41 is the largest accepted");
+
+        MockERC20Decimals base59 = new MockERC20Decimals(59);
+        MorphoPairAdapter maxBase = _deployAdapter(address(base59), address(quote));
+        bytes32 idB = oracle.pairId(address(base59), address(quote));
+        _push(idB, 1e40, block.timestamp);
+        assertEq(maxBase.price(), 1e5, "baseDecimals 59 is the largest accepted");
+    }
+
     function test_MorphoPairAdapter_InitializeOnlyOnce() public {
         MorphoPairAdapter adapter = _deployAdapter(address(base), address(quote));
         vm.expectRevert(Initializable.InvalidInitialization.selector);

--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -31,8 +31,10 @@ import {
     MockRevertingCorporateActions,
     CorporateActionsUnavailable
 } from "../../../mocks/MockRevertingCorporateActions.sol";
+import {CorporateActionsListHarness} from "../../../mocks/CorporateActionsListHarness.sol";
 import {TestERC1967Proxy} from "../../../mocks/TestERC1967Proxy.sol";
 import {ACTION_TYPE_STOCK_SPLIT_V1, ACTION_TYPE_INIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
+import {InvalidMask} from "st0x-deploy-0.1.1/src/error/ErrCorporateAction.sol";
 
 contract DIAVaultOracleTest is Test {
     DIAVaultOracle internal implementation;
@@ -194,6 +196,88 @@ contract DIAVaultOracleTest is Test {
         oracle.initialize(abi.encode(config));
     }
 
+    /// @notice The init probe must query the CONFIGURED `actionTypeMask`, not a
+    /// wildcard. Per the init NatSpec the probe exists so an incompatible wiring
+    /// — including "a mask with no bits in the upstream `VALID_ACTION_TYPES_MASK`
+    /// (`InvalidMask`)" — reverts THIS deploy transaction rather than every
+    /// future consumer read against immutable config.
+    ///
+    /// Driven against the REAL upstream traversal (`CorporateActionsListHarness`
+    /// wraps `LibCorporateActionNode` verbatim), which is what actually raises
+    /// `InvalidMask`; the hand-mock returns `NODE_NONE` instead and so cannot
+    /// pin this. A mask of `1 << 200` is non-zero and survives the INIT-bit
+    /// strip (so `InvalidPauseConfig` does NOT fire) yet matches no valid action
+    /// type, so the probe must surface `InvalidMask` at init. A regression that
+    /// probed with `type(uint256).max` — or with any mask other than the
+    /// configured one — would let this deploy succeed and brick every later
+    /// read.
+    function testInitProbeUsesConfiguredMaskNotWildcard() external {
+        CorporateActionsListHarness realActions = new CorporateActionsListHarness();
+        MockERC4626 vaultReal = new MockERC4626();
+        vaultReal.setAsset(address(realActions));
+
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.vault = address(vaultReal);
+        // Non-zero, not the INIT bit, but matches nothing in
+        // `VALID_ACTION_TYPES_MASK`.
+        config.actionTypeMask = 1 << 200;
+
+        DIAVaultOracle oracle = _deployUninit();
+        vm.expectRevert(InvalidMask.selector);
+        oracle.initialize(abi.encode(config));
+
+        // Positive control: the same wiring with a VALID configured mask
+        // initializes, so the revert above is the mask reaching the probe and
+        // not the harness being unusable.
+        config.actionTypeMask = ACTION_TYPE_STOCK_SPLIT_V1;
+        DIAVaultOracle ok = _deployUninit();
+        assertEq(ok.initialize(abi.encode(config)), ICLONEABLE_V2_SUCCESS, "valid mask must initialize");
+    }
+
+    /// @notice Config fields are validated in DECLARATION order, so the FIRST
+    /// offending field is the one reported. An integrator debugging a bad
+    /// deploy config fixes one field at a time and expects the next error to
+    /// advance; a reordered check would report a later field first and send
+    /// them after the wrong config entry. Pins the whole ladder in one test
+    /// (each step fixes exactly the field the previous step named).
+    function testInitValidatesConfigFieldsInDeclarationOrder() external {
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.diaOracle = IDIAOracleV2(address(0));
+        config.symbol = "";
+        config.vault = address(0);
+        config.maxAge = 0;
+
+        DIAVaultOracle oracle = _deployUninit();
+        vm.expectRevert(ZeroDIAOracle.selector);
+        oracle.initialize(abi.encode(config));
+
+        config.diaOracle = IDIAOracleV2(address(diaOracle));
+        vm.expectRevert(EmptySymbol.selector);
+        oracle.initialize(abi.encode(config));
+
+        config.symbol = SYMBOL;
+        vm.expectRevert(ZeroVault.selector);
+        oracle.initialize(abi.encode(config));
+
+        config.vault = address(vault);
+        vm.expectRevert(ZeroMaxAge.selector);
+        oracle.initialize(abi.encode(config));
+
+        // Beyond the four zero-checks the pause-coherence check precedes the
+        // cross-epoch invariant: with BOTH broken (empty mask AND
+        // `pauseTimeAfter < maxAge`) it is `InvalidPauseConfig` that surfaces.
+        config.maxAge = MAX_AGE;
+        config.actionTypeMask = 0;
+        config.pauseTimeAfter = 0;
+        vm.expectRevert(InvalidPauseConfig.selector);
+        oracle.initialize(abi.encode(config));
+
+        // ...and once the mask is coherent, the invariant check speaks.
+        config.actionTypeMask = ACTION_TYPE_STOCK_SPLIT_V1;
+        vm.expectRevert(abi.encodeWithSelector(PauseTimeAfterBelowMaxAge.selector, uint256(0), MAX_AGE));
+        oracle.initialize(abi.encode(config));
+    }
+
     /// @notice Inside a matching action's window, every price read reverts
     /// `OraclePausedCorporateAction` with that action's effectiveTime.
     function testAutoPauseRevertsInsideWindow() external {
@@ -203,6 +287,47 @@ contract DIAVaultOracleTest is Test {
         vault.setTotalSupply(1e18);
 
         // Completed split half a post-window ago → inside the pause window.
+        uint64 effectiveTime = uint64(block.timestamp - PAUSE_AFTER / 2);
+        actions.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
+        oracle.latestAnswer();
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
+        oracle.latestRoundData();
+    }
+
+    /// @notice The pause gate runs BEFORE the DIA read on BOTH entry points, so
+    /// inside a pause window the reported error is always
+    /// `OraclePausedCorporateAction` — never a DIA error that happens to fire
+    /// first. Ordering is observable and load-bearing: `DIAPriceStale` tells an
+    /// integrator "retry when the feed updates" (minutes), while
+    /// `OraclePausedCorporateAction` carries the `effectiveTime` that tells them
+    /// when the market reopens, and the two entry points must not disagree about
+    /// which condition dominates.
+    ///
+    /// The overlap is not contrived: it is the normal state late in a post-action
+    /// window, since `pauseTimeAfter >= maxAge` guarantees every push predating
+    /// the action has gone stale before the pause lifts. Here the push sits
+    /// exactly on the staleness edge (`age == maxAge`) while the completed action
+    /// is still mid-window.
+    function testPauseTakesPrecedenceOverStaleDIA() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+
+        // Stale by the contract's own fail-closed edge: age == maxAge.
+        uint128 staleTimestamp = uint128(block.timestamp - MAX_AGE);
+        diaOracle.setValue(SYMBOL, 100e18, staleTimestamp);
+
+        // Sanity: with no action in window the very same state reverts
+        // `DIAPriceStale`, so the assertions below are about precedence, not
+        // about the push being fresh.
+        vm.expectRevert(abi.encodeWithSelector(DIAPriceStale.selector, uint256(staleTimestamp)));
+        oracle.latestAnswer();
+        vm.expectRevert(abi.encodeWithSelector(DIAPriceStale.selector, uint256(staleTimestamp)));
+        oracle.latestRoundData();
+
+        // Now open a post-action window over that same instant.
         uint64 effectiveTime = uint64(block.timestamp - PAUSE_AFTER / 2);
         actions.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
 
@@ -241,6 +366,62 @@ contract DIAVaultOracleTest is Test {
         assertEq(
             storedDIAOracle, address(oracle.diaOracle()), "MainStorage must be namespaced at the ERC-7201 derived slot"
         );
+    }
+
+    /// @notice The namespace base is not enough: the ORDER of `MainStorage`'s
+    /// members is itself part of the layout contract, because a beacon upgrade
+    /// keeps every live proxy's storage. Reordering two members in a v2 leaves
+    /// the base slot intact (so the test above still passes) while every proxy
+    /// silently reinterprets one field as another — e.g. `vault` read out of the
+    /// `maxAge` word. Pin every member to its exact slot offset, read raw.
+    ///
+    /// Expected layout, one slot per member except the two `uint64` windows
+    /// which pack into a single word (before in the low 64 bits, after next):
+    ///   +0 diaOracle, +1 symbol, +2 vault, +3 maxAge,
+    ///   +4 corporateActionsVault, +5 actionTypeMask, +6 pauseTimeBefore|After.
+    /// If this fails, do NOT renumber the expectations — fix the struct.
+    function testMainStorageFieldOrderIsPinned() external {
+        // Distinct values per field (in particular before != after) so a swap of
+        // any two members is observable rather than masked by equal defaults.
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.pauseTimeBefore = 1234;
+        config.pauseTimeAfter = 7200;
+        DIAVaultOracle oracle = _deployProxy(config);
+        uint256 base = uint256(
+            keccak256(abi.encode(uint256(keccak256("st0x.diavaultoracle.main")) - 1)) & ~bytes32(uint256(0xff))
+        );
+
+        assertEq(
+            address(uint160(uint256(vm.load(address(oracle), bytes32(base + 0))))),
+            address(diaOracle),
+            "slot +0 must be diaOracle"
+        );
+        // Short strings store their bytes left-aligned with `2 * length` in the
+        // lowest byte, all in the head slot.
+        assertEq(
+            vm.load(address(oracle), bytes32(base + 1)),
+            bytes32(bytes(SYMBOL)) | bytes32(uint256(2 * bytes(SYMBOL).length)),
+            "slot +1 must be the symbol string head"
+        );
+        assertEq(
+            address(uint160(uint256(vm.load(address(oracle), bytes32(base + 2))))),
+            address(vault),
+            "slot +2 must be vault"
+        );
+        assertEq(uint256(vm.load(address(oracle), bytes32(base + 3))), MAX_AGE, "slot +3 must be maxAge");
+        assertEq(
+            address(uint160(uint256(vm.load(address(oracle), bytes32(base + 4))))),
+            address(actions),
+            "slot +4 must be corporateActionsVault"
+        );
+        assertEq(
+            uint256(vm.load(address(oracle), bytes32(base + 5))),
+            ACTION_TYPE_STOCK_SPLIT_V1,
+            "slot +5 must be actionTypeMask"
+        );
+        uint256 packedWindows = uint256(vm.load(address(oracle), bytes32(base + 6)));
+        assertEq(uint256(uint64(packedWindows)), uint256(1234), "slot +6 low word must be pauseTimeBefore");
+        assertEq(uint256(uint64(packedWindows >> 64)), uint256(7200), "slot +6 second word must be pauseTimeAfter");
     }
 
     // -------- Init validation --------
@@ -370,6 +551,31 @@ contract DIAVaultOracleTest is Test {
         // 100 * 2 / 1 = 200, scaled to 8dp = 200e8.
         int256 answer = oracle.latestAnswer();
         assertEq(answer, int256(200e8));
+    }
+
+    /// @notice A share price that is not exactly representable at 8 decimals is
+    /// TRUNCATED toward zero, never rounded up. Expected value derived from the
+    /// spec, not from the implementation: `vaultSharePrice = diaPrice *
+    /// totalAssets / totalSupply` = `$1 * 1e18 / 3e18` = `$0.3333...`, and 8dp
+    /// floor of that is `33333333` (a round-half-up implementation would give
+    /// `33333334`).
+    ///
+    /// Direction is the assertion. Truncation makes the oracle report slightly
+    /// LESS than the true NAV, which is the conservative side for a lending
+    /// market pricing collateral; rounding up would over-report collateral by up
+    /// to 1 wei of price on every read. The existing happy-path tests all use
+    /// exact powers of ten, so none of them can see this.
+    function testLatestAnswerTruncatesFractionalSharePrice() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        diaOracle.setValue(SYMBOL, 1e18, uint128(block.timestamp));
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(3e18);
+
+        assertEq(oracle.latestAnswer(), int256(33333333), "1/3 of a dollar must truncate down at 8dp");
+
+        // The same read path through latestRoundData agrees on the direction.
+        (, int256 roundAnswer,,,) = oracle.latestRoundData();
+        assertEq(roundAnswer, int256(33333333), "latestRoundData must truncate identically");
     }
 
     /// @notice Donations move the ratio and ARE served — the decided behaviour

--- a/test/src/concrete/oracle/ST0xPriceOracle.t.sol
+++ b/test/src/concrete/oracle/ST0xPriceOracle.t.sol
@@ -173,6 +173,22 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         oracle.initialize(RANDO, ORACLE_ADMIN, SIGNER, TIMEOUT);
     }
 
+    /// @notice The IMPLEMENTATION behind the beacon must be un-initialisable:
+    /// the constructor calls `_disableInitializers()`. Without it anyone could
+    /// `initialize` the shared implementation directly, seizing
+    /// `DEFAULT_ADMIN_ROLE` / `ORACLE_ADMIN_ROLE` on the logic contract and
+    /// setting its own global signer — a live target for `delegatecall`-shaped
+    /// mischief and a confusing on-chain artefact for anyone reading the
+    /// implementation's storage. Pinned with the exact
+    /// `InvalidInitialization` selector: the proxy-level `test_Initialize_OnlyOnce`
+    /// does NOT cover this (a proxy's own `initialized` flag is what stops it
+    /// there), so dropping `_disableInitializers()` otherwise ships silently.
+    function test_ImplementationInitializersDisabled() public {
+        ST0xPriceOracle impl = new ST0xPriceOracle();
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        impl.initialize(ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT);
+    }
+
     // -------- updatePrice: applied vs no-op vs revert --------
 
     /// @notice There is NO pair registration — the very first update on a

--- a/test/src/fork/DIAVaultOracleForkBase.t.sol
+++ b/test/src/fork/DIAVaultOracleForkBase.t.sol
@@ -114,6 +114,13 @@ contract DIAVaultOracleForkBaseTest is Test {
         // pass having verified nothing.
         vm.createSelectFork("base");
 
+        // `DIA_FEED` is mocked below (`_seedFreshDIA`), and `vm.mockCall`
+        // answers for ANY address — including an address with no code. So
+        // assert the pinned `DIA_FEED_BASE` is a live contract on Base BEFORE
+        // the mock is installed; otherwise a drifted/fat-fingered feed constant
+        // would sail through this fork test unnoticed.
+        assertGt(DIA_FEED.code.length, 0, "DIA_FEED_BASE must be a deployed contract on Base");
+
         DIAVaultOracle oracle = _deployOracle();
 
         // The corporate-actions vault is derived as wtCOIN.asset() == tCOIN.

--- a/test/src/lib/LibCorporateActionsPause.t.sol
+++ b/test/src/lib/LibCorporateActionsPause.t.sol
@@ -12,6 +12,7 @@ import {
     CorporateActionsUnavailable
 } from "../../mocks/MockRevertingCorporateActions.sol";
 import {MockStringRevertingCorporateActions} from "../../mocks/MockStringRevertingCorporateActions.sol";
+import {MockMalformedCorporateActions} from "../../mocks/MockMalformedCorporateActions.sol";
 
 contract LibCorporateActionsPauseTest is Test {
     MockCorporateActions internal mock;
@@ -166,6 +167,51 @@ contract LibCorporateActionsPauseTest is Test {
             LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
         assertEq(paused, true);
         assertEq(ts, effectiveTime);
+    }
+
+    /// Every other completed-branch test runs with `pauseTimeBefore ==
+    /// pauseTimeAfter` (both `3600`), so swapping the two parameters inside the
+    /// post-window predicate is invisible to them — only a fuzz run in the
+    /// consumer suite happened to catch it, which is seed-dependent. This pins
+    /// deterministically that the POST-window is sized by `pauseTimeAfter`
+    /// alone, using deliberately asymmetric windows in BOTH directions:
+    ///   (a) a short `before` and long `after` must still pause on a completed
+    ///       action 100s old (the mutation `+ pauseTimeBefore` would compute
+    ///       `now <= now - 100 + 10` and NOT pause), and
+    ///   (b) a long `before` and short `after` must NOT pause on that same
+    ///       action (the mutation would compute `now <= now - 100 + 3600` and
+    ///       spuriously pause).
+    function testPostWindowIsSizedByPauseTimeAfterNotBefore() external {
+        uint64 effectiveTime = uint64(block.timestamp - 100);
+        mock.setLatestCompleted(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+
+        // (a) after = 3600 covers the 100s-old action; before = 10 is irrelevant.
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, 10, 3600);
+        assertEq(paused, true, "post-window must be sized by pauseTimeAfter (3600 > 100)");
+        assertEq(ts, effectiveTime);
+
+        // (b) after = 10 does NOT cover it; the large before must not leak in.
+        (paused, ts) = LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, 3600, 10);
+        assertEq(paused, false, "pauseTimeBefore must not widen the post-window (10 < 100)");
+        assertEq(ts, 0);
+    }
+
+    /// Mirror of the above for the PRE-window: it is sized by `pauseTimeBefore`
+    /// alone. (a) before = 3600 opens on a pending action 100s out even when
+    /// after = 10; (b) before = 10 does not, even when after = 3600.
+    function testPreWindowIsSizedByPauseTimeBeforeNotAfter() external {
+        uint64 effectiveTime = uint64(block.timestamp + 100);
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, 3600, 10);
+        assertEq(paused, true, "pre-window must be sized by pauseTimeBefore (3600 > 100)");
+        assertEq(ts, effectiveTime);
+
+        (paused, ts) = LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, 10, 3600);
+        assertEq(paused, false, "pauseTimeAfter must not widen the pre-window (10 < 100)");
+        assertEq(ts, 0);
     }
 
     // -------- Mask filtering --------
@@ -349,6 +395,27 @@ contract LibCorporateActionsPauseTest is Test {
         assertEq(ts, 0);
     }
 
+    /// The INIT strip must be applied to the PENDING query too, not just the
+    /// COMPLETED one. `testWildcardMaskIgnoresBootstrapInitNode` only exercises
+    /// the completed side, so passing the raw (un-stripped) `mask` to
+    /// `earliestActionOfType` while stripping it for `latestActionOfType` goes
+    /// unnoticed. An INIT-typed node that is still PENDING is exactly the shape
+    /// the strip exists to suppress — the bootstrap entry is a price-irrelevant
+    /// bookkeeping row, so it must not open a pre-window under the recommended
+    /// `type(uint256).max` mask either. Discriminating value: not paused with a
+    /// zero effectiveTime, versus `(true, effectiveTime)` if the pending query
+    /// forwards the unstripped mask.
+    function testWildcardMaskIgnoresInitNodeOnPendingQuery() external {
+        uint64 effectiveTime = uint64(block.timestamp + BEFORE / 2);
+        // The only "action" is an INIT-typed node sitting squarely inside the
+        // pre-window; the wildcard mask must still not pause on it.
+        mock.setEarliestPending(1, ACTION_TYPE_INIT_V1, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), type(uint256).max, BEFORE, AFTER);
+        assertEq(paused, false, "INIT node must not open a pre-window: the PENDING query must strip the INIT bit");
+        assertEq(ts, 0);
+    }
+
     /// The INIT strip must not disarm the wildcard mask for REAL actions: a
     /// completed stock split under `type(uint256).max` still pauses.
     function testWildcardMaskStillMatchesRealAction() external {
@@ -477,6 +544,46 @@ contract LibCorporateActionsPauseTest is Test {
         (bool paused, uint64 ts) =
             LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, 0, AFTER);
         assertEq(paused, false, "phantom PENDING at exactly now must be skipped by the local filter re-assertion");
+        assertEq(ts, 0);
+    }
+
+    // -------- Cursor is authoritative over effectiveTime --------
+
+    /// The CURSOR is the no-match sentinel, not the effectiveTime. A vault that
+    /// returned the incoherent pair `(NODE_NONE, type, futureTime)` — no-match
+    /// cursor next to a live-looking pre-window effectiveTime — must be read as
+    /// "no pending action". `MockCorporateActions` cannot express this pair (it
+    /// derives no-match from the cursor and always zeroes the tuple), so a
+    /// regression loosening the guard to `pendingCursor != NODE_NONE ||
+    /// pendingEffective != 0` would enter the branch on a pure sentinel and
+    /// pause on a phantom whose "effectiveTime" is really the traversal's
+    /// zero-value padding. Discriminating value: `(false, 0)` rather than
+    /// `(true, effectiveTime)`.
+    function testNodeNoneCursorWithLiveEffectiveTimeIsNoMatchPending() external {
+        MockMalformedCorporateActions malformed = new MockMalformedCorporateActions();
+        uint64 effectiveTime = uint64(block.timestamp + BEFORE / 2);
+        malformed.setEarliestRaw(NODE_NONE, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        // Completed side left at the coherent no-match default (cursor 0 is a
+        // real slot, so zero its effectiveTime to keep it inert).
+        malformed.setLatestRaw(NODE_NONE, 0, 0);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(malformed), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, false, "NODE_NONE pending cursor must be no-match even with a live-looking effectiveTime");
+        assertEq(ts, 0);
+    }
+
+    /// Symmetric to the above on the COMPLETED branch: a `NODE_NONE` cursor
+    /// paired with an effectiveTime whose post-window contains `now` is still
+    /// no-match. Pins that the completed guard is a conjunction, so the cursor
+    /// sentinel alone is sufficient to reject.
+    function testNodeNoneCursorWithLiveEffectiveTimeIsNoMatchCompleted() external {
+        MockMalformedCorporateActions malformed = new MockMalformedCorporateActions();
+        uint64 effectiveTime = uint64(block.timestamp - AFTER / 2);
+        malformed.setEarliestRaw(NODE_NONE, 0, 0);
+        malformed.setLatestRaw(NODE_NONE, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(malformed), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, false, "NODE_NONE completed cursor must be no-match even with an in-window effectiveTime");
         assertEq(ts, 0);
     }
 

--- a/test/src/lib/LibCorporateActionsPauseConventions.t.sol
+++ b/test/src/lib/LibCorporateActionsPauseConventions.t.sol
@@ -11,6 +11,7 @@ import {
 } from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
 import {InvalidMask} from "st0x-deploy-0.1.1/src/error/ErrCorporateAction.sol";
 import {CorporateActionsListHarness} from "../../mocks/CorporateActionsListHarness.sol";
+import {LibCorporateActionsPause} from "../../../src/lib/LibCorporateActionsPause.sol";
 
 /// @title LibCorporateActionsPauseConventions
 /// @notice Enumeration test (audit #216) pinning every `ICorporateActionsV1`
@@ -144,6 +145,105 @@ contract LibCorporateActionsPauseConventionsTest is Test {
             harness.earliestActionOfType(ACTION_TYPE_STOCK_SPLIT_V1, CompletionFilter.PENDING);
         assertTrue(cursorAfter != earlier, "cancelled node must be unlinked from traversal");
         assertEq(effAfter, nowTs + 15 days, "earliest pending after cancel is the surviving node");
+    }
+
+    /// End-to-end window semantics against the REAL upstream list, not a mock.
+    /// Every other `inPauseWindow` test drives `MockCorporateActions`, which
+    /// re-encodes beliefs about the traversal; this one schedules a real action
+    /// and walks `block.timestamp` across every boundary instant the NatSpec
+    /// specifies, asserting the exact `(paused, effectiveTime)` pair at each:
+    ///
+    ///   E-before-1 : not paused          (pre-window not yet open)
+    ///   E-before   : paused, ts == E     (pre-window lower bound INCLUSIVE)
+    ///   E-1        : paused, ts == E     (still pending)
+    ///   E          : paused, ts == E     (HANDOVER — upstream flips the action
+    ///                                     from PENDING to COMPLETED exactly
+    ///                                     here, and the post-window's lower
+    ///                                     bound is inclusive, so there is no
+    ///                                     one-second hole at the single most
+    ///                                     price-sensitive instant)
+    ///   E+after    : paused, ts == E     (post-window upper bound INCLUSIVE)
+    ///   E+after+1  : not paused          (post-window closed)
+    ///
+    /// The handover instant is the load-bearing one: the library's defensive
+    /// `pendingEffective > now` re-assertion means the pending branch stops
+    /// matching at exactly `E`, so coverage there depends entirely on upstream
+    /// classifying `effectiveTime == now` as COMPLETED (`effectiveTime <= now`).
+    /// A mock cannot prove that; this does.
+    function testInPauseWindowBoundariesAgainstRealList() external {
+        uint64 pauseBefore = 1 hours;
+        uint64 pauseAfter = 2 hours;
+        uint64 effectiveTime = uint64(block.timestamp) + 1 days;
+        harness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+
+        bool paused;
+        uint64 ts;
+
+        vm.warp(effectiveTime - pauseBefore - 1);
+        (paused, ts) = LibCorporateActionsPause.inPauseWindow(
+            address(harness), ACTION_TYPE_STOCK_SPLIT_V1, pauseBefore, pauseAfter
+        );
+        assertEq(paused, false, "one second before the pre-window opens: not paused");
+        assertEq(ts, 0);
+
+        vm.warp(effectiveTime - pauseBefore);
+        (paused, ts) = LibCorporateActionsPause.inPauseWindow(
+            address(harness), ACTION_TYPE_STOCK_SPLIT_V1, pauseBefore, pauseAfter
+        );
+        assertEq(paused, true, "pre-window lower bound is inclusive");
+        assertEq(ts, effectiveTime, "pre-window reports the pending action's effectiveTime");
+
+        vm.warp(uint256(effectiveTime) - 1);
+        (paused, ts) = LibCorporateActionsPause.inPauseWindow(
+            address(harness), ACTION_TYPE_STOCK_SPLIT_V1, pauseBefore, pauseAfter
+        );
+        assertEq(paused, true, "still inside the pre-window one second before effect");
+        assertEq(ts, effectiveTime);
+
+        vm.warp(effectiveTime);
+        (paused, ts) = LibCorporateActionsPause.inPauseWindow(
+            address(harness), ACTION_TYPE_STOCK_SPLIT_V1, pauseBefore, pauseAfter
+        );
+        assertEq(paused, true, "handover instant: PENDING->COMPLETED must leave no coverage gap");
+        assertEq(ts, effectiveTime);
+
+        vm.warp(uint256(effectiveTime) + pauseAfter);
+        (paused, ts) = LibCorporateActionsPause.inPauseWindow(
+            address(harness), ACTION_TYPE_STOCK_SPLIT_V1, pauseBefore, pauseAfter
+        );
+        assertEq(paused, true, "post-window upper bound is inclusive");
+        assertEq(ts, effectiveTime);
+
+        vm.warp(uint256(effectiveTime) + pauseAfter + 1);
+        (paused, ts) = LibCorporateActionsPause.inPauseWindow(
+            address(harness), ACTION_TYPE_STOCK_SPLIT_V1, pauseBefore, pauseAfter
+        );
+        assertEq(paused, false, "one second after the post-window closes: not paused");
+        assertEq(ts, 0);
+    }
+
+    /// The library's NatSpec claims cancelled nodes need no explicit filter
+    /// because upstream unlinks them from traversal. `testCancelUnlinksActionFromTraversal`
+    /// proves the unlink at the primitive level; this proves the CONSEQUENCE the
+    /// library actually relies on — an action inside its pre-window pauses, and
+    /// after `cancel` the very same instant does not. End-to-end, real list.
+    function testCancelStopsPauseThroughInPauseWindow() external {
+        uint64 pauseBefore = 1 hours;
+        uint64 effectiveTime = uint64(block.timestamp) + 1 days;
+        uint256 actionId = harness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+
+        vm.warp(uint256(effectiveTime) - 30 minutes);
+        (bool paused, uint64 ts) =
+            LibCorporateActionsPause.inPauseWindow(address(harness), ACTION_TYPE_STOCK_SPLIT_V1, pauseBefore, 1 hours);
+        assertEq(paused, true, "scheduled action inside its pre-window pauses");
+        assertEq(ts, effectiveTime);
+
+        harness.cancel(actionId);
+
+        (paused, ts) =
+            LibCorporateActionsPause.inPauseWindow(address(harness), ACTION_TYPE_STOCK_SPLIT_V1, pauseBefore, 1 hours);
+        assertEq(paused, false, "a cancelled action must stop pausing at the same instant");
+        assertEq(ts, 0, "cancelled action must not leak an effectiveTime");
     }
 
     /// Convention 4b: cancelling the ONLY pending node returns the list to a

--- a/test/src/lib/LibDIAFeed.t.sol
+++ b/test/src/lib/LibDIAFeed.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {DIA_FEED_BASE} from "../../../src/lib/LibDIAFeed.sol";
+
+/// @title LibDIAFeedTest
+/// @notice `DIA_FEED_BASE` is the single repo-level constant for the live DIA
+/// push-oracle feed on Base. It is a deployment-address fact, not a derived
+/// value, so the only thing a test can prove offline is that it has not
+/// DRIFTED: every DIA-backed vault oracle is wired to whatever this literal
+/// says, and a silent edit (a fat-fingered nibble, a copy-paste from another
+/// chain's deployment) would point every oracle at an address with no feed.
+///
+/// Before this test the constant was referenced only by the fork test, which
+/// `vm.mockCall`s `getValue` AT that address — so the mock answers for any
+/// address and the fork test passes unchanged against a wrong one. That left
+/// the constant with zero coverage across the whole suite.
+///
+/// The expected value is re-derived from the primary source, not copied from
+/// `LibDIAFeed.sol`: DIA's Base push oracle at
+/// https://basescan.org/address/0xCE521b52513242c5094bc56f57887BB2A05B8129
+/// (the same address the README wiring example and the `IDIAOracleV2` NatSpec
+/// quote). Changing the deployment must therefore be a deliberate, reviewed
+/// edit in two places rather than a one-character slip in one.
+contract LibDIAFeedTest is Test {
+    function testDIAFeedBaseAddressIsPinned() external pure {
+        assertEq(
+            DIA_FEED_BASE,
+            address(0xCE521b52513242c5094bc56f57887BB2A05B8129),
+            "DIA_FEED_BASE must be the DIA push-oracle deployment on Base"
+        );
+    }
+
+    /// The constant must be a real address, not a zero/placeholder left behind
+    /// by a template. A zero feed would make every DIA read return empty
+    /// calldata results and fail in a confusing place far from the config.
+    function testDIAFeedBaseIsNotZero() external pure {
+        assertTrue(DIA_FEED_BASE != address(0), "DIA_FEED_BASE must not be the zero address");
+    }
+}

--- a/test/src/script/Deploy.t.sol
+++ b/test/src/script/Deploy.t.sol
@@ -3,11 +3,19 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Vm} from "forge-std-1.16.1/src/Vm.sol";
 import {Ownable} from "@openzeppelin-contracts-5.6.1/access/Ownable.sol";
+import {UpgradeableBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/UpgradeableBeacon.sol";
 import {DIAVaultOracleBeaconSetDeployer} from "../../../src/concrete/deploy/DIAVaultOracleBeaconSetDeployer.sol";
 import {ST0xPriceOracleBeaconSetDeployer} from "../../../src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.sol";
 import {MorphoPairAdapterBeaconSetDeployer} from "../../../src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.sol";
 import {ST0xPriceOracle} from "../../../src/concrete/oracle/ST0xPriceOracle.sol";
+import {DIAVaultOracle, DIAVaultOracleConfig} from "../../../src/concrete/oracle/DIAVaultOracle.sol";
+import {IDIAOracleV2} from "../../../src/interface/IDIAOracleV2.sol";
+import {MockDIAOracle} from "../../mocks/MockDIAOracle.sol";
+import {MockERC4626} from "../../mocks/MockERC4626.sol";
+import {MockCorporateActions} from "../../mocks/MockCorporateActions.sol";
+import {ACTION_TYPE_STOCK_SPLIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
 import {DeployExposed} from "./DeployExposed.sol";
 
 /// @title DeployTest
@@ -29,22 +37,81 @@ contract DeployTest is Test {
     address internal constant ST0X_SIGNER = address(0x57516E);
     uint64 internal constant ST0X_TIMEOUT = uint64(1 hours);
 
+    /// @dev Signature of the beacon-set deployers' `Deployment` event. Used to
+    /// discriminate WHICH suite `run()` actually dispatched to: the DIA suite
+    /// mints no proxies (zero `Deployment` logs) while the signed-price suite
+    /// mints exactly one — the singleton central store.
+    bytes32 internal constant DEPLOYMENT_EVENT_SIG = keccak256("Deployment(address,address)");
+
+    MockDIAOracle internal diaOracle;
+    MockERC4626 internal vault;
+    MockCorporateActions internal actions;
+
     function setUp() public {
         deploy = new DeployExposed();
+        diaOracle = new MockDIAOracle();
+        vault = new MockERC4626();
+        actions = new MockCorporateActions();
+        // The oracle derives its corporate-actions vault from vault.asset().
+        vault.setAsset(address(actions));
+        vm.warp(1_000_000);
     }
 
-    /// @notice The helper deploys the DIA beacon-set deployer and owns its
-    /// beacon with the requested owner (never the deploy key) — the security
-    /// postcondition `run()` require()s.
+    /// @dev Counts `Deployment(address,address)` logs recorded since the last
+    /// `vm.recordLogs()`.
+    function _countDeploymentLogs() internal returns (uint256 count) {
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].topics.length > 0 && entries[i].topics[0] == DEPLOYMENT_EVENT_SIG) {
+                count++;
+            }
+        }
+    }
+
+    function _diaOracleConfig() internal view returns (DIAVaultOracleConfig memory) {
+        return DIAVaultOracleConfig({
+            diaOracle: IDIAOracleV2(address(diaOracle)),
+            symbol: "COIN",
+            vault: address(vault),
+            maxAge: 1 hours,
+            actionTypeMask: ACTION_TYPE_STOCK_SPLIT_V1,
+            pauseTimeBefore: 3600,
+            pauseTimeAfter: 3600
+        });
+    }
+
+    /// @notice The helper deploys the DIA beacon-set deployer, owns its beacon
+    /// with the requested owner (never the deploy key) — the security
+    /// postcondition `run()` require()s — AND points that beacon at a real,
+    /// freshly deployed `DIAVaultOracle` implementation.
+    ///
+    /// The implementation assertion is not cosmetic: `deployDIAStackInfra`'s
+    /// only job besides ownership is wiring `new DIAVaultOracle()` behind the
+    /// beacon, and a beacon pointed at the wrong contract yields a BSD that
+    /// looks perfectly wired (right owner, non-zero beacon) yet mints oracles
+    /// that cannot serve a price. Proven end-to-end by actually minting through
+    /// the returned BSD and reading the config back off the proxy.
     function testDeployDIAStackInfraWiresBeaconAndOwner() external {
         DIAVaultOracleBeaconSetDeployer oracleBSD = deploy.exposedDeployDIAStackInfra(BEACON_OWNER);
 
         assertTrue(address(oracleBSD) != address(0), "oracle BSD wired");
-        assertEq(
-            Ownable(address(oracleBSD.iDIAVaultOracleBeacon())).owner(),
-            BEACON_OWNER,
-            "oracle beacon owned by requested owner"
-        );
+        address beacon = address(oracleBSD.iDIAVaultOracleBeacon());
+        assertEq(Ownable(beacon).owner(), BEACON_OWNER, "oracle beacon owned by requested owner");
+
+        // The beacon must front a real DIAVaultOracle implementation, freshly
+        // deployed by the helper (so: not the script itself, not a zero/EOA
+        // address, and not some unrelated contract).
+        address impl = UpgradeableBeacon(beacon).implementation();
+        assertTrue(impl != address(0), "beacon implementation set");
+        assertTrue(impl != address(deploy), "implementation is not the script contract");
+        assertGt(impl.code.length, 0, "implementation is a contract");
+
+        // End-to-end: an oracle minted through the returned BSD initializes and
+        // reports EXACTLY the config it was minted with.
+        DIAVaultOracle oracle = oracleBSD.newDIAVaultOracle(_diaOracleConfig());
+        assertEq(oracle.symbol(), "COIN", "minted oracle symbol");
+        assertEq(oracle.vault(), address(vault), "minted oracle vault");
+        assertEq(oracle.maxAge(), 1 hours, "minted oracle maxAge");
     }
 
     /// @notice One sequential test covering everything that reads the PROCESS
@@ -113,12 +180,25 @@ contract DeployTest is Test {
         // completes without reverting — the ONLY end-to-end exercise of the
         // `DEPLOYMENT_SUITE_SIGNED_PRICE_STACK` match arm. A typo in the
         // constant preimage or a mis-wired arm surfaces here.
+        //
+        // "Did not revert" alone does NOT prove the RIGHT arm ran — both
+        // helpers succeed under this env. Discriminate on an observable each
+        // suite emits differently: the signed-price suite mints the singleton
+        // central store through its beacon-set deployer, so EXACTLY ONE
+        // `Deployment` log; the DIA suite mints no proxies at all, so ZERO. If
+        // the two arms are swapped (or either arm calls the other helper), the
+        // counts flip and both assertions below fail.
         vm.setEnv("DEPLOYMENT_SUITE", "signed-price-stack");
+        vm.recordLogs();
         deploy.run();
+        assertEq(_countDeploymentLogs(), 1, "signed-price suite mints exactly the central store");
 
-        // Dispatch: "dia-vault-oracle" routes to `deployDIAStackInfra`.
+        // Dispatch: "dia-vault-oracle" routes to `deployDIAStackInfra`, which
+        // deploys infra ONLY — no per-vault proxy is minted, so no `Deployment`.
         vm.setEnv("DEPLOYMENT_SUITE", "dia-vault-oracle");
+        vm.recordLogs();
         deploy.run();
+        assertEq(_countDeploymentLogs(), 0, "dia suite mints no proxies");
 
         // Fall-through: an unrecognised suite hits the explicit
         // `revert("Unknown deployment suite")`. Pins the fall-through so a
@@ -126,6 +206,54 @@ contract DeployTest is Test {
         vm.setEnv("DEPLOYMENT_SUITE", "bogus-suite");
         vm.expectRevert("Unknown deployment suite");
         deploy.run();
+
+        // ----- run() forwards the REAL deploy key to the guards (#267) -----
+        // `run()` derives `deployer` from DEPLOYMENT_KEY and hands it to
+        // `deploySignedPriceStack`, which is what gives that helper's
+        // key-separation guards teeth in production. Prove the wiring by
+        // pointing ST0X_ADMIN at run()'s own deploy key: the deploy must fail
+        // loudly. If run() passed anything else (a placeholder, address(0)) the
+        // guard would silently pass and the feed would ship under the hot CI
+        // key.
+        //
+        // These two reverts land INSIDE `run()`'s `vm.startBroadcast`, so
+        // `vm.stopBroadcast()` never executes and the cheatcode-level broadcast
+        // (not EVM state) survives the revert — close it by hand or the next
+        // `run()` fails with "a broadcast is active already".
+        vm.setEnv("ST0X_ADMIN", vm.toString(deployer));
+        vm.setEnv("DEPLOYMENT_SUITE", "signed-price-stack");
+        vm.expectRevert("ST0X_ADMIN must not be the deploy key");
+        deploy.run();
+        vm.stopBroadcast();
+
+        // Same for ST0X_ORACLE_ADMIN, which rotates signer/timeout directly.
+        vm.setEnv("ST0X_ADMIN", vm.toString(ST0X_ADMIN));
+        vm.setEnv("ST0X_ORACLE_ADMIN", vm.toString(deployer));
+        vm.expectRevert("ST0X_ORACLE_ADMIN must not be the deploy key");
+        deploy.run();
+        vm.stopBroadcast();
+        vm.setEnv("ST0X_ORACLE_ADMIN", vm.toString(ST0X_ORACLE_ADMIN));
+
+        // ----- ST0X_TIMEOUT uint64 bound (#267) -----
+        // `ST0X_TIMEOUT` is read as a uint256 and narrowed to uint64. Solidity's
+        // explicit downcast TRUNCATES silently, so a value of 2**64 + 3600 would
+        // become a perfectly plausible 3600-second timeout and the deploy would
+        // ship a staleness bound nobody asked for. The script's
+        // `<= type(uint64).max` guard must reject it by MESSAGE, not truncate.
+        vm.setEnv("ST0X_TIMEOUT", vm.toString(uint256(type(uint64).max) + 1 + 3600));
+        vm.expectRevert("ST0X_TIMEOUT overflows uint64");
+        deploy.exposedDeploySignedPriceStack(BEACON_OWNER, DEPLOYER);
+
+        // Boundary, the OTHER edge: exactly `type(uint64).max` IS representable,
+        // so the script's own guard must let it through (`<=`, not `<`) and the
+        // rejection must come from DOWNSTREAM — `ST0xPriceOracle`'s
+        // `MAX_TIMEOUT` (30 days) bound, carrying the offending value. A `<`
+        // guard here would swap this for the script's string revert.
+        vm.setEnv("ST0X_TIMEOUT", vm.toString(uint256(type(uint64).max)));
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.TimeoutTooLarge.selector, type(uint64).max));
+        deploy.exposedDeploySignedPriceStack(BEACON_OWNER, DEPLOYER);
+
+        vm.setEnv("ST0X_TIMEOUT", vm.toString(uint256(ST0X_TIMEOUT)));
 
         // ----- signed-price helper: key-separation guards (#267) -----
         // Guard: ST0X_ADMIN holds DEFAULT_ADMIN_ROLE (can rotate the publisher


### PR DESCRIPTION
Coverage half of the adversarial-mutation-test run (skill 0.30.0) against `main @ c371a23`. 4 group workers (Opus), 340 behaviours probed; the majority were already killed by existing tests. This commits only the gaps — 18 discriminating tests, each verified pass-on-clean / fail-under-mutation. `src/` and `script/` byte-identical to c371a23.

The adversarial half's findings land as code fixes stacked on top (starting [#292](https://app.graphite.com/github/pr/ST0x-Technology/st0x.oracle/292)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)