### PR TITLE
audit(H01): publisher-signed expiry replaces the global timeout

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -37,11 +37,6 @@ on:
         required: false
         type: string
         default: ''
-      st0x-timeout:
-        description: 'signed-price-stack ONLY: global staleness timeout in seconds (must be <= 30 days).'
-        required: false
-        type: string
-        default: ''
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -84,7 +79,6 @@ jobs:
           ST0X_ADMIN: ${{ inputs.st0x-admin }}
           ST0X_ORACLE_ADMIN: ${{ inputs.st0x-oracle-admin }}
           ST0X_SIGNER: ${{ inputs.st0x-signer }}
-          ST0X_TIMEOUT: ${{ inputs.st0x-timeout }}
           DEPLOY_BROADCAST: '1'
           DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
           ETH_RPC_URL: ${{ secrets[env.rpc_secret_name] || vars[env.rpc_secret_name] || '' }}

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ pairs, and a thin per-market adapter (`MorphoPairAdapter`) that reshapes one
 pair into the exact convention Morpho expects.
 
 ```text
-publisher ── EIP-712 signed (pairId, price, timestamp) ──▶┌───────────────────┐
+         EIP-712 signed (pairId, price, timestamp, expiry)
+publisher ───────────────────────────────────────────────▶┌───────────────────┐
                                                           │  ST0xPriceOracle  │  ← singleton
                                                           │  multi-pair store │     store
                                                           │  opaque uint256   │
@@ -150,11 +151,21 @@ Morpho Blue ────── IOracle.price() ───────────
   (`keccak256(abi.encodePacked(base, quote))`, no registration); values are
   opaque `uint256`s whose scaling belongs to the publisher. `updatePrice` is
   permissionless — a global publisher's EIP-712 signature authorises each
-  update, replay-protected by a strict per-pair timestamp inequality (stale
-  payloads no-op, future-dated payloads revert). The EIP-712 domain deliberately
-  binds name + version only, so one signed payload serves every chain the oracle
-  is deployed on. Global `signer` / `timeout` rotate via
-  `ORACLE_ADMIN_ROLE`-gated setters.
+  update, replay-protected by a strict per-pair timestamp inequality
+  (not-strictly-newer payloads no-op, future-dated payloads revert). Every
+  payload also carries the publisher's signed `expiry` — the producer's own
+  validity horizon: a payload whose window has already closed is rejected
+  outright at submission, and `price()` refuses a stored price once its expiry
+  passes. There is no consumer-side staleness knob — the publisher controls the
+  stale window per payload, with nothing to update on-chain (short windows while
+  the underlying market trades, one long window across a close or weekend;
+  window overlap is what bounds a submitter's choice between concurrently-live
+  payloads, so keep it minimal). `expiry - timestamp` is sanity-capped at
+  `MAX_VALIDITY_WINDOW` (30 days) purely to fail a wrong-scale (e.g.
+  milliseconds) signing pipeline closed. The EIP-712 domain deliberately binds
+  name + version only, so one signed payload serves every chain the oracle is
+  deployed on. The global `signer` rotates via an `ORACLE_ADMIN_ROLE`-gated
+  setter.
 - **`MorphoPairAdapter`** — beacon-proxied adapter (not a pricing source, a
   transformation) exposing one pair on the central store through Morpho Blue's
   `IOracle.price()`. It owns the decimal conversion: the publisher signs an

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -83,8 +83,7 @@ contract Deploy is Script {
     /// minted through that deployer, and a `MorphoPairAdapterBeaconSetDeployer`
     /// bound to that singleton. No per-market adapter proxies are minted here.
     /// Assumes the caller has an active broadcast. Reads the oracle config from
-    /// env: `ST0X_ADMIN`, `ST0X_ORACLE_ADMIN`, `ST0X_SIGNER` (addresses) and
-    /// `ST0X_TIMEOUT` (uint64).
+    /// env: `ST0X_ADMIN`, `ST0X_ORACLE_ADMIN`, `ST0X_SIGNER` (addresses).
     /// @param beaconInitialOwner Initial owner of both beacons.
     /// @return central The singleton central `ST0xPriceOracle` store.
     /// @return oracleBSD The deployed `ST0xPriceOracleBeaconSetDeployer`.
@@ -100,14 +99,11 @@ contract Deploy is Script {
         address admin = vm.envAddress("ST0X_ADMIN");
         address oracleAdmin = vm.envAddress("ST0X_ORACLE_ADMIN");
         address signer = vm.envAddress("ST0X_SIGNER");
-        uint256 timeoutRaw = vm.envUint("ST0X_TIMEOUT");
-        require(timeoutRaw <= type(uint64).max, "ST0X_TIMEOUT overflows uint64");
-        uint64 timeout = uint64(timeoutRaw);
 
         // ST0X_ADMIN holds DEFAULT_ADMIN_ROLE, the role-admin for
         // ORACLE_ADMIN_ROLE — so it can grant itself ORACLE_ADMIN_ROLE and
-        // rotate the publisher signer/timeout, i.e. fully control every served
-        // price. It (and ST0X_ORACLE_ADMIN, which rotates them directly) must
+        // rotate the publisher signer, i.e. fully control every served
+        // price. It (and ST0X_ORACLE_ADMIN, which rotates it directly) must
         // therefore be governance, never the hot CI deploy key — the same
         // separation the beacon owner enforces. Fail the deploy loudly rather
         // than silently leaving the feed under the deploy key's control.
@@ -130,17 +126,16 @@ contract Deploy is Script {
 
         // The singleton central store, minted through its own beacon-set
         // deployer so its creation is atomic and recorded (Deployment event).
-        central = oracleBSD.newST0xPriceOracle(admin, oracleAdmin, signer, timeout);
+        central = oracleBSD.newST0xPriceOracle(admin, oracleAdmin, signer);
 
         adapterBSD = new MorphoPairAdapterBeaconSetDeployer(
             MorphoPairAdapterBeaconSetDeployerConfig({initialOwner: beaconInitialOwner, central: central})
         );
 
         // Postcondition: the central store carries the requested signer and the
-        // ORACLE_ADMIN_ROLE grant, so signer/timeout rotation is callable from
+        // ORACLE_ADMIN_ROLE grant, so signer rotation is callable from
         // day one and no post-deploy grant step is left dangling.
         require(central.signer() == signer, "signer mismatch");
-        require(central.timeout() == timeout, "timeout mismatch");
         require(central.hasRole(central.ORACLE_ADMIN_ROLE(), oracleAdmin), "oracle admin role not granted");
 
         // Postcondition: both beacons — which control the implementation behind

--- a/src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.sol
+++ b/src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.sol
@@ -78,19 +78,18 @@ contract ST0xPriceOracleBeaconSetDeployer {
     /// @param admin Receives `DEFAULT_ADMIN_ROLE`.
     /// @param oracleAdmin Receives `ORACLE_ADMIN_ROLE`.
     /// @param signer The initial global publisher key.
-    /// @param timeout The initial global staleness bound.
     /// @return oracle The deployed proxy as a typed reference.
     // slither-disable-next-line reentrancy-events
-    function newST0xPriceOracle(address admin, address oracleAdmin, address signer, uint64 timeout)
+    function newST0xPriceOracle(address admin, address oracleAdmin, address signer)
         external
         returns (ST0xPriceOracle oracle)
     {
-        bytes32 salt = keccak256(abi.encode(admin, oracleAdmin, signer, timeout));
+        bytes32 salt = keccak256(abi.encode(admin, oracleAdmin, signer));
         oracle = ST0xPriceOracle(
             address(
                 new BeaconProxy{salt: salt}(
                     address(iST0xPriceOracleBeacon),
-                    abi.encodeCall(ST0xPriceOracle.initialize, (admin, oracleAdmin, signer, timeout))
+                    abi.encodeCall(ST0xPriceOracle.initialize, (admin, oracleAdmin, signer))
                 )
             )
         );

--- a/src/concrete/oracle/ST0xPriceOracle.sol
+++ b/src/concrete/oracle/ST0xPriceOracle.sol
@@ -15,14 +15,39 @@ import {MessageHashUtils} from "@openzeppelin-contracts-5.6.1/utils/cryptography
 /// doesn't. Pair ids are deterministic —
 /// `keccak256(abi.encodePacked(baseToken, quoteToken))`, exposed as the
 /// `pairId` pure helper — and the first `updatePrice` on a brand-new pair
-/// simply works. The publisher key (`signer`) and the staleness bound
-/// (`timeout`) are GLOBAL, shared by every pair, and rotated via two
-/// separate role-gated setters (separate functions deliberately, so a
-/// signer rotation can never race a timeout change in one calldata blob).
+/// simply works. The publisher key (`signer`) is GLOBAL, shared by every
+/// pair, and rotated via a role-gated setter.
 ///
 /// Price VALUES are opaque `uint256`s: scaling and semantics belong
 /// entirely to the publisher / consumer of each pair. Each pair's publisher
 /// decides what its values mean; this contract never interprets them.
+///
+/// PRODUCER-CONTROLLED VALIDITY: every signed payload carries the
+/// publisher's own `expiry` — the instant past which the publisher has
+/// disowned the price. Validity is therefore a claim MADE BY the price's
+/// producer and enforced here, not a constant guessed by this contract or
+/// its consumers. Two enforcement points, both fail-closed at the edge
+/// instant:
+///
+///  - SUBMISSION: `updatePrice` rejects a payload whose window has already
+///    closed (`expiry <= block.timestamp` reverts `PriceExpired`). Once a
+///    payload's window passes it is dead for every deployment, permanently.
+///    The set of payloads a submitter can choose between at any instant is
+///    only the currently-live windows, so the publisher's window policy —
+///    windows that do not overlap, or overlap only by the small margin
+///    needed for continuity of service — is what bounds adversarial
+///    selection between genuine signed prices. The publisher tunes that
+///    bound off-chain, per payload, with nothing to update on-chain: short
+///    windows while the underlying market trades, one long window across a
+///    close or weekend.
+///  - READ: `price()` refuses to serve a stored price past its expiry
+///    (`block.timestamp >= expiry` reverts `PriceExpired`). There is no
+///    separate consumer-side staleness knob: the producer's signed horizon
+///    is the staleness bound.
+///
+/// `MAX_VALIDITY_WINDOW` caps `expiry - timestamp` at submission — a
+/// sanity cap against a wrong-scale signing pipeline, not a security
+/// boundary (see the constant's docs).
 ///
 /// `updatePrice` is PERMISSIONLESS — the global publisher's EIP-712
 /// signature is what authorises an update, not the caller. Replay
@@ -38,36 +63,50 @@ import {MessageHashUtils} from "@openzeppelin-contracts-5.6.1/utils/cryptography
 /// so the same signed price payload is valid on every deployment sharing
 /// the global signer. One publisher signature fans out to every chain the
 /// oracle is deployed on; that is a feature for multi-chain deployment, not
-/// an oversight. NOTE the precondition: because `pairId` binds the base and
-/// quote token ADDRESSES (`keccak256(abi.encodePacked(baseToken,
-/// quoteToken))`), a signature only replays to deployments where the pair's
-/// token addresses are IDENTICAL (e.g. deterministic CREATE2 addresses).
-/// Pairs whose token addresses differ per chain resolve to different
-/// `pairId`s and therefore require a per-chain signature; a publisher must
-/// not assume one signature covers a pair whose addresses vary by chain.
+/// an oversight. The signed `expiry` composes with this: the horizon is
+/// chain-agnostic wall-clock time, so a payload expires everywhere at the
+/// same instant. NOTE the precondition: because `pairId`
+/// binds the base and quote token ADDRESSES (`keccak256(abi.encodePacked(
+/// baseToken, quoteToken))`), a signature only replays to deployments where
+/// the pair's token addresses are IDENTICAL (e.g. deterministic CREATE2
+/// addresses). Pairs whose token addresses differ per chain resolve to
+/// different `pairId`s and therefore require a per-chain signature; a
+/// publisher must not assume one signature covers a pair whose addresses
+/// vary by chain.
 ///
 /// Roles:
 ///  - `DEFAULT_ADMIN_ROLE` — role administration only (granted to `admin`
 ///    at `initialize`).
-///  - `ORACLE_ADMIN_ROLE` — `setSigner` / `setTimeout`.
+///  - `ORACLE_ADMIN_ROLE` — `setSigner`.
 contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
-    /// @notice Role gating `setSigner` / `setTimeout` (rotation of the global
-    /// publisher key and the staleness bound). Granted to `oracleAdmin` at
-    /// `initialize`; distinct from `DEFAULT_ADMIN_ROLE`, which only administers
-    /// roles and cannot itself rotate signer/timeout.
+    /// @notice Role gating `setSigner` (rotation of the global publisher
+    /// key). Granted to `oracleAdmin` at `initialize`; distinct from
+    /// `DEFAULT_ADMIN_ROLE`, which only administers roles and cannot itself
+    /// rotate the signer.
     bytes32 public constant ORACLE_ADMIN_ROLE = keccak256("ORACLE_ADMIN");
 
-    /// @notice Upper bound on the global staleness `timeout`. A value larger
-    /// than this is a misconfiguration (e.g. a milliseconds figure) that would
-    /// silently disable staleness protection — reject it rather than let
-    /// `price()` serve arbitrarily old values.
-    uint64 public constant MAX_TIMEOUT = 30 days;
+    /// @notice Upper bound on a payload's validity window
+    /// (`expiry - timestamp`) at submission. A SANITY CAP against a
+    /// systematically wrong-scale signing pipeline (e.g. a milliseconds
+    /// expiry where seconds are meant, which would silently disable
+    /// staleness) — NOT a security
+    /// boundary: an individually fat-fingered expiry is already recoverable
+    /// by superseding it with a strictly-newer tight-window payload or by
+    /// rotating the signer, but a pipeline that scales every expiry wrong
+    /// defeats both recoveries, and this cap fails it closed at the first
+    /// submission. Generous by design so it never constrains legitimate
+    /// publisher window policy (a long weekend or market holiday is days,
+    /// not weeks).
+    uint256 public constant MAX_VALIDITY_WINDOW = 30 days;
 
-    /// @notice EIP-712 typehash binding (pairId, price, timestamp). No
-    /// nonce — replay protection is the strict timestamp inequality in
-    /// `updatePrice`.
+    /// @notice EIP-712 typehash binding (pairId, price, timestamp, expiry).
+    /// No nonce — replay protection is the strict timestamp inequality in
+    /// `updatePrice`; `expiry` is the publisher's signed validity horizon
+    /// for the price. Schema evolution is carried by this typehash — a
+    /// signature over any other field set produces a different struct hash
+    /// and cannot validate — so the domain version never needs bumping.
     bytes32 public constant PRICE_UPDATE_TYPEHASH =
-        keccak256("PriceUpdate(bytes32 pairId,uint256 price,uint256 timestamp)");
+        keccak256("PriceUpdate(bytes32 pairId,uint256 price,uint256 timestamp,uint256 expiry)");
 
     /// @dev The EIP-712 domain separator. The domain deliberately omits
     /// chainId and verifyingContract so a signed price replays across every
@@ -83,15 +122,14 @@ contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
     struct PricePoint {
         uint256 price;
         uint256 timestamp;
+        uint256 expiry;
     }
 
     /// @custom:storage-location erc7201:st0x.priceoracle.main
     struct MainStorage {
-        // ---- global configuration (setSigner / setTimeout) ----
+        // ---- global configuration (setSigner) ----
         // Publisher key whose ECDSA signature authorises every price update.
         address signer;
-        // Maximum allowed staleness on `price()` before it reverts.
-        uint64 timeout;
         // ---- per-pair price state (updatePrice) ----
         mapping(bytes32 pairId => PricePoint) prices;
     }
@@ -107,16 +145,25 @@ contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
 
     error ZeroAdmin();
     error ZeroSigner();
-    /// @dev Raised when a zero `timeout` is set — it would make `price()`
-    /// revert `PriceStale` for every reading past its own block, bricking the
-    /// oracle. Mirrors the DIA stack's `ZeroMaxAge`.
-    error ZeroTimeout();
-    /// @dev Raised when a `timeout` above `MAX_TIMEOUT` is set.
-    /// @param timeout The rejected timeout value.
-    error TimeoutTooLarge(uint64 timeout);
     error PriceUnset(bytes32 pairId);
-    error PriceStale(bytes32 pairId);
     error PriceFuture(bytes32 pairId);
+    /// @dev Raised in TWO places, one predicate (`expiry <= block.timestamp`,
+    /// the edge instant fails closed): at SUBMISSION for a payload whose
+    /// validity window has already closed — an expired payload is dead
+    /// permanently, no matter that its timestamp beats the stored one — and
+    /// at READ for a stored price past its publisher-signed horizon. The two
+    /// sites are disambiguated by which function reverted, so one selector
+    /// serves both.
+    /// @param pairId The pair whose payload or stored price has expired.
+    error PriceExpired(bytes32 pairId);
+    /// @dev Raised when a payload's validity window (`expiry - timestamp`)
+    /// exceeds `MAX_VALIDITY_WINDOW` — the wrong-scale-pipeline sanity cap
+    /// (see the constant's NatSpec for why this is belt-and-braces rather
+    /// than a security boundary).
+    /// @param pairId The pair whose payload carried the oversized window.
+    /// @param timestamp The payload's observation timestamp.
+    /// @param expiry The payload's rejected expiry.
+    error ValidityWindowTooLong(bytes32 pairId, uint256 timestamp, uint256 expiry);
     /// @dev Raised when a signed update carries a zero `price`. A zero is the
     /// uninitialized default of the signing pipeline and, if served, values a
     /// pair at nothing downstream (e.g. Morpho collateral priced at zero).
@@ -127,8 +174,7 @@ contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
     error PriceUpdateInvalidSignature(bytes32 pairId);
 
     event SignerSet(address indexed signer);
-    event TimeoutSet(uint64 timeout);
-    event PriceUpdated(bytes32 indexed pairId, uint256 price, uint256 timestamp);
+    event PriceUpdated(bytes32 indexed pairId, uint256 price, uint256 timestamp, uint256 expiry);
 
     constructor() {
         _disableInitializers();
@@ -136,59 +182,39 @@ contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
 
     /// @notice Initialise the singleton. `admin` receives
     /// `DEFAULT_ADMIN_ROLE` (role administration only) and `oracleAdmin`
-    /// receives `ORACLE_ADMIN_ROLE` (signer/timeout rotation) — both granted
+    /// receives `ORACLE_ADMIN_ROLE` (signer rotation) — both granted
     /// atomically so no post-deploy "remember to grant the role" step exists.
     /// A missing grant would leave `setSigner` uncallable, blocking an
     /// emergency key rotation behind the `DEFAULT_ADMIN` multisig while the
     /// compromised signer's permissionless payloads keep landing. The initial
-    /// global signer and timeout are set here and announced through the same
-    /// events the setters emit.
+    /// global signer is set here and announced through the same event the
+    /// setter emits.
     /// @param admin Receives `DEFAULT_ADMIN_ROLE`. Cannot be zero.
     /// @param oracleAdmin Receives `ORACLE_ADMIN_ROLE`. Cannot be zero (may be
     /// the same address as `admin` if a single multisig holds both).
     /// @param signer_ The initial global publisher key. Cannot be zero.
-    /// @param timeout_ The initial global staleness bound. `(0, MAX_TIMEOUT]`.
-    function initialize(address admin, address oracleAdmin, address signer_, uint64 timeout_) external initializer {
+    function initialize(address admin, address oracleAdmin, address signer_) external initializer {
         if (admin == address(0) || oracleAdmin == address(0)) revert ZeroAdmin();
         if (signer_ == address(0)) revert ZeroSigner();
-        _validateTimeout(timeout_);
         __AccessControl_init();
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
         _grantRole(ORACLE_ADMIN_ROLE, oracleAdmin);
 
-        MainStorage storage $ = _main();
-        $.signer = signer_;
-        $.timeout = timeout_;
+        _main().signer = signer_;
         emit SignerSet(signer_);
-        emit TimeoutSet(timeout_);
     }
 
     // ------------------------------------------------------------------ //
     //                        Global configuration                        //
     // ------------------------------------------------------------------ //
 
-    /// @notice Rotate the GLOBAL publisher key. Deliberately a separate
-    /// function from `setTimeout` so the two config axes can never race
-    /// each other inside one calldata blob.
+    /// @notice Rotate the GLOBAL publisher key. Rotation invalidates every
+    /// outstanding payload signed by the old key, including any still-live
+    /// validity windows.
     function setSigner(address newSigner) external onlyRole(ORACLE_ADMIN_ROLE) {
         if (newSigner == address(0)) revert ZeroSigner();
         _main().signer = newSigner;
         emit SignerSet(newSigner);
-    }
-
-    /// @notice Set the GLOBAL staleness bound applied by `price()`. Bounded to
-    /// `(0, MAX_TIMEOUT]` — zero bricks every read, and an over-large value
-    /// silently disables staleness.
-    function setTimeout(uint64 newTimeout) external onlyRole(ORACLE_ADMIN_ROLE) {
-        _validateTimeout(newTimeout);
-        _main().timeout = newTimeout;
-        emit TimeoutSet(newTimeout);
-    }
-
-    /// @dev Reverts `ZeroTimeout` / `TimeoutTooLarge` for out-of-range values.
-    function _validateTimeout(uint64 newTimeout) private pure {
-        if (newTimeout == 0) revert ZeroTimeout();
-        if (newTimeout > MAX_TIMEOUT) revert TimeoutTooLarge(newTimeout);
     }
 
     // ------------------------------------------------------------------ //
@@ -204,29 +230,38 @@ contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
 
     /// @notice Push a signed price for a pair. Open — anyone may submit;
     /// the global publisher's EIP-712 signature over
-    /// (pairId, price, timestamp) is what authorises. No registration is
-    /// required: the first update on a brand-new pair works as-is.
+    /// (pairId, price, timestamp, expiry) is what authorises. No
+    /// registration is required: the first update on a brand-new pair works
+    /// as-is.
     /// @return applied `true` if the update was strictly newer and was
     /// stored (a `PriceUpdated` event was emitted); `false` if the payload
     /// was not strictly newer than the stored timestamp — a deliberate
     /// NO-OP, so a lost update race can never revert a surrounding call. A
     /// strictly-newer payload timestamped in the FUTURE (`> block.timestamp`)
-    /// reverts `PriceFuture` — it would strand `price()` behind an arithmetic
-    /// underflow. A strictly-newer payload carrying a zero `price` reverts
-    /// `PriceZero`. The signature is verified before the future/zero content
-    /// checks, so an unauthenticated payload never reverts a content-check
-    /// selector. A payload whose signature RECOVERS to a non-signer address
-    /// reverts `PriceUpdateInvalidSignature`. A SYNTACTICALLY malformed
-    /// signature (wrong length, `s` in the upper half-order, `v` not in
-    /// {27,28}) reverts inside `ECDSA.recover` FIRST, with OpenZeppelin's own
+    /// reverts `PriceFuture`. A strictly-newer payload whose validity window
+    /// has already CLOSED (`expiry <= block.timestamp`) reverts
+    /// `PriceExpired` — an expired payload is permanently dead (see the
+    /// contract NatSpec, "Producer-controlled validity"). A window longer than
+    /// `MAX_VALIDITY_WINDOW` reverts `ValidityWindowTooLong`. A
+    /// strictly-newer payload carrying a zero `price` reverts `PriceZero`.
+    /// The signature is verified before the content checks, so an
+    /// unauthenticated payload never reverts a content-check selector. A
+    /// payload whose signature RECOVERS to a non-signer address reverts
+    /// `PriceUpdateInvalidSignature`. A SYNTACTICALLY malformed signature
+    /// (wrong length, `s` in the upper half-order, `v` not in {27,28})
+    /// reverts inside `ECDSA.recover` FIRST, with OpenZeppelin's own
     /// `ECDSAInvalidSignatureLength` / `ECDSAInvalidSignatureS` /
-    /// `ECDSAInvalidSignature` — so monitoring keyed on the revert selector must
-    /// treat those three as equivalent to `PriceUpdateInvalidSignature`. Every
-    /// path is fail-closed: no unsigned or malformed payload is ever applied.
-    function updatePrice(bytes32 id, uint256 newPrice, uint256 newTimestamp, bytes calldata signature)
-        external
-        returns (bool applied)
-    {
+    /// `ECDSAInvalidSignature` — so monitoring keyed on the revert selector
+    /// must treat those three as equivalent to
+    /// `PriceUpdateInvalidSignature`. Every path is fail-closed: no
+    /// unsigned, malformed or expired payload is ever applied.
+    function updatePrice(
+        bytes32 id,
+        uint256 newPrice,
+        uint256 newTimestamp,
+        uint256 newExpiry,
+        bytes calldata signature
+    ) external returns (bool applied) {
         MainStorage storage $ = _main();
         PricePoint storage stored = $.prices[id];
 
@@ -239,38 +274,58 @@ contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
         // Verify the publisher signature BEFORE any content validation of the
         // payload, so an unauthenticated payload always reverts
         // `PriceUpdateInvalidSignature` — never a content-check selector
-        // (`PriceFuture` / `PriceZero`) that would misreport an unsigned probe
-        // as an operator/clock fault to off-chain monitoring. The stale/no-op
+        // (`PriceFuture` / `PriceExpired` / `ValidityWindowTooLong` /
+        // `PriceZero`) that would misreport an unsigned probe as an
+        // operator/clock fault to off-chain monitoring. The stale/no-op
         // short-circuit above stays first: it is intentionally cheap and
         // signature-free so a lost update race can never brick a caller.
-        bytes32 structHash = keccak256(abi.encode(PRICE_UPDATE_TYPEHASH, id, newPrice, newTimestamp));
+        bytes32 structHash = keccak256(abi.encode(PRICE_UPDATE_TYPEHASH, id, newPrice, newTimestamp, newExpiry));
         if (ECDSA.recover(MessageHashUtils.toTypedDataHash(DOMAIN_SEPARATOR, structHash), signature) != $.signer) {
             revert PriceUpdateInvalidSignature(id);
         }
 
-        // A future timestamp is out-of-model input: `price()` computes
-        // `block.timestamp - stored.timestamp`, which would underflow (revert
-        // with an arithmetic panic) for any stored timestamp ahead of the
-        // block clock — stranding the pair for every consumer until wall-clock
-        // catches up, and blocking every honest lower-timestamped update in
-        // between. Reject it rather than admit an un-serveable price. Miner
-        // drift on block.timestamp only moves the accept/reject boundary by
-        // seconds and cannot forge a signature, so the comparison is safe.
+        // A future timestamp is out-of-model input: the payload claims an
+        // observation instant that hasn't happened yet. Reject it — a
+        // clock-skewed or buggy publisher signing `now + delta` is a
+        // realistic operational fault, and admitting it would let the pair's
+        // stored timestamp run ahead of wall-clock, blocking every honest
+        // update signed in between. Miner drift on block.timestamp only
+        // moves the accept/reject boundary by seconds and cannot forge a
+        // signature, so the comparison is safe.
         // slither-disable-next-line timestamp
         if (newTimestamp > block.timestamp) {
             revert PriceFuture(id);
         }
 
+        // A payload whose validity window has already closed is rejected
+        // outright — the publisher has disowned this price, and being
+        // strictly newer than the stored timestamp does not resurrect it.
+        // The edge instant fails closed: at `block.timestamp == expiry` the
+        // payload is expired. Same drift argument as above.
+        // slither-disable-next-line timestamp
+        if (newExpiry <= block.timestamp) {
+            revert PriceExpired(id);
+        }
+
+        // Sanity-cap the window. The two checks above guarantee
+        // `newTimestamp <= block.timestamp < newExpiry`, so the subtraction
+        // cannot underflow and a coherent (positive-length) window is
+        // already proven — only its SCALE is validated here.
+        if (newExpiry - newTimestamp > MAX_VALIDITY_WINDOW) {
+            revert ValidityWindowTooLong(id, newTimestamp, newExpiry);
+        }
+
         // A zero price is the uninitialized default of the signing pipeline;
         // serving it would value the pair at nothing downstream. Reject it,
-        // symmetric with the future-timestamp guard.
+        // symmetric with the other degenerate-value guards.
         if (newPrice == 0) {
             revert PriceZero(id);
         }
 
         stored.price = newPrice;
         stored.timestamp = newTimestamp;
-        emit PriceUpdated(id, newPrice, newTimestamp);
+        stored.expiry = newExpiry;
+        emit PriceUpdated(id, newPrice, newTimestamp, newExpiry);
         return true;
     }
 
@@ -279,17 +334,20 @@ contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
     // ------------------------------------------------------------------ //
 
     /// @notice The stored price for a pair. Reverts `PriceUnset` when no
-    /// update has ever landed (stored timestamp 0) and `PriceStale` when
-    /// the stored timestamp has aged past the global `timeout`. Value
-    /// semantics are the publisher's — this contract treats them as opaque.
+    /// update has ever landed (stored timestamp 0) and `PriceExpired` once
+    /// `block.timestamp` reaches the stored payload's publisher-signed
+    /// `expiry` (the edge instant fails closed — a price is dead AT its
+    /// expiry). There is no other staleness bound: the producer's signed
+    /// horizon is the staleness bound. Value semantics are the publisher's —
+    /// this contract treats them as opaque.
     function price(bytes32 id) external view returns (uint256) {
         MainStorage storage $ = _main();
         PricePoint storage stored = $.prices[id];
         if (stored.timestamp == 0) revert PriceUnset(id);
-        // Staleness is measured against block time by design — miner drift
-        // is seconds against a timeout measured in minutes/hours.
+        // Expiry is measured against block time by design — miner drift is
+        // seconds against validity windows measured in minutes/hours.
         // slither-disable-next-line timestamp
-        if (block.timestamp - stored.timestamp > $.timeout) revert PriceStale(id);
+        if (block.timestamp >= stored.expiry) revert PriceExpired(id);
         return stored.price;
     }
 
@@ -298,16 +356,18 @@ contract ST0xPriceOracle is Initializable, AccessControlUpgradeable {
         return _main().signer;
     }
 
-    /// @notice The global staleness bound applied by `price()`.
-    function timeout() external view returns (uint64) {
-        return _main().timeout;
-    }
-
-    /// @notice Raw stored price state (no staleness check) — for publishers
-    /// sizing their next timestamp and for off-chain monitoring.
-    function pairPrice(bytes32 id) external view returns (uint256 storedPrice, uint256 storedTimestamp) {
+    /// @notice Raw stored price state (no expiry check) — for publishers
+    /// sizing their next timestamp and for off-chain monitoring. Consumers
+    /// of this RAW view that serve prices onward MUST apply the expiry
+    /// themselves (`block.timestamp < storedExpiry`, fail closed), exactly
+    /// as `price()` does.
+    function pairPrice(bytes32 id)
+        external
+        view
+        returns (uint256 storedPrice, uint256 storedTimestamp, uint256 storedExpiry)
+    {
         PricePoint storage stored = _main().prices[id];
-        return (stored.price, stored.timestamp);
+        return (stored.price, stored.timestamp, stored.expiry);
     }
 
     /// @notice EIP-712 domain separator — used by publishers / tests. A

--- a/test/src/concrete/adapter/MorphoPairAdapter.t.sol
+++ b/test/src/concrete/adapter/MorphoPairAdapter.t.sol
@@ -24,12 +24,11 @@ import {MockERC20Decimals} from "../../../mocks/MockERC20Decimals.sol";
 /// @title MorphoPairAdapterTest
 /// @notice Unit coverage for the `MorphoPairAdapter` beacon-proxied adapter:
 /// the publisher-scale → Morpho-convention rescale (known-answer), central
-/// staleness/unset passthrough, constructor / initializer guards, and the
+/// expiry/unset passthrough, constructor / initializer guards, and the
 /// shared beacon upgrade retargeting every deployed adapter proxy at once.
 contract MorphoPairAdapterTest is SignedPriceTestBase {
     // SIGNER_PK / SIGNER are inherited from SignedPriceTestBase.
     address constant ADMIN = address(0xC0DE);
-    uint64 constant TIMEOUT = 1 hours;
 
     // base = Morpho collateral (18 dec), quote = Morpho loan (6 dec, USDC-like).
     MockERC20Decimals base;
@@ -45,9 +44,7 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
         UpgradeableBeacon beacon = new UpgradeableBeacon(address(impl), ADMIN);
         oracle = ST0xPriceOracle(
             address(
-                new BeaconProxy(
-                    address(beacon), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ADMIN, SIGNER, TIMEOUT))
-                )
+                new BeaconProxy(address(beacon), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ADMIN, SIGNER)))
             )
         );
 
@@ -85,8 +82,10 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
         assertEq(adapter.price(), 1e36, "1.0 at equal decimals is bare 1e36");
     }
 
-    /// @notice Central staleness / unset reverts pass straight through the
-    /// rescale — the adapter never masks them.
+    /// @notice Central expiry / unset reverts pass straight through the
+    /// rescale — the adapter never masks them. The adapter needs no staleness
+    /// logic of its own: it calls `price()`, which refuses a stored price at
+    /// its publisher-signed expiry, and the revert bubbles to Morpho.
     function test_MorphoPairAdapter_CentralRevertsPassThrough() public {
         MorphoPairAdapter adapter = _deployAdapter(address(base), address(quote));
 
@@ -94,8 +93,8 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
         adapter.price();
 
         _push(PAIR_A, 42e18, block.timestamp);
-        vm.warp(block.timestamp + TIMEOUT + 1);
-        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceStale.selector, PAIR_A));
+        vm.warp(block.timestamp + DEFAULT_VALIDITY);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceExpired.selector, PAIR_A));
         adapter.price();
     }
 

