### PR TITLE
fix(signed-price): adapter fails closed on price rounding to zero + ECDSA doc

### DIFF
--- a/src/concrete/adapter/MorphoPairAdapter.sol
+++ b/src/concrete/adapter/MorphoPairAdapter.sol
@@ -17,6 +17,16 @@ error ZeroToken();
 /// configuration error.
 error IdenticalTokens();
 
+/// @dev The rescaled Morpho price floored to zero even though the central store
+/// served a valid non-zero price. Reachable only for collateral tokens whose
+/// decimals make the net Morpho exponent deeply negative (`baseDecimals > 18 +
+/// quoteDecimals`). Feeding Morpho a zero here would value the collateral at
+/// nothing (fail-OPEN — every position unhealthy), the exact outcome the
+/// central store's own `PriceZero` guard prevents, so the adapter fails CLOSED
+/// instead: the read reverts and the market freezes rather than mispricing.
+/// @param central The non-zero central price that rescaled to zero.
+error PriceRoundsToZero(uint256 central);
+
 /// @title MorphoPairAdapter
 /// @notice Beacon-proxied adapter binding one Morpho Blue market to one pair
 /// on the central `ST0xPriceOracle`, converting the central store's
@@ -154,9 +164,15 @@ contract MorphoPairAdapter is Initializable, IOracle {
     /// change: the result is the Morpho *collateral* price, and under-stating
     /// collateral is the conservative direction (less borrowing power, earlier
     /// liquidation) that favours the lender/protocol. A `Ceil` variant would
-    /// silently reverse this safety property.
+    /// silently reverse this safety property. The one place flooring is unsafe
+    /// is when it collapses a valid non-zero central price all the way to zero
+    /// (deeply negative net exponent, i.e. very-high-decimal collateral): a zero
+    /// collateral price is fail-OPEN in Morpho, so guard it and fail closed.
     function price() external view returns (uint256) {
         MainStorage storage $ = _main();
-        return Math.mulDiv(iCentral.price($.pairId), $.scaleNumerator, $.scaleDenominator);
+        uint256 central = iCentral.price($.pairId);
+        uint256 scaled = Math.mulDiv(central, $.scaleNumerator, $.scaleDenominator);
+        if (scaled == 0) revert PriceRoundsToZero(central);
+        return scaled;
     }
 }

--- a/src/concrete/oracle/ST0xPriceOracle.sol
+++ b/src/concrete/oracle/ST0xPriceOracle.sol
@@ -209,10 +209,16 @@ contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
     /// strictly-newer payload timestamped in the FUTURE (`> block.timestamp`)
     /// reverts `PriceFuture` — it would strand `price()` behind an arithmetic
     /// underflow. A strictly-newer payload carrying a zero `price` reverts
-    /// `PriceZero`. An invalid signature on a strictly-newer payload is
-    /// malformed input and reverts `PriceUpdateInvalidSignature`; the
-    /// signature is verified before the future/zero content checks, so an
-    /// unauthenticated payload always reverts the signature error.
+    /// `PriceZero`. The signature is verified before the future/zero content
+    /// checks, so an unauthenticated payload never reverts a content-check
+    /// selector. A payload whose signature RECOVERS to a non-signer address
+    /// reverts `PriceUpdateInvalidSignature`. A SYNTACTICALLY malformed
+    /// signature (wrong length, `s` in the upper half-order, `v` not in
+    /// {27,28}) reverts inside `ECDSA.recover` FIRST, with OpenZeppelin's own
+    /// `ECDSAInvalidSignatureLength` / `ECDSAInvalidSignatureS` /
+    /// `ECDSAInvalidSignature` — so monitoring keyed on the revert selector must
+    /// treat those three as equivalent to `PriceUpdateInvalidSignature`. Every
+    /// path is fail-closed: no unsigned or malformed payload is ever applied.
     function updatePrice(bytes32 id, uint256 newPrice, uint256 newTimestamp, bytes calldata signature)
         external
         returns (bool applied)

--- a/test/src/concrete/adapter/MorphoPairAdapter.t.sol
+++ b/test/src/concrete/adapter/MorphoPairAdapter.t.sol
@@ -12,7 +12,12 @@ import {BeaconProxy} from "@openzeppelin-contracts-5.6.1/proxy/beacon/BeaconProx
 import {Initializable} from "@openzeppelin-contracts-upgradeable-5.6.1/proxy/utils/Initializable.sol";
 
 import {ST0xPriceOracle} from "../../../../src/concrete/oracle/ST0xPriceOracle.sol";
-import {MorphoPairAdapter, ZeroToken, IdenticalTokens} from "../../../../src/concrete/adapter/MorphoPairAdapter.sol";
+import {
+    MorphoPairAdapter,
+    ZeroToken,
+    IdenticalTokens,
+    PriceRoundsToZero
+} from "../../../../src/concrete/adapter/MorphoPairAdapter.sol";
 import {MorphoPairAdapterV2} from "../../../mocks/MorphoPairAdapterV2.sol";
 import {MockERC20Decimals} from "../../../mocks/MockERC20Decimals.sol";
 
@@ -202,6 +207,26 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
         bytes32 idB = oracle.pairId(address(base59), address(quote));
         _push(idB, 1e40, block.timestamp);
         assertEq(maxBase.price(), 1e5, "baseDecimals 59 is the largest accepted");
+    }
+
+    /// @notice A valid, fresh, non-zero central price that the decimal rescale
+    /// FLOORS all the way to zero must fail closed (revert `PriceRoundsToZero`),
+    /// not return 0. Morpho reading a zero collateral price treats the
+    /// collateral as worthless — every position unhealthy — which is the
+    /// fail-OPEN outcome the central store's own `PriceZero` guard exists to
+    /// prevent, arriving through the adapter instead. Reachable for very-high-
+    /// decimal collateral (`baseDecimals > 18 + quoteDecimals`): base 59 /
+    /// quote 6 scales by `10^(36+6-59-18) = 10^-35`, so the canonical 1.0 price
+    /// (`1e18`) floors to 0. Issue: signed-price C2.
+    function test_MorphoPairAdapter_PriceRoundingToZeroFailsClosed() public {
+        MockERC20Decimals base59 = new MockERC20Decimals(59);
+        MorphoPairAdapter adapter = _deployAdapter(address(base59), address(quote));
+        bytes32 id = oracle.pairId(address(base59), address(quote));
+        // Canonical 1.0 — a perfectly valid, fresh central price.
+        _push(id, 1e18, block.timestamp);
+        assertEq(oracle.price(id), 1e18, "central serves a valid non-zero price");
+        vm.expectRevert(abi.encodeWithSelector(PriceRoundsToZero.selector, uint256(1e18)));
+        adapter.price();
     }
 
     function test_MorphoPairAdapter_InitializeOnlyOnce() public {


### PR DESCRIPTION
Signed-price adversarial findings (mutation-test run @ c371a23). Stacked on [#293](https://app.graphite.com/github/pr/ST0x-Technology/st0x.oracle/293).

- **C2 (MED)** — `MorphoPairAdapter.price()` floors the rescale to **0** for very-high-decimal collateral (base > 18 + quote), feeding Morpho a zero collateral price (fail-OPEN) — the exact thing the central store's `PriceZero` guard prevents. Now reverts `PriceRoundsToZero` (fail-closed); mutation-verified.
- **C1 (doc)** — `updatePrice` NatSpec now documents that a malformed signature reverts OpenZeppelin's ECDSA errors before `PriceUpdateInvalidSignature`, all fail-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)