### PR TITLE
audit(H02): reject a zero pauseTimeBefore as strictly as the post-window

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ few minutes; the 1-hour heartbeat is the dead-market floor. Recommended
 > `maxAge = 2 hours` with `pauseTimeAfter = 3 hours` (a 1h margin) is the
 > reference.
 
+> **⚠️ `pauseTimeBefore` is also mandatory (non-zero, enforced at `initialize` —
+> `ZeroPauseTimeBefore`).** The market revalues at the ex-date, which precedes
+> the on-chain `effectiveTime`, so DIA can publish the post-action equity price
+> against the still-pre-action vault ratio. Only the pre-window pauses reads
+> across that interval. Size it above the worst-case ex-date → `effectiveTime`
+> lead, and schedule actions with more notice than `pauseTimeBefore` — the
+> oracle cannot enforce scheduling lead time (see `ZeroPauseTimeBefore`
+> NatSpec).
+
 **DIA on Base mainnet:** the canonical oracle contract address is the
 `DIA_FEED_BASE` constant in [`src/lib/LibDIAFeed.sol`](src/lib/LibDIAFeed.sol) —
 the single source of truth; import it rather than pasting the literal.
@@ -99,7 +108,7 @@ DIAVaultOracle oracle = diaVaultOracleBeaconSetDeployer.newDIAVaultOracle(
         vault:           wtStockVault,  // ICorporateActionsV1 derived from vault.asset()
         maxAge:          2 hours,
         actionTypeMask:  type(uint256).max,
-        pauseTimeBefore: 1 hours,
+        pauseTimeBefore: 1 hours,  // non-zero required; size above the ex-date → effectiveTime lead
         pauseTimeAfter:  3 hours  // > maxAge, with a skew margin (see invariant above)
     })
 );

--- a/src/concrete/oracle/DIAVaultOracle.sol
+++ b/src/concrete/oracle/DIAVaultOracle.sol
@@ -33,10 +33,32 @@ error ZeroMaxAge();
 /// boundary), so it fails loud at init instead.
 error ZeroCorporateActionsVault();
 
-/// @dev Error raised when the corporate-action pause window is incoherent: a
-/// non-zero `actionTypeMask` and at least one non-zero window are both
-/// required, else the auto-pause never fires despite being "configured".
+/// @dev Error raised when the corporate-action pause mask is incoherent: the
+/// mask must retain at least one REAL action bit after the library strips
+/// `ACTION_TYPE_INIT_V1`, else the auto-pause never fires despite being
+/// "configured".
 error InvalidPauseConfig();
+
+/// @dev Error raised when `pauseTimeBefore == 0`. The PRE-action window is as
+/// mandatory as the post-action one, and is rejected with the same
+/// strictness. The pre-window guards the mirror image of the cross-epoch
+/// hazard the `pauseTimeAfter > maxAge` invariant closes: a stock split's
+/// ex-date on the real market PRECEDES the on-chain `effectiveTime` (the
+/// exchange sets the former, the operator schedules the latter), so the DIA
+/// feed can publish the already-rebalanced (e.g. halved) equity price while
+/// the vault's NAV ratio is still pre-action. Only the pre-window pauses
+/// reads across that interval; with a zero pre-window nothing does, the
+/// share is underpriced (~half on a 2:1 split), and the loss falls on
+/// BORROWERS — every wtStock-collateralised position appears
+/// undercollateralised and becomes liquidatable at a price the collateral
+/// does not actually trade at. Note the residual the contract cannot
+/// enforce: the upstream scheduler only requires `effectiveTime >
+/// block.timestamp`, so an action scheduled at shorter notice than
+/// `pauseTimeBefore` nullifies part of the pre-window regardless of its
+/// size. A minimum scheduling notice (comfortably above `pauseTimeBefore`)
+/// is therefore an OPERATIONAL requirement on the corporate-action
+/// scheduler, recorded here because no on-chain check can carry it.
+error ZeroPauseTimeBefore();
 
 /// @dev Error raised when `pauseTimeAfter <= maxAge`. The post-action pause MUST
 /// last STRICTLY longer than the DIA staleness window, otherwise a
@@ -110,10 +132,12 @@ error HistoricalRoundDataUnsupported(uint80 roundId);
 /// `ACTION_TYPE_STOCK_SPLIT_V1` for splits only, or `type(uint256).max` for
 /// every present and future action type. Must be non-zero.
 /// @param pauseTimeBefore Seconds before a pending action's `effectiveTime` to
-/// start pausing.
+/// start pausing. Must be non-zero, sized above the worst-case ex-date →
+/// `effectiveTime` lead — see `ZeroPauseTimeBefore`.
 /// @param pauseTimeAfter Seconds after a completed action's `effectiveTime` to