--- a/test/src/concrete/deploy/DeployerSaltDerivation.t.sol
+++ b/test/src/concrete/deploy/DeployerSaltDerivation.t.sol
@@ -30,7 +30,6 @@ contract DeployerSaltDerivationTest is Test {
     address internal constant ADMIN = address(0xC0DE);
     address internal constant ORACLE_ADMIN = address(0xADDD);
     address internal constant SIGNER = address(0x516E);
-    uint64 internal constant TIMEOUT = 1 hours;
 
     function setUp() public {
         vm.warp(1_000_000);
@@ -57,9 +56,7 @@ contract DeployerSaltDerivationTest is Test {
             UpgradeableBeacon beacon = new UpgradeableBeacon(address(impl), ADMIN);
             central = ST0xPriceOracle(
                 address(
-                    new BeaconProxy(
-                        address(beacon), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ADMIN, SIGNER, TIMEOUT))
-                    )
+                    new BeaconProxy(address(beacon), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ADMIN, SIGNER)))
                 )
             );
         }
@@ -82,8 +79,8 @@ contract DeployerSaltDerivationTest is Test {
         assertEq(address(adapter), predicted, "Morpho proxy must land at keccak256(base,quote) CREATE2 address");
     }
 
-    /// @notice ST0x salt MUST be keccak256(abi.encode(admin, oracleAdmin, signer,
-    /// timeout)). If the deployer drops any arg (e.g. timeout) from the salt, the
+    /// @notice ST0x salt MUST be keccak256(abi.encode(admin, oracleAdmin,
+    /// signer)). If the deployer drops any arg (e.g. signer) from the salt, the
     /// deployed address will not match this independent prediction.
     function testST0xSaltIsKeccakAllArgs() external {
         ST0xPriceOracle implementation = new ST0xPriceOracle();
@@ -93,15 +90,15 @@ contract DeployerSaltDerivationTest is Test {
             })
         );
 
