### PR TITLE
audit: resolve the 11 minor findings from the 0.34.0 pre-audit review

### DIFF
--- a/.github/workflows/suite-name-sync.yaml
+++ b/.github/workflows/suite-name-sync.yaml
@@ -38,9 +38,12 @@ jobs:
             in_opts && !/^          - / { in_opts=0; in_suite=0 }
           ' "$workflow" | sort)
 
-          # keccak256("...") preimages used as DEPLOYMENT_SUITE_* dispatch keys.
-          constants=$(grep -oE 'keccak256\("[^"]+"\)' "$deploy" \
-            | sed -E 's/keccak256\("([^"]+)"\)/\1/' | sort -u)
+          # keccak256("...") preimages of the DEPLOYMENT_SUITE_* dispatch keys
+          # specifically — scoped to the `DEPLOYMENT_SUITE_<NAME> = keccak256(...)`
+          # constant definitions so an unrelated keccak256("...") string literal
+          # elsewhere in Deploy.sol can't spuriously enter the set and red CI.
+          constants=$(grep -oE 'DEPLOYMENT_SUITE_[A-Z0-9_]+ *= *keccak256\("[^"]+"\)' "$deploy" \
+            | sed -E 's/.*keccak256\("([^"]+)"\)/\1/' | sort -u)
 
           echo "Dropdown suites:"; echo "$dropdown" | sed 's/^/  - /'
           echo "Deploy.sol suites:"; echo "$constants" | sed 's/^/  - /'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,16 @@ locally. The workflow runs `rainix-sol-artifacts`, which executes
   oracle is minted afterwards through the beacon-set deployer with that vault's
   DIA feed + corporate-action pause config.
 - `signed-price-stack` — the `ST0xPriceOracle` singleton + its beacon-set
-  deployer, and a `MorphoPairAdapterBeaconSetDeployer` bound to it.
+  deployer, and a `MorphoPairAdapterBeaconSetDeployer` bound to it. This suite
+  additionally requires four dispatch inputs: `st0x-admin` (`ST0X_ADMIN`),
+  `st0x-oracle-admin` (`ST0X_ORACLE_ADMIN`), `st0x-signer` (`ST0X_SIGNER`), and
+  `st0x-timeout` (`ST0X_TIMEOUT`, seconds, `<= 30 days`). The dropdown marks
+  them optional because the `dia-vault-oracle` suite ignores them, but they are
+  effectively required here: `Deploy.sol` reads each via `vm.envAddress` /
+  `vm.envUint` and reverts on any empty/missing value, and the three address
+  roles (admin, oracle-admin, signer) must each differ from the deploy key — the
+  signer authorises every published price, so it gets the same governance
+  separation as the beacon owner.
 
 `BEACON_INITIAL_OWNER` is **required** and must differ from the deploy key: the
 beacon owner controls the implementation behind every proxy (every served
@@ -115,7 +124,8 @@ price), so it must be governance — a multisig — never the hot CI deploy key.
 workflow exposes it as a required dispatch input; a missing value fails the
 deploy loudly.
 
-1. Run the workflow with the target network, suite, and beacon owner
+1. Run the workflow with the target network, suite, and beacon owner (plus the
+   four `st0x-*` inputs when the suite is `signed-price-stack`)
 2. Parse the deployed addresses from the workflow logs; if the repo needs to
    reference any (e.g. the Base token addresses the fork tests use), keep them
    as `.sol` constants, not a separate registry file

--- a/README.md
+++ b/README.md
@@ -46,12 +46,13 @@ consumers ──▶│           DIAVaultOracle          │   ← canonical add
   (`ICorporateActionsV1`) is **derived** as the priced vault's `asset()` — the
   tStock the wtStock wraps — not a separate config field, and the auto-pause is
   mandatory.