-/// keep pausing. At least one of before/after must be non-zero, AND
-/// `pauseTimeAfter > maxAge` (STRICTLY) is REQUIRED and enforced at init
+/// keep pausing. Both windows are individually mandatory (each has its own
+/// strict check), AND `pauseTimeAfter > maxAge` (STRICTLY) is REQUIRED and
+/// enforced at init
 /// (`PauseTimeAfterBelowMaxAge`) — the post-action pause must outlast the DIA
 /// staleness window so a pre-action price can never be served against the
 /// post-action ratio. The margin `pauseTimeAfter - maxAge` is the maximum
@@ -225,6 +249,11 @@ struct DIAVaultOracleConfig {
 /// still within `maxAge` (hence accepted by the staleness check), that stale
 /// price pairs with the already-rebalanced ratio: on a 2:1 split the share is
 /// valued at ~2x, letting a borrower draw against phantom collateral (bad debt).
+///
+/// The PRE-action window closes the mirror-image hazard — the market's
+/// ex-date revaluation precedes the on-chain `effectiveTime` — so
+/// `pauseTimeBefore` is equally mandatory: see `ZeroPauseTimeBefore` for
+/// the full argument and the scheduling-notice requirement.
 ///
 /// The subtlety is which CLOCK ages the push. Staleness is measured from the
 /// push's own DIA SOURCE timestamp, not from when it landed on chain, and that
@@ -357,11 +386,14 @@ contract DIAVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable 
         // mask of exactly `ACTION_TYPE_INIT_V1` would pass a bare `!= 0` check
         // yet the library short-circuits it to "never pauses", silently
         // defeating the mandatory auto-pause.
-        if (
-            (config.actionTypeMask & ~ACTION_TYPE_INIT_V1) == 0
-                || (config.pauseTimeBefore == 0 && config.pauseTimeAfter == 0)
-        ) {
+        if ((config.actionTypeMask & ~ACTION_TYPE_INIT_V1) == 0) {
             revert InvalidPauseConfig();
+        }
+
+        // The PRE-action window is rejected at zero with the same strictness
+        // as the post-action side below — see `ZeroPauseTimeBefore`.
+        if (config.pauseTimeBefore == 0) {
+            revert ZeroPauseTimeBefore();
         }
 
         // Cross-epoch safety invariant: the post-action pause must STRICTLY

--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -14,6 +14,7 @@ import {
     ZeroMaxAge,
     ZeroCorporateActionsVault,
     InvalidPauseConfig,
+    ZeroPauseTimeBefore,
     PauseTimeAfterBelowMaxAge,
     OraclePausedCorporateAction,
     EmptySymbol,
@@ -123,12 +124,15 @@ contract DIAVaultOracleTest is Test {
         oracle.initialize(abi.encode(config));
     }
 
+    /// @notice Both windows zero reverts `ZeroPauseTimeBefore` — the
+    /// pre-window check precedes the relative post-window invariant, so the
+    /// pre side is named first.
     function testInitRevertsBothWindowsZero() external {
         DIAVaultOracleConfig memory config = _defaultConfig();
         config.pauseTimeBefore = 0;
         config.pauseTimeAfter = 0;
         DIAVaultOracle oracle = _deployUninit();
-        vm.expectRevert(InvalidPauseConfig.selector);
+        vm.expectRevert(ZeroPauseTimeBefore.selector);
         oracle.initialize(abi.encode(config));
     }
 
@@ -148,17 +152,32 @@ contract DIAVaultOracleTest is Test {
         oracle.initialize(abi.encode(config));
     }
 
-    /// @notice A post-window-only config (`pauseTimeBefore == 0`) is valid as
-    /// long as `pauseTimeAfter > maxAge`. The default `PAUSE_AFTER` carries a
-    /// positive margin over `MAX_AGE`, which init accepts.
-    function testInitSucceedsWithOnlyPostWindow() external {
+    /// @notice A post-window-only config (`pauseTimeBefore == 0`) is
+    /// REJECTED. The pre-window guards the ex-date → `effectiveTime`
+    /// interval (the market revalues before the on-chain action), and with a
+    /// zero pre-window the already-rebalanced DIA price pairs with the
+    /// pre-action vault ratio, underpricing the share against borrowers.
+    function testInitRevertsZeroPauseTimeBefore() external {
         DIAVaultOracleConfig memory config = _defaultConfig();
         config.pauseTimeBefore = 0;
         config.pauseTimeAfter = PAUSE_AFTER;
         DIAVaultOracle oracle = _deployUninit();
+        vm.expectRevert(ZeroPauseTimeBefore.selector);
+        oracle.initialize(abi.encode(config));
+    }
+
+    /// @notice The minimum viable pre-window (one second) is accepted — the
+    /// strict check rejects exactly zero, it does not impose a floor beyond
+    /// non-zero (sizing the window against the ex-date lead is the
+    /// operator's job, documented as such).
+    function testInitAcceptsOneSecondPreWindow() external {
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.pauseTimeBefore = 1;
+        config.pauseTimeAfter = PAUSE_AFTER;
+        DIAVaultOracle oracle = _deployUninit();
         bytes32 ok = oracle.initialize(abi.encode(config));
-        assertEq(ok, ICLONEABLE_V2_SUCCESS, "post-window-only config must be accepted");
-        assertEq(oracle.pauseTimeBefore(), 0);
+        assertEq(ok, ICLONEABLE_V2_SUCCESS, "one-second pre-window must be accepted");
+        assertEq(oracle.pauseTimeBefore(), 1);
         assertEq(oracle.pauseTimeAfter(), PAUSE_AFTER);
     }
 
@@ -781,7 +800,7 @@ contract DIAVaultOracleTest is Test {
         // fuzzer would waste runs on.
         extraPause = uint64(bound(extraPause, 1, 4));
         uint64 pauseAfter = maxAgeSeconds + extraPause;
-        pauseBefore = uint64(bound(pauseBefore, 0, 30 days));
+        pauseBefore = uint64(bound(pauseBefore, 1, 30 days));
         // The push is pre-action: at or just before `effectiveTime`. Pushes far
         // earlier are strictly staler, so the tight offsets are the hard cases.
         pushOffset = uint64(bound(pushOffset, 0, 3));

--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -382,6 +382,29 @@ contract DIAVaultOracleTest is Test {
         assertEq(oracle.latestAnswer(), 100e8, "prices normally outside the pause window");
     }
 
+    /// @notice PRE-window twin of `testAutoPauseRevertsInsideWindow`: a
+    /// PENDING action whose `effectiveTime` is within `pauseTimeBefore` of
+    /// now pauses BOTH read entry points. The pre-window predicate itself is
+    /// covered in LibCorporateActionsPause.t.sol; what this pins is the
+    /// ORACLE's wiring of `pauseTimeBefore` into that call — the interval the
+    /// zero-pre-window rejection exists to guard (the market's ex-date
+    /// revaluation precedes the on-chain `effectiveTime`).
+    function testAutoPauseRevertsInsidePreWindow() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        diaOracle.setValue(SYMBOL, 100e18, uint64(block.timestamp));
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+
+        // Pending split half a pre-window ahead → inside the pause window.
+        uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
+        actions.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
+        oracle.latestAnswer();
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
+        oracle.latestRoundData();
+    }
+
     // -------- ERC-7201 storage-layout pin (beacon-upgrade safety) --------
 
     /// @notice The `MainStorage` slot constant is a hardcoded hex literal with


### PR DESCRIPTION
## Protofire H02 — zero `pauseTimeBefore` accepted, leaving the pre-action window unguarded

The pause-coherence disjunct (`before == 0 && after == 0`) could never fire on the pre side — `pauseTimeAfter > maxAge >= 1` is forced by the cross-epoch invariant — so `pauseTimeBefore = 0` initialized cleanly and was immutable thereafter. The ex-date → `effectiveTime` interval was then unguarded: the exchange revalues at the ex-date before the on-chain action, so DIA can publish the already-rebalanced (halved, on a 2:1 split) equity price against the still-pre-action vault ratio — underpricing the share, with the loss falling on borrowers (spurious liquidations), the mirror image of the post-action hazard.

### The fix

- `pauseTimeBefore == 0` reverts a dedicated `ZeroPauseTimeBefore`, rejected as strictly as the post-action side (per the report's recommendation of separate strict checks).
- The "Cross-epoch safety invariant" NatSpec now documents the pre-action direction symmetrically, including the borrower-side loss asymmetry.
- The residual no on-chain check can carry is documented where the error is declared: the upstream scheduler only requires `effectiveTime > block.timestamp`, so a short-notice schedule truncates any pre-window — **minimum scheduling notice comfortably above `pauseTimeBefore` is an operational requirement on the corporate-action scheduler** (st0x.deploy runbook).

Tests: `testInitSucceedsWithOnlyPostWindow` (which pinned the vulnerable behaviour) is replaced by an H02 regression test; a one-second pre-window acceptance test pins that the check is non-zero-only (sizing stays the operator's documented job); the epoch-boundary fuzz now draws `pauseBefore` from `[1, 30 days]`.

### Gates

`forge test` green (incl. Base fork test), slither 0 findings, `forge fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FTbsUf9TY7uEtBJETSViV