-        bytes32 expectedSalt = keccak256(abi.encode(ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT));
+        bytes32 expectedSalt = keccak256(abi.encode(ADMIN, ORACLE_ADMIN, SIGNER));
         address predicted = _predict(
             address(bsd),
             expectedSalt,
             address(bsd.iST0xPriceOracleBeacon()),
-            abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT))
+            abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, SIGNER))
         );
 
-        ST0xPriceOracle oracle = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT);
+        ST0xPriceOracle oracle = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER);
         assertEq(address(oracle), predicted, "ST0x proxy must land at keccak256(all-args) CREATE2 address");
     }
 }

--- a/test/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.t.sol
@@ -20,7 +20,6 @@ contract MorphoPairAdapterBeaconSetDeployerTest is SignedPriceTestBase {
     // SIGNER_PK / SIGNER are inherited from SignedPriceTestBase.
     address internal constant BEACON_OWNER = address(0xBEEF);
     address internal constant ADMIN = address(0xC0DE);
-    uint64 internal constant TIMEOUT = 1 hours;
 
     ST0xPriceOracle internal central;
     MockERC20Decimals internal base;
@@ -36,9 +35,7 @@ contract MorphoPairAdapterBeaconSetDeployerTest is SignedPriceTestBase {
         UpgradeableBeacon beacon = new UpgradeableBeacon(address(impl), ADMIN);
         central = ST0xPriceOracle(
             address(
-                new BeaconProxy(
-                    address(beacon), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ADMIN, SIGNER, TIMEOUT))
-                )
+                new BeaconProxy(address(beacon), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ADMIN, SIGNER)))
             )
         );
 