-- **`wtStock` NAV tracking via `convertToAssets`.** The
-  `totalAssets /
-  totalSupply` factor is exactly ERC-4626
-  `convertToAssets(1 share)`. Post-split rebalances inside the underlying
-  `tStock` vault flow through to the share price automatically on the first read
-  after the pause window closes — no oracle-side intervention.
+- **`wtStock` NAV tracking.** The `totalAssets /
+  totalSupply` factor is the
+  vault's raw ERC-4626 assets-per-share ratio (equal to
+  `convertToAssets(1 share)` up to OpenZeppelin's virtual-offset rounding).
+  Post-split rebalances inside the underlying `tStock` vault flow through to the
+  share price automatically on the first read after the pause window closes — no
+  oracle-side intervention.
 
 **DIA freshness model:** DIA pushes a new value whenever **either** 0.1%
 deviation OR 1 hour elapsed (whichever first). Volatile periods get pushes every
@@ -79,19 +80,21 @@ few minutes; the 1-hour heartbeat is the dead-market floor. Recommended
 > `maxAge = 2 hours` with `pauseTimeAfter = 3 hours` (a 1h margin) is the
 > reference.
 
-**DIA on Base mainnet:** the canonical oracle contract is
-`0xCE521b52513242c5094bc56f57887BB2A05B8129`. Per-symbol feeds are all served
-from this single contract via `getValue(string key)` and the key is the bare
-symbol (e.g. `"COIN"`).
+**DIA on Base mainnet:** the canonical oracle contract address is the
+`DIA_FEED_BASE` constant in [`src/lib/LibDIAFeed.sol`](src/lib/LibDIAFeed.sol) —
+the single source of truth; import it rather than pasting the literal.
+Per-symbol feeds are all served from this single contract via
+`getValue(string key)` and the key is the bare symbol (e.g. `"COIN"`).
 
 ### Integrator Quickstart
 
 Mint a `DIAVaultOracle` for a new vault through its beacon-set deployer:
 
 ```solidity
+// DIA_FEED_BASE is the canonical Base feed address, from src/lib/LibDIAFeed.sol.
 DIAVaultOracle oracle = diaVaultOracleBeaconSetDeployer.newDIAVaultOracle(
     DIAVaultOracleConfig({
-        diaOracle:       IDIAOracleV2(0xCE521b52513242c5094bc56f57887BB2A05B8129),
+        diaOracle:       IDIAOracleV2(DIA_FEED_BASE),
         symbol:          "COIN",
         vault:           wtStockVault,  // ICorporateActionsV1 derived from vault.asset()
         maxAge:          2 hours,
@@ -217,7 +220,8 @@ src/
 │   ├── IAggregatorV2V3.sol      (vendored Chainlink shape)
 │   └── IOracle.sol              (vendored Morpho Blue oracle shape)
 └── lib/
-    └── LibCorporateActionsPause.sol
+    ├── LibCorporateActionsPause.sol
+    └── LibDIAFeed.sol           (single source of truth: DIA Base feed address)
 test/
 ├── mocks/
 └── src/

--- a/src/concrete/oracle/DIAVaultOracle.sol
+++ b/src/concrete/oracle/DIAVaultOracle.sol
@@ -9,7 +9,7 @@ import {ACTION_TYPE_INIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateAct
 import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
 import {IERC4626} from "@openzeppelin-contracts-5.6.1/interfaces/IERC4626.sol";
 import {ICLONEABLE_V2_SUCCESS, ICloneableV2} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
-import {Initializable} from "@openzeppelin-contracts-5.6.1/proxy/utils/Initializable.sol";
+import {Initializable} from "@openzeppelin-contracts-upgradeable-5.6.1/proxy/utils/Initializable.sol";
 
 /// @dev Error raised when a zero address is provided for the DIA feed.
 error ZeroDIAOracle();
@@ -147,9 +147,12 @@ struct DIAVaultOracleConfig {
 /// surface they already use for Chainlink feeds.
 ///
 /// Math: `vaultSharePrice = diaPrice * totalAssets / totalSupply` scaled to 8
-/// decimals — i.e. the equity's USD price times `convertToAssets(1 share)`, so
-/// the price tracks any NAV change inside the vault (most importantly the
-/// post-split rebalance in the underlying `tStock`). Performed in Rain float
+/// decimals — i.e. the equity's USD price times the vault's raw assets-per-share
+/// ratio (≈ `convertToAssets(1 share)`, up to OZ ERC-4626 virtual-offset
+/// rounding), so the price tracks any NAV change inside the vault (most
+/// importantly the post-split rebalance in the underlying `tStock`). Uses the
+/// RAW `totalAssets / totalSupply` — see the trust-model note below. Performed
+/// in Rain float
 /// space throughout so neither operand can overflow uint256; the conversion to
 /// fixed-point 8dp happens only at the final return.
 ///

--- a/src/concrete/oracle/ST0xPriceOracle.sol
+++ b/src/concrete/oracle/ST0xPriceOracle.sol
@@ -51,6 +51,10 @@ import {MessageHashUtils} from "@openzeppelin-contracts-5.6.1/utils/cryptography
 ///    at `initialize`).
 ///  - `ORACLE_ADMIN_ROLE` — `setSigner` / `setTimeout`.
 contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
+    /// @notice Role gating `setSigner` / `setTimeout` (rotation of the global
+    /// publisher key and the staleness bound). Granted to `oracleAdmin` at
+    /// `initialize`; distinct from `DEFAULT_ADMIN_ROLE`, which only administers
+    /// roles and cannot itself rotate signer/timeout.
     bytes32 public constant ORACLE_ADMIN_ROLE = keccak256("ORACLE_ADMIN");
 
     /// @notice Upper bound on the global staleness `timeout`. A value larger

--- a/src/interface/IAggregatorV2V3.sol
+++ b/src/interface/IAggregatorV2V3.sol
@@ -40,9 +40,9 @@ interface AggregatorV2V3Interface {
     /// @return startedAt Timestamp when the round was started.
     /// @return updatedAt Timestamp when the round was updated.
     /// @return answeredInRound The round in which the answer was computed.
-    /// @dev Pyth-backed implementations may revert because Pyth does not
-    /// expose historical rounds via this interface. Pure Chainlink-backed
-    /// implementations honour the request.
+    /// @dev Implementations backed by a latest-only feed (such as the
+    /// DIA-backed oracle in this repo) revert here — no per-round history is
+    /// available; only backings that retain round history honour the request.
     function getRoundData(uint80 _roundId)
         external
         view

--- a/src/interface/IDIAOracleV2.sol
+++ b/src/interface/IDIAOracleV2.sol
@@ -4,10 +4,9 @@ pragma solidity ^0.8.25;
 
 // SYNC NOTE: This interface mirrors DIA Data Association's canonical
 // `IDIAOracleV2` (the on-chain feed surface exposed by their oracle
-// contracts — e.g. on Base mainnet at
-// `0xCE521b52513242c5094bc56f57887BB2A05B8129`). Last synced 2026-06-29
-// against the contract's verified bytecode (probed via
-// `cast call ... getValue(string)(uint128,uint128) "COIN"`).
+// contracts — the live Base address is `DIA_FEED_BASE` in
+// `src/lib/LibDIAFeed.sol`). Last synced 2026-06-29 against the contract's
+// verified bytecode (probed via `cast call ... getValue(string)(uint128,uint128) "COIN"`).
 //
 // Vendored rather than pulled as a dep — the interface is small,
 // stable, and DIA does not publish a soldeer package. Same pattern as

--- a/src/lib/LibDIAFeed.sol
+++ b/src/lib/LibDIAFeed.sol
@@ -3,8 +3,6 @@
 pragma solidity ^0.8.25;
 
 /// @dev The live DIA push-oracle feed on Base that every DIA-backed vault
-/// oracle reads. Single source of truth for the address that was previously
-/// re-typed across README.md, `IDIAOracleV2.sol` and the fork test — import
-/// this constant instead of pasting the literal. Last synced 2026-06-29.
+/// oracle reads.
 /// https://basescan.org/address/0xCE521b52513242c5094bc56f57887BB2A05B8129
 address constant DIA_FEED_BASE = 0xCE521b52513242c5094bc56f57887BB2A05B8129;

--- a/test/src/concrete/adapter/MorphoPairAdapter.t.sol
+++ b/test/src/concrete/adapter/MorphoPairAdapter.t.sol
@@ -27,9 +27,7 @@ import {MockERC20Decimals} from "../../../mocks/MockERC20Decimals.sol";
 /// staleness/unset passthrough, constructor / initializer guards, and the
 /// shared beacon upgrade retargeting every deployed adapter proxy at once.
 contract MorphoPairAdapterTest is SignedPriceTestBase {
-    uint256 constant SIGNER_PK = uint256(keccak256("st0x.price-oracle.signer.test"));
-    address SIGNER;
-
+    // SIGNER_PK / SIGNER are inherited from SignedPriceTestBase.
     address constant ADMIN = address(0xC0DE);
     uint64 constant TIMEOUT = 1 hours;
 
@@ -42,7 +40,6 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
     UpgradeableBeacon adapterBeacon;
 
     function setUp() public {
-        SIGNER = vm.addr(SIGNER_PK);
         // Same shape as production: implementation behind a beacon proxy.
         ST0xPriceOracle impl = new ST0xPriceOracle();
         UpgradeableBeacon beacon = new UpgradeableBeacon(address(impl), ADMIN);
@@ -304,6 +301,6 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
     }
 
     function _push(bytes32 id, uint256 price, uint256 timestamp) internal {
-        assertTrue(oracle.updatePrice(id, price, timestamp, signPriceUpdate(oracle, SIGNER_PK, id, price, timestamp)));
+        push(oracle, id, price, timestamp);
     }
 }

--- a/test/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.t.sol
@@ -17,9 +17,7 @@ import {MorphoPairAdapterV2} from "../../../mocks/MorphoPairAdapterV2.sol";
 import {MockERC20Decimals} from "../../../mocks/MockERC20Decimals.sol";
 
 contract MorphoPairAdapterBeaconSetDeployerTest is SignedPriceTestBase {
-    uint256 internal constant SIGNER_PK = uint256(keccak256("st0x.price-oracle.signer.test"));
-    address internal SIGNER;
-
+    // SIGNER_PK / SIGNER are inherited from SignedPriceTestBase.
     address internal constant BEACON_OWNER = address(0xBEEF);
     address internal constant ADMIN = address(0xC0DE);
     uint64 internal constant TIMEOUT = 1 hours;
@@ -31,7 +29,6 @@ contract MorphoPairAdapterBeaconSetDeployerTest is SignedPriceTestBase {
     event Deployment(address indexed caller, address indexed oracle);
 
     function setUp() public {
-        SIGNER = vm.addr(SIGNER_PK);
         vm.warp(1_000_000);
 
         // The central store, shaped as in production: impl behind a beacon proxy.
@@ -201,6 +198,6 @@ contract MorphoPairAdapterBeaconSetDeployerTest is SignedPriceTestBase {
     // -------- Helpers --------
 
     function _push(bytes32 id, uint256 price, uint256 timestamp) internal {
-        assertTrue(central.updatePrice(id, price, timestamp, signPriceUpdate(central, SIGNER_PK, id, price, timestamp)));
+        push(central, id, price, timestamp);
     }
 }

--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -35,6 +35,7 @@ import {CorporateActionsListHarness} from "../../../mocks/CorporateActionsListHa
 import {TestERC1967Proxy} from "../../../mocks/TestERC1967Proxy.sol";
 import {ACTION_TYPE_STOCK_SPLIT_V1, ACTION_TYPE_INIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
 import {InvalidMask} from "st0x-deploy-0.1.1/src/error/ErrCorporateAction.sol";
+import {FixedDecimalOverflow} from "rain-math-float-0.1.1/src/error/ErrDecimalFloat.sol";
 
 contract DIAVaultOracleTest is Test {
     DIAVaultOracle internal implementation;
@@ -955,6 +956,29 @@ contract DIAVaultOracleTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(VaultSharePriceOverflow.selector, uint256(7e76)));
         oracle.latestAnswer();
+    }
+
+    /// @notice The UPPER overflow band the NatSpec distinguishes: a share price
+    /// so large it exceeds uint256 during the 8-decimal scaling aborts EARLIER,
+    /// inside `LibDecimalFloat`, with its own `FixedDecimalOverflow` — before the
+    /// contract's own int256-band `VaultSharePriceOverflow` guard is reached.
+    /// Pins that this fails CLOSED (reverts) rather than wrapping to a wrong
+    /// positive answer. diaPrice raw 1e38 (natural 1e20) * totalAssets 1e60 /
+    /// totalSupply 1 = natural 1e80 → 8dp 1e88, past uint256.max (~1.16e77).
+    /// Selector-only: the library error's args are internal.
+    function testLatestAnswerRevertsFixedDecimalOverflowAboveUintMax() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        diaOracle.setValue(SYMBOL, 1e38, uint128(block.timestamp));
+        vault.setTotalAssets(1e60);
+        vault.setTotalSupply(1);
+
+        // Assert the exact selector (not a bare revert). The library error
+        // carries internal args (coefficient/exponent/decimals), so match on
+        // the selector to stay robust to those while still pinning that this
+        // fails closed as FixedDecimalOverflow rather than wrapping.
+        (bool ok, bytes memory ret) = address(oracle).staticcall(abi.encodeCall(DIAVaultOracle.latestAnswer, ()));
+        assertFalse(ok, "must revert, not return a wrapped answer");
+        assertEq(bytes4(ret), FixedDecimalOverflow.selector, "upper overflow band must revert FixedDecimalOverflow");
     }
 
     // -------- latestRoundData --------

--- a/test/src/concrete/oracle/ST0xPriceOracle.t.sol
+++ b/test/src/concrete/oracle/ST0xPriceOracle.t.sol
@@ -10,6 +10,7 @@ import {Initializable} from "@openzeppelin-contracts-upgradeable-5.6.1/proxy/uti
 import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
 
 import {ST0xPriceOracle} from "../../../../src/concrete/oracle/ST0xPriceOracle.sol";
+import {ECDSA} from "@openzeppelin-contracts-5.6.1/utils/cryptography/ECDSA.sol";
 
 /// @title ST0xPriceOracleTest
 /// @notice Unit coverage for the central multi-pair oracle: global signer /
@@ -17,9 +18,7 @@ import {ST0xPriceOracle} from "../../../../src/concrete/oracle/ST0xPriceOracle.s
 /// `updatePrice` (no registration, no nonce), `price()` unset/staleness
 /// reverts, and the deterministic `pairId` derivation.
 contract ST0xPriceOracleTest is SignedPriceTestBase {
-    uint256 constant SIGNER_PK = uint256(keccak256("st0x.price-oracle.signer.test"));
-    address SIGNER;
-
+    // SIGNER_PK / SIGNER are inherited from SignedPriceTestBase.
     address constant ADMIN = address(0xC0DE);
     address constant ORACLE_ADMIN = address(0xADDD);
     address constant RANDO = address(0xF00D);
@@ -35,7 +34,6 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     UpgradeableBeacon beacon;
 
     function setUp() public {
-        SIGNER = vm.addr(SIGNER_PK);
         // Same shape as production: implementation behind a beacon proxy.
         ST0xPriceOracle impl = new ST0xPriceOracle();
         beacon = new UpgradeableBeacon(address(impl), ADMIN);
@@ -250,6 +248,25 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     }
 
     /// @notice `updatePrice` is permissionless — any caller with a validly
+    /// @notice A syntactically malformed (wrong-length) signature on a strictly-
+    /// newer payload reverts INSIDE `ECDSA.recover` with OpenZeppelin's own
+    /// `ECDSAInvalidSignatureLength` — the documented fail-closed path (the
+    /// contract NatSpec spells out that malformed sigs surface OZ's selectors,
+    /// not `PriceUpdateInvalidSignature`). Never swallowed into
+    /// `PriceUpdateInvalidSignature` (which a regression to `ECDSA.tryRecover`
+    /// would produce) and never applied — the pair stays unset. The existing
+    /// `hex"deadbeef"` tests only hit the no-op (equal/older timestamp) path,
+    /// which short-circuits before `recover` is reached, so this fresh-timestamp
+    /// case is the one that actually exercises `recover` on malformed input.
+    function test_UpdatePrice_MalformedSignatureOnFreshTimestamp_RevertsInEcdsa() public {
+        bytes memory malformed = hex"deadbeef"; // 4 bytes, not 65
+        vm.expectRevert(abi.encodeWithSelector(ECDSA.ECDSAInvalidSignatureLength.selector, uint256(4)));
+        oracle.updatePrice(PAIR_A, 42e18, block.timestamp, malformed);
+        // Nothing stored — price() reverts the normal unset revert, not a panic.
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUnset.selector, PAIR_A));
+        oracle.price(PAIR_A);
+    }
+
     /// signed fresh payload succeeds.
     function test_UpdatePrice_Permissionless() public {
         bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, block.timestamp);
@@ -547,6 +564,6 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     // -------- Helpers --------
 
     function _push(bytes32 id, uint256 price, uint256 timestamp) internal {
-        assertTrue(oracle.updatePrice(id, price, timestamp, signPriceUpdate(oracle, SIGNER_PK, id, price, timestamp)));
+        push(oracle, id, price, timestamp);
     }
 }

--- a/test/src/lib/SignedPriceTestBase.sol
+++ b/test/src/lib/SignedPriceTestBase.sol
@@ -15,6 +15,24 @@ import {ST0xPriceOracle} from "../../../src/concrete/oracle/ST0xPriceOracle.sol"
 /// scheme ever changes, this is the only helper to update and every inheriting
 /// suite recompiles against it — no silent per-file drift.
 abstract contract SignedPriceTestBase is Test {
+    /// @notice The canonical test publisher private key, and its address. Held
+    /// here so every signed-price suite shares one signer fixture rather than
+    /// re-declaring it — the key/address counterpart to the single `push` /
+    /// `signPriceUpdate` helpers below.
+    uint256 internal constant SIGNER_PK = uint256(keccak256("st0x.price-oracle.signer.test"));
+    address internal immutable SIGNER = vm.addr(SIGNER_PK);
+
+    /// @notice Signs and applies a price update against `store` with the
+    /// canonical `SIGNER_PK`, asserting it was accepted. The single push flow
+    /// every suite's thin `_push` wrapper delegates to.
+    /// @param store The oracle to push to.
+    /// @param id The pair id.
+    /// @param price The price being pushed.
+    /// @param timestamp The observation timestamp.
+    function push(ST0xPriceOracle store, bytes32 id, uint256 price, uint256 timestamp) internal {
+        assertTrue(store.updatePrice(id, price, timestamp, signPriceUpdate(store, SIGNER_PK, id, price, timestamp)));
+    }
+
     /// @notice Recreates the EIP-712 digest an off-chain signer would sign for
     /// a price update against `store`, taking the oracle store as a parameter
     /// so the derivation is not tied to any one test's local variable name.


### PR DESCRIPTION
Resolves all **11 minor findings** from the 0.34.0 whole-repo pre-audit review (which returned **zero critical/high/medium, zero security, zero correctness**). All docs/tests/CI — the only non-comment src edit is an `Initializable` import that resolves to the same file, so contract bytecode is unchanged.

- **AGENTS.md (was MED):** document the four `ST0X_*` signed-price-stack deploy inputs the deploy section omitted.
- **Docs:** README structure map + `convertToAssets` 'exactly' softened to the raw ratio; stale Pyth/Chainlink `getRoundData` note replaced; `ORACLE_ADMIN_ROLE` NatSpec added.
- **DIA feed address:** per review feedback, instead of a CI grep guard the drifting prose copies are **removed** — README, its config example, and the `IDIAOracleV2` sync note now reference the `DIA_FEED_BASE` constant, so the literal lives only in `LibDIAFeed.sol` and its pin test. No new workflow.
- **Tests:** pin the two documented-but-untested fail-closed paths (malformed signature in `ECDSA.recover`; the upper `FixedDecimalOverflow` band). Hoist the triplicated signer fixture into `SignedPriceTestBase`.
- **CI:** tightened `suite-name-sync` grep to `DEPLOYMENT_SUITE_*`.

194 tests; fmt/slither/reuse/single-contract clean.

Once merged, the mutation + audit evidence is regenerated against the post-fix tip (final pre-audit stamp, skill 0.34.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)