--- a/test/src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.t.sol
@@ -22,7 +22,9 @@ contract ST0xPriceOracleBeaconSetDeployerTest is Test {
     address internal constant ORACLE_ADMIN = address(0xADDD);
     uint256 internal constant SIGNER_PK = uint256(keccak256("st0x.price-oracle.signer.test"));
     address internal SIGNER;
-    uint64 internal constant TIMEOUT = 1 hours;
+    /// @dev A second distinct signer — the differing-config axis for the
+    /// CREATE2 divergence tests below (initialize only requires non-zero).
+    address internal constant SIGNER_B = address(0x51B2);
 
     event Deployment(address indexed caller, address indexed oracle);
 
@@ -70,14 +72,13 @@ contract ST0xPriceOracleBeaconSetDeployerTest is Test {
 
     // -------- newST0xPriceOracle --------
 
-    /// @notice The proxy is initialized inside its constructor: signer, timeout,
-    /// and both role grants are live immediately after mint.
+    /// @notice The proxy is initialized inside its constructor: signer and
+    /// both role grants are live immediately after mint.
     function testNewST0xPriceOracleInitializesState() external {
         ST0xPriceOracleBeaconSetDeployer bsd = _deployBSD();
-        ST0xPriceOracle oracle = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT);
+        ST0xPriceOracle oracle = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER);
 
         assertEq(oracle.signer(), SIGNER, "signer set");
-        assertEq(oracle.timeout(), TIMEOUT, "timeout set");
         assertTrue(oracle.hasRole(oracle.DEFAULT_ADMIN_ROLE(), ADMIN), "admin has default admin role");
         assertTrue(oracle.hasRole(oracle.ORACLE_ADMIN_ROLE(), ORACLE_ADMIN), "oracle admin has oracle admin role");
     }
@@ -87,11 +88,11 @@ contract ST0xPriceOracleBeaconSetDeployerTest is Test {
     /// divergent oracle. Differing args land at a different address.
     function testNewST0xPriceOracleIsIdempotentPerConfig() external {
         ST0xPriceOracleBeaconSetDeployer bsd = _deployBSD();
-        ST0xPriceOracle first = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT);
+        ST0xPriceOracle first = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER);
 
         // Same args → CREATE2 collision → revert (empty returndata).
         vm.expectRevert();
-        bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT);
+        bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER);
 
         // The bare vm.expectRevert above is intentional: a raw CREATE2 address
         // collision carries no selector. Prove it WAS the collision (not an
@@ -101,7 +102,7 @@ contract ST0xPriceOracleBeaconSetDeployerTest is Test {
         assertEq(first.signer(), SIGNER, "first instance config intact after the collision");
 
         // Differing args → different deterministic address.
-        ST0xPriceOracle second = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT + 1);
+        ST0xPriceOracle second = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER_B);
         assertTrue(address(first) != address(second), "distinct args give distinct address");
     }
 
@@ -109,7 +110,7 @@ contract ST0xPriceOracleBeaconSetDeployerTest is Test {
         ST0xPriceOracleBeaconSetDeployer bsd = _deployBSD();
 
         vm.recordLogs();
-        ST0xPriceOracle oracle = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT);
+        ST0xPriceOracle oracle = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER);
 
         Vm.Log[] memory entries = vm.getRecordedLogs();
         bytes32 sig = keccak256("Deployment(address,address)");
@@ -131,7 +132,7 @@ contract ST0xPriceOracleBeaconSetDeployerTest is Test {
     function testNewST0xPriceOraclePropagatesInitRevertZeroSigner() external {
         ST0xPriceOracleBeaconSetDeployer bsd = _deployBSD();
         vm.expectRevert(ST0xPriceOracle.ZeroSigner.selector);
-        bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, address(0), TIMEOUT);
+        bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, address(0));
     }
 
     /// @notice The beacon is genuinely SHARED: deploy two singletons with
@@ -141,8 +142,8 @@ contract ST0xPriceOracleBeaconSetDeployerTest is Test {
     function testMultipleProxiesShareBeacon() external {
         ST0xPriceOracleBeaconSetDeployer bsd = _deployBSD();
 
-        ST0xPriceOracle a = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT);
-        ST0xPriceOracle b = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT + 1);
+        ST0xPriceOracle a = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER);
+        ST0xPriceOracle b = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER_B);
         assertTrue(address(a) != address(b), "proxies must be distinct");
 
         address beacon = address(bsd.iST0xPriceOracleBeacon());
@@ -163,7 +164,7 @@ contract ST0xPriceOracleBeaconSetDeployerTest is Test {
         assertEq(ST0xPriceOracleV2(address(b)).implVersion(), 2, "proxy b retargeted");
 
         // Each proxy retains its OWN distinct config across the upgrade.
-        assertEq(a.timeout(), TIMEOUT, "proxy a keeps its own timeout");
-        assertEq(b.timeout(), TIMEOUT + 1, "proxy b keeps its own timeout");
+        assertEq(a.signer(), SIGNER, "proxy a keeps its own signer");
+        assertEq(b.signer(), SIGNER_B, "proxy b keeps its own signer");
     }
 }

--- a/test/src/concrete/oracle/ST0xPriceOracle.t.sol
+++ b/test/src/concrete/oracle/ST0xPriceOracle.t.sol
@@ -13,19 +13,21 @@ import {ST0xPriceOracle} from "../../../../src/concrete/oracle/ST0xPriceOracle.s
 import {ECDSA} from "@openzeppelin-contracts-5.6.1/utils/cryptography/ECDSA.sol";
 
 /// @title ST0xPriceOracleTest
-/// @notice Unit coverage for the central multi-pair oracle: global signer /
-/// timeout config, the strict-timestamp no-op-vs-revert semantics of
-/// `updatePrice` (no registration, no nonce), `price()` unset/staleness
-/// reverts, and the deterministic `pairId` derivation.
+/// @notice Unit coverage for the central multi-pair oracle: global signer
+/// config, the strict-timestamp no-op-vs-revert semantics of `updatePrice`
+/// (no registration, no nonce), the publisher-signed expiry (submission-time
+/// rejection of dead payloads, read-time refusal of expired stored prices,
+/// the validity-window sanity cap), and the deterministic `pairId`
+/// derivation.
 contract ST0xPriceOracleTest is SignedPriceTestBase {
-    // SIGNER_PK / SIGNER are inherited from SignedPriceTestBase.
+    // SIGNER_PK / SIGNER / DEFAULT_VALIDITY are inherited from
+    // SignedPriceTestBase.
     address constant ADMIN = address(0xC0DE);
     address constant ORACLE_ADMIN = address(0xADDD);
     address constant RANDO = address(0xF00D);
 
     address constant BASE_TOKEN = address(0xAAA1);
     address constant QUOTE_TOKEN = address(0xBBB2);
-    uint64 constant TIMEOUT = 1 hours;
 
     bytes32 PAIR_A;
     bytes32 constant PAIR_UNKNOWN = keccak256("pair-unknown");
@@ -40,7 +42,7 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         oracle = ST0xPriceOracle(
             address(
                 new BeaconProxy(
-                    address(beacon), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT))
+                    address(beacon), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, SIGNER))
                 )
             )
         );
@@ -69,106 +71,57 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     function test_Initialize_SetsGlobalsAndEmits() public {
         ST0xPriceOracle impl = new ST0xPriceOracle();
         UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
-        // Initial values arrive as initialize params but are announced
-        // through the same events the setters emit.
+        // The initial signer arrives as an initialize param but is announced
+        // through the same event the setter emits.
         vm.expectEmit();
         emit ST0xPriceOracle.SignerSet(SIGNER);
-        vm.expectEmit();
-        emit ST0xPriceOracle.TimeoutSet(TIMEOUT);
         ST0xPriceOracle fresh = ST0xPriceOracle(
             address(
-                new BeaconProxy(
-                    address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT))
-                )
+                new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, SIGNER)))
             )
         );
         assertEq(fresh.signer(), SIGNER, "global signer set");
-        assertEq(fresh.timeout(), TIMEOUT, "global timeout set");
     }
 
     /// @notice Both roles are granted atomically at initialize — no separate
-    /// grant step. ORACLE_ADMIN can rotate config immediately; DEFAULT_ADMIN
-    /// cannot (rotation authority is not implicitly the role admin).
+    /// grant step. ORACLE_ADMIN can rotate the signer immediately;
+    /// DEFAULT_ADMIN cannot (rotation authority is not implicitly the role
+    /// admin).
     function test_Initialize_GrantsBothRolesAtomically() public {
         assertTrue(oracle.hasRole(oracle.DEFAULT_ADMIN_ROLE(), ADMIN), "admin has DEFAULT_ADMIN_ROLE");
         assertTrue(oracle.hasRole(oracle.ORACLE_ADMIN_ROLE(), ORACLE_ADMIN), "oracleAdmin has ORACLE_ADMIN_ROLE");
         assertFalse(oracle.hasRole(oracle.ORACLE_ADMIN_ROLE(), ADMIN), "default admin is not implicitly oracle admin");
         // ORACLE_ADMIN can rotate immediately, with no prior grant tx.
+        address rotated = vm.addr(uint256(keccak256("rotated-at-init-test")));
         vm.prank(ORACLE_ADMIN);
-        oracle.setTimeout(2 hours);
-        assertEq(oracle.timeout(), 2 hours, "oracle admin rotates config at once");
+        oracle.setSigner(rotated);
+        assertEq(oracle.signer(), rotated, "oracle admin rotates config at once");
     }
 
     function test_Initialize_ZeroAdmin_Reverts() public {
         ST0xPriceOracle impl = new ST0xPriceOracle();
         UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
         vm.expectRevert(ST0xPriceOracle.ZeroAdmin.selector);
-        new BeaconProxy(
-            address(b), abi.encodeCall(ST0xPriceOracle.initialize, (address(0), ORACLE_ADMIN, SIGNER, TIMEOUT))
-        );
+        new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (address(0), ORACLE_ADMIN, SIGNER)));
     }
 
     function test_Initialize_ZeroOracleAdmin_Reverts() public {
         ST0xPriceOracle impl = new ST0xPriceOracle();
         UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
         vm.expectRevert(ST0xPriceOracle.ZeroAdmin.selector);
-        new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, address(0), SIGNER, TIMEOUT)));
+        new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, address(0), SIGNER)));
     }
 
     function test_Initialize_ZeroSigner_Reverts() public {
         ST0xPriceOracle impl = new ST0xPriceOracle();
         UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
         vm.expectRevert(ST0xPriceOracle.ZeroSigner.selector);
-        new BeaconProxy(
-            address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, address(0), TIMEOUT))
-        );
-    }
-
-    function test_Initialize_ZeroTimeout_Reverts() public {
-        ST0xPriceOracle impl = new ST0xPriceOracle();
-        UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
-        vm.expectRevert(ST0xPriceOracle.ZeroTimeout.selector);
-        new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, SIGNER, 0)));
-    }
-
-    function test_Initialize_TimeoutTooLarge_Reverts() public {
-        ST0xPriceOracle impl = new ST0xPriceOracle();
-        UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
-        uint64 tooLarge = oracle.MAX_TIMEOUT() + 1;
-        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.TimeoutTooLarge.selector, tooLarge));
-        new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, SIGNER, tooLarge)));
-    }
-
-    function test_Initialize_TimeoutAtMax_Ok() public {
-        ST0xPriceOracle impl = new ST0xPriceOracle();
-        UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
-        uint64 atMax = impl.MAX_TIMEOUT();
-        ST0xPriceOracle fresh = ST0xPriceOracle(
-            address(
-                new BeaconProxy(
-                    address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, SIGNER, atMax))
-                )
-            )
-        );
-        assertEq(fresh.timeout(), atMax, "timeout at MAX_TIMEOUT is accepted");
-    }
-
-    function test_SetTimeout_Zero_Reverts() public {
-        vm.prank(ORACLE_ADMIN);
-        vm.expectRevert(ST0xPriceOracle.ZeroTimeout.selector);
-        oracle.setTimeout(0);
-    }
-
-    function test_SetTimeout_TooLarge_Reverts() public {
-        uint64 tooLarge = oracle.MAX_TIMEOUT() + 1;
-        vm.prank(ORACLE_ADMIN);
-        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.TimeoutTooLarge.selector, tooLarge));
-        oracle.setTimeout(tooLarge);
+        new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, address(0))));
     }
 
     function test_Initialize_OnlyOnce() public {
         vm.expectRevert(Initializable.InvalidInitialization.selector);
-        oracle.initialize(RANDO, ORACLE_ADMIN, SIGNER, TIMEOUT);
+        oracle.initialize(RANDO, ORACLE_ADMIN, SIGNER);
     }
 
     /// @notice The IMPLEMENTATION behind the beacon must be un-initialisable:
@@ -184,7 +137,7 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     function test_ImplementationInitializersDisabled() public {
         ST0xPriceOracle impl = new ST0xPriceOracle();
         vm.expectRevert(Initializable.InvalidInitialization.selector);
-        impl.initialize(ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT);
+        impl.initialize(ADMIN, ORACLE_ADMIN, SIGNER);
     }
 
     // -------- updatePrice: applied vs no-op vs revert --------
@@ -193,16 +146,22 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     /// brand-new pair just works (stored timestamp starts at 0 and any real
     /// timestamp is strictly newer).
     function test_UpdatePrice_FirstUpdateOnBrandNewPair_AppliesAndEmits() public {
+        uint256 expiry = block.timestamp + DEFAULT_VALIDITY;
         vm.expectEmit(true, false, false, true, address(oracle));
-        emit ST0xPriceOracle.PriceUpdated(PAIR_A, 42e18, block.timestamp);
+        emit ST0xPriceOracle.PriceUpdated(PAIR_A, 42e18, block.timestamp, expiry);
         bool applied = oracle.updatePrice(
-            PAIR_A, 42e18, block.timestamp, signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, block.timestamp)
+            PAIR_A,
+            42e18,
+            block.timestamp,
+            expiry,
+            signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, block.timestamp, expiry)
         );
         assertTrue(applied, "fresh update should apply");
 
-        (uint256 storedPrice, uint256 storedTs) = oracle.pairPrice(PAIR_A);
+        (uint256 storedPrice, uint256 storedTs, uint256 storedExpiry) = oracle.pairPrice(PAIR_A);
         assertEq(storedPrice, 42e18, "price stored");
         assertEq(storedTs, block.timestamp, "timestamp stored");
+        assertEq(storedExpiry, expiry, "expiry stored");
         assertEq(oracle.price(PAIR_A), 42e18, "price() serves stored value");
     }
 
@@ -210,14 +169,15 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     /// not a revert: no state change, no event, even with a garbage
     /// signature (freshness is checked before the signature).
     function test_UpdatePrice_EqualTimestamp_NoOpNotRevert() public {
+        uint256 expiry = block.timestamp + DEFAULT_VALIDITY;
         _push(PAIR_A, 42e18, block.timestamp);
 
         vm.recordLogs();
-        bool applied = oracle.updatePrice(PAIR_A, 99e18, block.timestamp, hex"deadbeef");
+        bool applied = oracle.updatePrice(PAIR_A, 99e18, block.timestamp, expiry, hex"deadbeef");
         assertFalse(applied, "equal timestamp must be a no-op");
         assertEq(vm.getRecordedLogs().length, 0, "no event on a no-op");
 
-        (uint256 storedPrice, uint256 storedTs) = oracle.pairPrice(PAIR_A);
+        (uint256 storedPrice, uint256 storedTs,) = oracle.pairPrice(PAIR_A);
         assertEq(storedPrice, 42e18, "price unchanged");
         assertEq(storedTs, block.timestamp, "timestamp unchanged");
     }
@@ -228,11 +188,12 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         _push(PAIR_A, 42e18, block.timestamp);
 
         vm.recordLogs();
-        bool applied = oracle.updatePrice(PAIR_A, 99e18, block.timestamp - 50, hex"deadbeef");
+        bool applied =
+            oracle.updatePrice(PAIR_A, 99e18, block.timestamp - 50, block.timestamp + DEFAULT_VALIDITY, hex"deadbeef");
         assertFalse(applied, "older timestamp must be a no-op");
         assertEq(vm.getRecordedLogs().length, 0, "no event on a no-op");
 
-        (uint256 storedPrice, uint256 storedTs) = oracle.pairPrice(PAIR_A);
+        (uint256 storedPrice, uint256 storedTs,) = oracle.pairPrice(PAIR_A);
         assertEq(storedPrice, 42e18, "price unchanged");
         assertEq(storedTs, block.timestamp, "timestamp unchanged");
     }
@@ -241,13 +202,13 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     /// a strictly-newer payload is malformed input — that DOES revert.
     function test_UpdatePrice_InvalidSignatureOnFreshTimestamp_Reverts() public {
         uint256 wrongPk = uint256(keccak256("wrong-signer"));
-        bytes32 digest = digestFor(oracle, PAIR_A, 42e18, block.timestamp);
+        uint256 expiry = block.timestamp + DEFAULT_VALIDITY;
+        bytes32 digest = digestFor(oracle, PAIR_A, 42e18, block.timestamp, expiry);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, digest);
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUpdateInvalidSignature.selector, PAIR_A));
-        oracle.updatePrice(PAIR_A, 42e18, block.timestamp, abi.encodePacked(r, s, v));
+        oracle.updatePrice(PAIR_A, 42e18, block.timestamp, expiry, abi.encodePacked(r, s, v));
     }
 
-    /// @notice `updatePrice` is permissionless — any caller with a validly
     /// @notice A syntactically malformed (wrong-length) signature on a strictly-
     /// newer payload reverts INSIDE `ECDSA.recover` with OpenZeppelin's own
     /// `ECDSAInvalidSignatureLength` — the documented fail-closed path (the
@@ -261,27 +222,31 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     function test_UpdatePrice_MalformedSignatureOnFreshTimestamp_RevertsInEcdsa() public {
         bytes memory malformed = hex"deadbeef"; // 4 bytes, not 65
         vm.expectRevert(abi.encodeWithSelector(ECDSA.ECDSAInvalidSignatureLength.selector, uint256(4)));
-        oracle.updatePrice(PAIR_A, 42e18, block.timestamp, malformed);
+        oracle.updatePrice(PAIR_A, 42e18, block.timestamp, block.timestamp + DEFAULT_VALIDITY, malformed);
         // Nothing stored — price() reverts the normal unset revert, not a panic.
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUnset.selector, PAIR_A));
         oracle.price(PAIR_A);
     }
 
+    /// @notice `updatePrice` is permissionless — any caller with a validly
     /// signed fresh payload succeeds.
     function test_UpdatePrice_Permissionless() public {
-        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, block.timestamp);
+        uint256 expiry = block.timestamp + DEFAULT_VALIDITY;
+        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, block.timestamp, expiry);
         vm.prank(RANDO);
-        assertTrue(oracle.updatePrice(PAIR_A, 42e18, block.timestamp, sig), "rando can push a signed price");
+        assertTrue(oracle.updatePrice(PAIR_A, 42e18, block.timestamp, expiry, sig), "rando can push a signed price");
     }
 
     /// @notice DELIBERATE PROPERTY: with no nonce and an EIP-712 domain
     /// that binds name + version only (no chainId, no verifyingContract),
     /// the exact same signed payload applies on a different chain and a
     /// different oracle deployment — one publisher signature fans out to a
-    /// multi-chain deployment.
+    /// multi-chain deployment. The signed expiry composes unchanged: the
+    /// horizon is wall-clock time, chain-agnostic.
     function test_UpdatePrice_CrossChainReplay_SameSignatureAppliesOnOtherDeployment() public {
-        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, block.timestamp);
-        assertTrue(oracle.updatePrice(PAIR_A, 42e18, block.timestamp, sig), "applies on the home chain");
+        uint256 expiry = block.timestamp + DEFAULT_VALIDITY;
+        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, block.timestamp, expiry);
+        assertTrue(oracle.updatePrice(PAIR_A, 42e18, block.timestamp, expiry, sig), "applies on the home chain");
 
         // A second deployment (fresh proxy → different verifyingContract)
         // on a different chainId, sharing the global signer.
@@ -290,34 +255,129 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
         ST0xPriceOracle other = ST0xPriceOracle(
             address(
-                new BeaconProxy(
-                    address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, SIGNER, TIMEOUT))
-                )
+                new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, SIGNER)))
             )
         );
-        assertTrue(other.updatePrice(PAIR_A, 42e18, block.timestamp, sig), "same signature replays cross-chain");
+        assertTrue(other.updatePrice(PAIR_A, 42e18, block.timestamp, expiry, sig), "same signature replays cross-chain");
         assertEq(other.price(PAIR_A), 42e18, "replayed price served");
     }
 
     /// @notice A payload timestamped in the FUTURE (ahead of block.timestamp)
-    /// must be rejected. Accepting it strands the pair: `price()` computes
-    /// `block.timestamp - stored.timestamp`, which underflows (arithmetic
-    /// panic) for a future stored timestamp — bricking every consumer read
-    /// until wall-clock catches up, and blocking every honest
-    /// lower-timestamped update in the meantime. The signer is trusted, but
-    /// a clock-skewed / buggy publisher signing `now + delta` is a realistic
-    /// operational fault, so the contract must reject it rather than admit
-    /// an un-serveable price.
+    /// must be rejected: it claims an observation instant that hasn't
+    /// happened yet, and admitting it would let the pair's stored timestamp
+    /// run ahead of wall-clock, blocking every honest lower-timestamped
+    /// update in the meantime. The signer is trusted, but a clock-skewed /
+    /// buggy publisher signing `now + delta` is a realistic operational
+    /// fault, so the contract must reject it rather than admit it.
     function test_UpdatePrice_FutureTimestamp_Rejected() public {
         uint256 future = block.timestamp + 1 hours;
-        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, future);
+        uint256 expiry = future + DEFAULT_VALIDITY;
+        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, future, expiry);
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceFuture.selector, PAIR_A));
-        oracle.updatePrice(PAIR_A, 42e18, future, sig);
+        oracle.updatePrice(PAIR_A, 42e18, future, expiry, sig);
 
         // The pair stays unset — nothing was stored, so price() reverts the
         // normal unset revert (NOT an arithmetic panic).
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUnset.selector, PAIR_A));
         oracle.price(PAIR_A);
+    }
+
+    /// @notice A payload whose validity window has
+    /// already closed is rejected at SUBMISSION, no matter that its
+    /// timestamp is strictly newer than the stored one. This is what stops
+    /// a submitter holding a set of genuine publisher signatures from
+    /// resurrecting whichever historical extremum suits them (install the
+    /// old low to force a liquidation, the old high to over-borrow): once a
+    /// payload's window passes, it is permanently dead for every deployment.
+    function test_UpdatePrice_ExpiredPayload_RevertsEvenThoughStrictlyNewer() public {
+        // Anchor a stored price, then let time pass beyond a later payload's
+        // whole validity window.
+        _push(PAIR_A, 42e18, block.timestamp);
+
+        uint256 attackTs = block.timestamp + 10;
+        uint256 attackExpiry = attackTs + 60;
+        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 13e18, attackTs, attackExpiry);
+
+        // The window closes; the payload dies with it.
+        vm.warp(attackExpiry + 1 hours);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceExpired.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 13e18, attackTs, attackExpiry, sig);
+
+        // Stored state untouched by the rejected resurrection.
+        (uint256 storedPrice,,) = oracle.pairPrice(PAIR_A);
+        assertEq(storedPrice, 42e18, "stored price untouched");
+    }
+
+    /// @notice The submission expiry edge fails CLOSED: a payload whose
+    /// expiry equals `block.timestamp` is already dead; one second of
+    /// remaining validity is accepted (and immediately servable).
+    function test_UpdatePrice_ExpiryBoundary_FailsClosedAtTheEdge() public {
+        uint256 ts = block.timestamp;
+
+        uint256 deadExpiry = block.timestamp;
+        bytes memory deadSig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, ts, deadExpiry);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceExpired.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 42e18, ts, deadExpiry, deadSig);
+
+        uint256 liveExpiry = block.timestamp + 1;
+        bytes memory liveSig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, ts, liveExpiry);
+        assertTrue(oracle.updatePrice(PAIR_A, 42e18, ts, liveExpiry, liveSig), "one second of validity is accepted");
+        assertEq(oracle.price(PAIR_A), 42e18, "and immediately servable");
+    }
+
+    /// @notice A validity window longer than `MAX_VALIDITY_WINDOW` is
+    /// rejected — the wrong-scale-pipeline sanity cap. Exactly at the cap is
+    /// accepted (the cap is generous by design; it exists to catch a
+    /// milliseconds-for-seconds scale error, not to constrain publisher
+    /// window policy).
+    function test_UpdatePrice_ValidityWindowCap_RejectsAboveAcceptsAt() public {
+        uint256 ts = block.timestamp;
+
+        uint256 tooLong = ts + oracle.MAX_VALIDITY_WINDOW() + 1;
+        bytes memory longSig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, ts, tooLong);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.ValidityWindowTooLong.selector, PAIR_A, ts, tooLong));
+        oracle.updatePrice(PAIR_A, 42e18, ts, tooLong, longSig);
+
+        uint256 atCap = ts + oracle.MAX_VALIDITY_WINDOW();
+        bytes memory capSig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, ts, atCap);
+        assertTrue(oracle.updatePrice(PAIR_A, 42e18, ts, atCap, capSig), "window exactly at the cap is accepted");
+    }
+
+    /// @notice RECOVERY PATH (documented in the contract NatSpec): a
+    /// strictly-newer payload with a TIGHTER window supersedes a stored
+    /// long-window price. After the tight expiry passes, reads fail closed
+    /// even though the superseded payload's window would still have been
+    /// live — the publisher's newest word is what binds.
+    function test_UpdatePrice_SupersedingPayloadShrinksWindow() public {
+        // A (fat-fingered) long-window price.
+        uint256 longExpiry = block.timestamp + 30 days;
+        _push(PAIR_A, 42e18, block.timestamp, longExpiry);
+
+        // The corrective: strictly newer, tight window.
+        vm.warp(block.timestamp + 10);
+        uint256 tightExpiry = block.timestamp + 60;
+        _push(PAIR_A, 43e18, block.timestamp, tightExpiry);
+
+        // Inside the tight window: served.
+        assertEq(oracle.price(PAIR_A), 43e18, "corrective price served");
+
+        // Past the tight window but well inside the superseded long one:
+        // dead. The long window no longer exists on-chain.
+        vm.warp(tightExpiry);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceExpired.selector, PAIR_A));
+        oracle.price(PAIR_A);
+    }
+
+    /// @notice The signature BINDS the expiry: submitting a signed payload
+    /// with any other expiry (e.g. stretching the window) recovers a
+    /// different address and reverts `PriceUpdateInvalidSignature`.
+    function test_UpdatePrice_SignatureBindsExpiry() public {
+        uint256 ts = block.timestamp;
+        uint256 signedExpiry = ts + 60;
+        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, ts, signedExpiry);
+
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUpdateInvalidSignature.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 42e18, ts, signedExpiry + 1 hours, sig);
     }
 
     /// @notice A strictly-newer, validly-signed payload carrying a ZERO price
@@ -326,9 +386,10 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     /// (e.g. Morpho collateral priced at zero). Guarded symmetrically with the
     /// other degenerate-value reverts, and the pair stays unset.
     function test_UpdatePrice_ZeroPrice_Reverts() public {
-        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 0, block.timestamp);
+        uint256 expiry = block.timestamp + DEFAULT_VALIDITY;
+        bytes memory sig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 0, block.timestamp, expiry);
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceZero.selector, PAIR_A));
-        oracle.updatePrice(PAIR_A, 0, block.timestamp, sig);
+        oracle.updatePrice(PAIR_A, 0, block.timestamp, expiry, sig);
 
         // Nothing was stored — price() reverts the normal unset revert.
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUnset.selector, PAIR_A));
@@ -344,18 +405,38 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     function test_UpdatePrice_WronglySignedFuturePayload_RevertsInvalidSignatureNotFuture() public {
         uint256 wrongPk = uint256(keccak256("wrong-signer"));
         uint256 future = block.timestamp + 1 hours;
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, digestFor(oracle, PAIR_A, 42e18, future));
+        uint256 expiry = future + DEFAULT_VALIDITY;
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, digestFor(oracle, PAIR_A, 42e18, future, expiry));
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUpdateInvalidSignature.selector, PAIR_A));
-        oracle.updatePrice(PAIR_A, 42e18, future, abi.encodePacked(r, s, v));
+        oracle.updatePrice(PAIR_A, 42e18, future, expiry, abi.encodePacked(r, s, v));
+    }
+
+    /// @notice Signature-before-content also holds for the NEW expiry check:
+    /// an already-expired payload with a WRONG-key signature reverts
+    /// `PriceUpdateInvalidSignature`, NOT `PriceExpired` — an unauthenticated
+    /// probe can never map the live-vs-dead boundary of the window checks.
+    function test_UpdatePrice_WronglySignedExpiredPayload_RevertsInvalidSignatureNotExpired() public {
+        uint256 wrongPk = uint256(keccak256("wrong-signer"));
+        vm.warp(block.timestamp + 1 days);
+        uint256 ts = block.timestamp - 120;
+        uint256 expiry = block.timestamp - 60;
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, digestFor(oracle, PAIR_A, 42e18, ts, expiry));
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUpdateInvalidSignature.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 42e18, ts, expiry, abi.encodePacked(r, s, v));
     }
 
     /// @notice The boundary: a payload timestamped at EXACTLY block.timestamp
     /// is not in the future and applies. (`newTimestamp <= block.timestamp`
     /// is the accepted region.)
     function test_UpdatePrice_CurrentTimestamp_Applies() public {
+        uint256 expiry = block.timestamp + DEFAULT_VALIDITY;
         assertTrue(
             oracle.updatePrice(
-                PAIR_A, 42e18, block.timestamp, signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, block.timestamp)
+                PAIR_A,
+                42e18,
+                block.timestamp,
+                expiry,
+                signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, block.timestamp, expiry)
             ),
             "now is not the future"
         );
@@ -363,9 +444,10 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     }
 
     /// @notice Per-pair isolation: two DISTINCT pairs each keep their own
-    /// price and timestamp. A regression that collapses the pair mapping to a
-    /// single global slot (or mis-keys writes/reads) would make one pair's
-    /// write clobber the other — this test fails under that mutation.
+    /// price, timestamp and expiry. A regression that collapses the pair
+    /// mapping to a single global slot (or mis-keys writes/reads) would make
+    /// one pair's write clobber the other — this test fails under that
+    /// mutation.
     function test_UpdatePrice_TwoPairs_IsolatedState() public {
         address baseTokenB = address(0xCCC3);
         address quoteTokenB = address(0xDDD4);
@@ -382,12 +464,14 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
 
         // Each pair reads back exactly its own value — not the other's, and
         // not a shared last-write.
-        (uint256 priceA, uint256 storedTsA) = oracle.pairPrice(PAIR_A);
-        (uint256 priceB, uint256 storedTsB) = oracle.pairPrice(pairB);
+        (uint256 priceA, uint256 storedTsA, uint256 expiryA) = oracle.pairPrice(PAIR_A);
+        (uint256 priceB, uint256 storedTsB, uint256 expiryB) = oracle.pairPrice(pairB);
         assertEq(priceA, 42e18, "pair A price isolated");
         assertEq(storedTsA, tsA, "pair A timestamp isolated");
+        assertEq(expiryA, tsA + DEFAULT_VALIDITY, "pair A expiry isolated");
         assertEq(priceB, 99e18, "pair B price isolated");
         assertEq(storedTsB, tsB, "pair B timestamp isolated");
+        assertEq(expiryB, tsB + DEFAULT_VALIDITY, "pair B expiry isolated");
 
         assertEq(oracle.price(PAIR_A), 42e18, "price() serves pair A's own value");
         assertEq(oracle.price(pairB), 99e18, "price() serves pair B's own value");
@@ -396,7 +480,7 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         vm.warp(block.timestamp + 7);
         _push(PAIR_A, 43e18, block.timestamp);
         assertEq(oracle.price(PAIR_A), 43e18, "pair A advanced");
-        (uint256 priceBAfter, uint256 storedTsBAfter) = oracle.pairPrice(pairB);
+        (uint256 priceBAfter, uint256 storedTsBAfter,) = oracle.pairPrice(pairB);
         assertEq(priceBAfter, 99e18, "pair B price untouched by pair A write");
         assertEq(storedTsBAfter, tsB, "pair B timestamp untouched by pair A write");
     }
@@ -406,6 +490,9 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
     /// @notice `DOMAIN_SEPARATOR` is a hardcoded hex literal — pin it to its
     /// normative EIP-712 derivation so a wrong literal can never ship
     /// undetected. Recomputed independently here (not read off the contract).
+    /// The domain is UNCHANGED by the expiry schema addition: schema
+    /// evolution is carried by the typehash (a four-field struct hash can
+    /// never validate a three-field signature), so no version bump.
     function test_DomainSeparator_MatchesNormativeDerivation() public view {
         bytes32 expected = keccak256(
             abi.encode(
@@ -415,23 +502,24 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         assertEq(oracle.domainSeparator(), expected, "domain separator must equal its EIP-712 derivation");
     }
 
-    /// @notice The `PRICE_UPDATE_TYPEHASH` matches its normative string.
+    /// @notice The `PRICE_UPDATE_TYPEHASH` matches its normative string —
+    /// including the `expiry` field the publisher signs.
     function test_PriceUpdateTypehash_MatchesNormativeDerivation() public view {
         assertEq(
             oracle.PRICE_UPDATE_TYPEHASH(),
-            keccak256("PriceUpdate(bytes32 pairId,uint256 price,uint256 timestamp)"),
+            keccak256("PriceUpdate(bytes32 pairId,uint256 price,uint256 timestamp,uint256 expiry)"),
             "typehash must equal its EIP-712 struct derivation"
         );
     }
 
-    /// @notice `MAX_TIMEOUT` is the documented 30-day upper bound on the
-    /// global staleness `timeout`. Pin the exact value: a widened bound would
-    /// silently let `price()` serve staler data than the spec permits, and no
-    /// other test asserts it (the range-reject tests read `MAX_TIMEOUT()`
-    /// dynamically, so they float with the constant).
-    function test_MaxTimeout_IsThirtyDays() public view {
-        assertEq(oracle.MAX_TIMEOUT(), 30 days, "MAX_TIMEOUT must be exactly 30 days");
-        assertEq(oracle.MAX_TIMEOUT(), 2592000, "30 days in seconds");
+    /// @notice `MAX_VALIDITY_WINDOW` is the documented 30-day sanity cap on a
+    /// payload's `expiry - timestamp`. Pin the exact value: a widened cap
+    /// would silently admit longer windows than the spec permits, and no
+    /// other test asserts it (the range-reject tests read
+    /// `MAX_VALIDITY_WINDOW()` dynamically, so they float with the constant).
+    function test_MaxValidityWindow_IsThirtyDays() public view {
+        assertEq(oracle.MAX_VALIDITY_WINDOW(), 30 days, "MAX_VALIDITY_WINDOW must be exactly 30 days");
+        assertEq(oracle.MAX_VALIDITY_WINDOW(), 2592000, "30 days in seconds");
     }
 
     /// @notice `ORACLE_ADMIN_ROLE` is the public role identifier off-chain
@@ -459,7 +547,7 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         assertEq(storedSigner, oracle.signer(), "MainStorage must be namespaced at the ERC-7201 derived slot");
     }
 
-    // -------- price(): unset + staleness --------
+    // -------- price(): unset + expiry --------
 
     /// @notice A pair either has a stored price or it doesn't — an unset
     /// pair (stored timestamp 0) reverts `PriceUnset`.
@@ -468,18 +556,23 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         oracle.price(PAIR_UNKNOWN);
     }
 
-    function test_Price_RevertsWhenPastGlobalTimeout() public {
-        _push(PAIR_A, 42e18, block.timestamp);
+    /// @notice The read-side expiry edge fails CLOSED, mirroring the
+    /// submission edge: a stored price is served up to the last second
+    /// BEFORE its expiry and refused AT the expiry instant. There is no
+    /// other staleness bound — the publisher's signed horizon is the bound.
+    function test_Price_RevertsAtStoredExpiry() public {
+        uint256 expiry = block.timestamp + DEFAULT_VALIDITY;
+        _push(PAIR_A, 42e18, block.timestamp, expiry);
 
-        vm.warp(block.timestamp + TIMEOUT);
-        assertEq(oracle.price(PAIR_A), 42e18, "still fresh at the timeout bound");
+        vm.warp(expiry - 1);
+        assertEq(oracle.price(PAIR_A), 42e18, "still live one second before expiry");
 
-        vm.warp(block.timestamp + 1);
-        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceStale.selector, PAIR_A));
+        vm.warp(expiry);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceExpired.selector, PAIR_A));
         oracle.price(PAIR_A);
     }
 
-    // -------- setSigner / setTimeout --------
+    // -------- setSigner --------
 
     /// @notice Rotating the global signer emits `SignerSet`, invalidates
     /// payloads signed by the old key, and honours the new one. Stored
@@ -497,13 +590,16 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
 
         // Old key no longer authorises a fresh payload...
         vm.warp(block.timestamp + 1);
-        bytes memory oldKeySig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 43e18, block.timestamp);
+        uint256 expiry = block.timestamp + DEFAULT_VALIDITY;
+        bytes memory oldKeySig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 43e18, block.timestamp, expiry);
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUpdateInvalidSignature.selector, PAIR_A));
-        oracle.updatePrice(PAIR_A, 43e18, block.timestamp, oldKeySig);
+        oracle.updatePrice(PAIR_A, 43e18, block.timestamp, expiry, oldKeySig);
 
         // ...the new key does.
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(newPk, digestFor(oracle, PAIR_A, 43e18, block.timestamp));
-        assertTrue(oracle.updatePrice(PAIR_A, 43e18, block.timestamp, abi.encodePacked(r, s, v)), "new key applies");
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(newPk, digestFor(oracle, PAIR_A, 43e18, block.timestamp, expiry));
+        assertTrue(
+            oracle.updatePrice(PAIR_A, 43e18, block.timestamp, expiry, abi.encodePacked(r, s, v)), "new key applies"
+        );
 
         // Rotation preserved the previously stored state until then.
         assertEq(oracle.price(PAIR_A), 43e18, "state advanced under the new key");
@@ -535,35 +631,13 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         oracle.setSigner(address(0));
     }
 
-    /// @notice Tightening the global timeout emits `TimeoutSet` and
-    /// immediately applies to every pair's `price()`.
-    function test_SetTimeout_UpdatesAndEmits() public {
-        _push(PAIR_A, 42e18, block.timestamp);
-        vm.warp(block.timestamp + 10 minutes);
-        assertEq(oracle.price(PAIR_A), 42e18, "fresh under the 1h timeout");
-
-        vm.expectEmit(address(oracle));
-        emit ST0xPriceOracle.TimeoutSet(5 minutes);
-        vm.prank(ORACLE_ADMIN);
-        oracle.setTimeout(5 minutes);
-        assertEq(oracle.timeout(), 5 minutes, "timeout updated");
-
-        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceStale.selector, PAIR_A));
-        oracle.price(PAIR_A);
-    }
-
-    function test_SetTimeout_RoleGated() public {
-        bytes32 oracleAdminRole = oracle.ORACLE_ADMIN_ROLE();
-        vm.prank(RANDO);
-        vm.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, RANDO, oracleAdminRole)
-        );
-        oracle.setTimeout(5 minutes);
-    }
-
     // -------- Helpers --------
 
     function _push(bytes32 id, uint256 price, uint256 timestamp) internal {
         push(oracle, id, price, timestamp);
+    }
+
+    function _push(bytes32 id, uint256 price, uint256 timestamp, uint256 expiry) internal {
+        push(oracle, id, price, timestamp, expiry);
     }
 }

--- a/test/src/lib/SignedPriceTestBase.sol
+++ b/test/src/lib/SignedPriceTestBase.sol
@@ -22,15 +22,41 @@ abstract contract SignedPriceTestBase is Test {
     uint256 internal constant SIGNER_PK = uint256(keccak256("st0x.price-oracle.signer.test"));
     address internal immutable SIGNER = vm.addr(SIGNER_PK);
 
+    /// @notice The default validity window applied by the expiry-less `push`
+    /// overload: `expiry = timestamp + DEFAULT_VALIDITY`. Sized like a real
+    /// intraday publisher window (minutes, not hours) so suites that only
+    /// need "a currently-valid price" get one without caring about expiry
+    /// mechanics; suites that DO care pass an explicit expiry.
+    uint256 internal constant DEFAULT_VALIDITY = 5 minutes;
+
     /// @notice Signs and applies a price update against `store` with the
-    /// canonical `SIGNER_PK`, asserting it was accepted. The single push flow
-    /// every suite's thin `_push` wrapper delegates to.
+    /// canonical `SIGNER_PK` and the default validity window
+    /// (`timestamp + DEFAULT_VALIDITY`), asserting it was accepted. The
+    /// convenience flow for suites that need a valid stored price but are not
+    /// exercising expiry semantics.
     /// @param store The oracle to push to.
     /// @param id The pair id.
     /// @param price The price being pushed.
     /// @param timestamp The observation timestamp.
     function push(ST0xPriceOracle store, bytes32 id, uint256 price, uint256 timestamp) internal {
-        assertTrue(store.updatePrice(id, price, timestamp, signPriceUpdate(store, SIGNER_PK, id, price, timestamp)));
+        push(store, id, price, timestamp, timestamp + DEFAULT_VALIDITY);
+    }
+
+    /// @notice Signs and applies a price update against `store` with the
+    /// canonical `SIGNER_PK` and an explicit expiry, asserting it was
+    /// accepted. The single push flow every suite's thin `_push` wrapper
+    /// delegates to.
+    /// @param store The oracle to push to.
+    /// @param id The pair id.
+    /// @param price The price being pushed.
+    /// @param timestamp The observation timestamp.
+    /// @param expiry The publisher-signed validity horizon.
+    function push(ST0xPriceOracle store, bytes32 id, uint256 price, uint256 timestamp, uint256 expiry) internal {
+        assertTrue(
+            store.updatePrice(
+                id, price, timestamp, expiry, signPriceUpdate(store, SIGNER_PK, id, price, timestamp, expiry)
+            )
+        );
     }
 
     /// @notice Recreates the EIP-712 digest an off-chain signer would sign for
@@ -40,13 +66,14 @@ abstract contract SignedPriceTestBase is Test {
     /// @param id The pair id.
     /// @param price The price being pushed.
     /// @param timestamp The observation timestamp.
+    /// @param expiry The publisher-signed validity horizon.
     /// @return The 32-byte EIP-712 digest.
-    function digestFor(ST0xPriceOracle store, bytes32 id, uint256 price, uint256 timestamp)
+    function digestFor(ST0xPriceOracle store, bytes32 id, uint256 price, uint256 timestamp, uint256 expiry)
         internal
         view
         returns (bytes32)
     {
-        bytes32 structHash = keccak256(abi.encode(store.PRICE_UPDATE_TYPEHASH(), id, price, timestamp));
+        bytes32 structHash = keccak256(abi.encode(store.PRICE_UPDATE_TYPEHASH(), id, price, timestamp, expiry));
         return keccak256(abi.encodePacked("\x19\x01", store.domainSeparator(), structHash));
     }
 
@@ -57,13 +84,17 @@ abstract contract SignedPriceTestBase is Test {
     /// @param id The pair id.
     /// @param price The price being pushed.
     /// @param timestamp The observation timestamp.
+    /// @param expiry The publisher-signed validity horizon.
     /// @return The `abi.encodePacked(r, s, v)` signature.
-    function signPriceUpdate(ST0xPriceOracle store, uint256 pk, bytes32 id, uint256 price, uint256 timestamp)
-        internal
-        view
-        returns (bytes memory)
-    {
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digestFor(store, id, price, timestamp));
+    function signPriceUpdate(
+        ST0xPriceOracle store,
+        uint256 pk,
+        bytes32 id,
+        uint256 price,
+        uint256 timestamp,
+        uint256 expiry
+    ) internal view returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digestFor(store, id, price, timestamp, expiry));
         return abi.encodePacked(r, s, v);
     }
 }

--- a/test/src/script/Deploy.t.sol
+++ b/test/src/script/Deploy.t.sol
@@ -35,7 +35,6 @@ contract DeployTest is Test {
     address internal constant ST0X_ADMIN = address(0x57ADAD);
     address internal constant ST0X_ORACLE_ADMIN = address(0x57ADDD);
     address internal constant ST0X_SIGNER = address(0x57516E);
-    uint64 internal constant ST0X_TIMEOUT = uint64(1 hours);
 
     /// @dev Signature of the beacon-set deployers' `Deployment` event. Used to
     /// discriminate WHICH suite `run()` actually dispatched to: the DIA suite
@@ -131,7 +130,6 @@ contract DeployTest is Test {
         vm.setEnv("ST0X_ADMIN", vm.toString(ST0X_ADMIN));
         vm.setEnv("ST0X_ORACLE_ADMIN", vm.toString(ST0X_ORACLE_ADMIN));
         vm.setEnv("ST0X_SIGNER", vm.toString(ST0X_SIGNER));
-        vm.setEnv("ST0X_TIMEOUT", vm.toString(uint256(ST0X_TIMEOUT)));
 
         // ----- signed-price helper: env-config wiring (#267) -----
         // Happy path: admin/oracleAdmin both distinct from the deploy key, so
@@ -146,7 +144,6 @@ contract DeployTest is Test {
         ) = deploy.exposedDeploySignedPriceStack(BEACON_OWNER, DEPLOYER);
 
         assertEq(central.signer(), ST0X_SIGNER, "signer wired from env");
-        assertEq(central.timeout(), ST0X_TIMEOUT, "timeout wired from env");
         assertTrue(
             central.hasRole(central.ORACLE_ADMIN_ROLE(), ST0X_ORACLE_ADMIN), "oracleAdmin granted ORACLE_ADMIN_ROLE"
         );
@@ -226,7 +223,7 @@ contract DeployTest is Test {
         deploy.run();
         vm.stopBroadcast();
 
-        // Same for ST0X_ORACLE_ADMIN, which rotates signer/timeout directly.
+        // Same for ST0X_ORACLE_ADMIN, which rotates the signer directly.
         vm.setEnv("ST0X_ADMIN", vm.toString(ST0X_ADMIN));
         vm.setEnv("ST0X_ORACLE_ADMIN", vm.toString(deployer));
         vm.expectRevert("ST0X_ORACLE_ADMIN must not be the deploy key");
@@ -243,27 +240,6 @@ contract DeployTest is Test {
         vm.stopBroadcast();
         vm.setEnv("ST0X_SIGNER", vm.toString(ST0X_SIGNER));
 
-        // ----- ST0X_TIMEOUT uint64 bound (#267) -----
-        // `ST0X_TIMEOUT` is read as a uint256 and narrowed to uint64. Solidity's
-        // explicit downcast TRUNCATES silently, so a value of 2**64 + 3600 would
-        // become a perfectly plausible 3600-second timeout and the deploy would
-        // ship a staleness bound nobody asked for. The script's
-        // `<= type(uint64).max` guard must reject it by MESSAGE, not truncate.
-        vm.setEnv("ST0X_TIMEOUT", vm.toString(uint256(type(uint64).max) + 1 + 3600));
-        vm.expectRevert("ST0X_TIMEOUT overflows uint64");
-        deploy.exposedDeploySignedPriceStack(BEACON_OWNER, DEPLOYER);
-
-        // Boundary, the OTHER edge: exactly `type(uint64).max` IS representable,
-        // so the script's own guard must let it through (`<=`, not `<`) and the
-        // rejection must come from DOWNSTREAM — `ST0xPriceOracle`'s
-        // `MAX_TIMEOUT` (30 days) bound, carrying the offending value. A `<`
-        // guard here would swap this for the script's string revert.
-        vm.setEnv("ST0X_TIMEOUT", vm.toString(uint256(type(uint64).max)));
-        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.TimeoutTooLarge.selector, type(uint64).max));
-        deploy.exposedDeploySignedPriceStack(BEACON_OWNER, DEPLOYER);
-
-        vm.setEnv("ST0X_TIMEOUT", vm.toString(uint256(ST0X_TIMEOUT)));
-
         // ----- signed-price helper: key-separation guards (#267) -----
         // Guard: ST0X_ADMIN holds DEFAULT_ADMIN_ROLE (can rotate the publisher
         // signer), so it must never be the hot deploy key.
@@ -271,7 +247,7 @@ contract DeployTest is Test {
         vm.expectRevert("ST0X_ADMIN must not be the deploy key");
         deploy.exposedDeploySignedPriceStack(BEACON_OWNER, DEPLOYER);
 
-        // Guard: ST0X_ORACLE_ADMIN rotates signer/timeout directly — same rule.
+        // Guard: ST0X_ORACLE_ADMIN rotates the signer directly — same rule.
         vm.setEnv("ST0X_ADMIN", vm.toString(ST0X_ADMIN));
         vm.setEnv("ST0X_ORACLE_ADMIN", vm.toString(DEPLOYER));
         vm.expectRevert("ST0X_ORACLE_ADMIN must not be the deploy key");


### PR DESCRIPTION
## Protofire H01 — no bound on payload age at submission: the submitter chooses which price becomes current

With only the strictly-newer and not-future checks, every publisher signature was a bearer capability valid forever: a submitter holding several signed payloads could install whichever extremum suited them inside the `(max(stored, now − timeout), now]` window — the old low to force a liquidation, the old high to over-borrow. The read-side global `timeout` was also a consumer-side constant guess at how long a price stays good, which is the producer's question to answer, not ours.

### The fix: publisher-signed expiry (the `/context/v5` pattern)

The `PriceUpdate` struct gains the publisher's own `expiry` — the horizon past which the producer has disowned the price, mirroring what `st0x-oracle-server`'s `/context/v5` already signs into the Raindex context (sourced from `st0x.pricing`'s `expiry_unix_ms`):

- **Submission**: a payload whose window has already closed reverts `PriceExpired` — expired payloads are permanently dead; being newer than stored does not resurrect them. The selectable set at any instant collapses to the currently-live windows, so the publisher's window-overlap policy bounds adversarial selection, tunable per payload with nothing to update on-chain (short intraday windows; one long window across a close/weekend).
- **Read**: `price()` refuses a stored price at its expiry (fail-closed edge, both sides). `timeout` / `setTimeout` / `MAX_TIMEOUT` are deleted; `ORACLE_ADMIN_ROLE` keeps only `setSigner`.
- **Sanity cap**: `MAX_VALIDITY_WINDOW` (30 days) bounds `expiry − timestamp` at submission. Documented explicitly as belt-and-braces, not a security boundary: an individually fat-fingered expiry is recovered by a strictly-newer tight-window payload or a signer roll; the cap exists for the systematically wrong-scale pipeline (ms-for-s) where every corrective is equally wrong and rotation buys nothing.

### Ripples

- Typehash → `PriceUpdate(bytes32 pairId,uint256 price,uint256 timestamp,uint256 expiry)`; domain unchanged (schema evolution is carried by the typehash — a three-field signature can never validate against the four-field struct hash).
- `pairPrice` → `(price, timestamp, expiry)`. Raw-view consumers must apply the expiry themselves — the univ4 hook migration is tracked as [RAI-1963](https://linear.app/makeitrain/issue/RAI-1963).
- Deployer `newST0xPriceOracle` and `script/Deploy.sol` lose the timeout wiring (`ST0X_TIMEOUT` env gone); CREATE2 salt is now `keccak256(admin, oracleAdmin, signer)`.
- `MorphoPairAdapter` unchanged: it calls `price()` and inherits the expiry revert fail-closed.
- Cross-chain replay design unchanged — the horizon is wall-clock, chain-agnostic.

Conflicts with #300 (NAV ratio) are expected — same struct/typehash surface; merge order to be decided separately.

### Gates

`forge test` 198/198 (incl. Base fork test), slither 0 findings, `forge fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FTbsUf9TY7uEtBJETSViV
