### PR TITLE
audit(L02): absolute caps on maxAge and the pause windows

### DIFF
--- a/src/concrete/oracle/DIAVaultOracle.sol
+++ b/src/concrete/oracle/DIAVaultOracle.sol
@@ -26,6 +26,22 @@ error EmptySymbol();
 /// price read is instantly stale, which is never the desired configuration.
 error ZeroMaxAge();
 
+/// @dev Error raised when `maxAge` exceeds `MAX_AGE_LIMIT`. The relative
+/// invariant (`pauseTimeAfter > maxAge`) is SCALE-INVARIANT — a units
+/// mistake (e.g. the reference config's "2 hours" and "3 hours" expressed in
+/// MILLISECONDS) scales both operands equally and passes it cleanly, quietly
+/// stretching the staleness window from hours to ~83 days. Only an absolute
+/// bound catches that class of error.
+/// @param maxAge The rejected max age value.
+error MaxAgeTooLarge(uint256 maxAge);
+
+/// @dev Error raised when a pause window (`pauseTimeBefore` or
+/// `pauseTimeAfter`) exceeds `MAX_PAUSE_WINDOW`. Same scale-error rationale
+/// as `MaxAgeTooLarge` — the relative pause invariant cannot see a
+/// wrong-units config in which every term is uniformly oversized.
+/// @param pauseTime The rejected window value.
+error PauseWindowTooLarge(uint64 pauseTime);
+
 /// @dev Error raised when the priced vault's `asset()` (the tStock that
 /// carries `ICorporateActionsV1`) is the zero address — a broken / non-ST0x
 /// vault. The auto-pause is mandatory, and a zero corporate-actions vault
@@ -127,7 +143,10 @@ error HistoricalRoundDataUnsupported(uint80 roundId);
 /// `block.timestamp - timestamp >= maxAge` reverts `DIAPriceStale` (the edge
 /// instant fails closed — a push exactly `maxAge` old is stale). Immutable
 /// after init — redeploy a fresh proxy to change. MUST be `< pauseTimeAfter`
-/// STRICTLY (a positive margin is required — see `pauseTimeAfter`).
+/// STRICTLY (a positive margin is required — see `pauseTimeAfter`) and at
+/// most `MAX_AGE_LIMIT` (`MaxAgeTooLarge` — an absolute scale guard the
+/// relative invariant cannot provide; both pause windows are likewise capped
+/// at `MAX_PAUSE_WINDOW`).
 /// @param actionTypeMask Bitmap of action types that trigger the auto-pause.
 /// `ACTION_TYPE_STOCK_SPLIT_V1` for splits only, or `type(uint256).max` for
 /// every present and future action type. Must be non-zero.
@@ -275,6 +294,20 @@ struct DIAVaultOracleConfig {
 ///
 /// Deployed as a beacon-proxy clone via `ICloneableV2.initialize`.
 contract DIAVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable {
+    /// @notice Absolute upper bound on `maxAge`. A pure SCALE guard: the
+    /// production reference is 2 hours, and the only realistic way to land
+    /// above a week is a wrong-units config (2 hours in milliseconds is ~83
+    /// days), which the scale-invariant relative checks cannot catch.
+    /// Deliberately below `MAX_PAUSE_WINDOW` so `pauseTimeAfter > maxAge`
+    /// remains satisfiable at this bound.
+    uint256 public constant MAX_AGE_LIMIT = 7 days;
+
+    /// @notice Absolute upper bound on each pause window. Generous — a
+    /// deliberately long post-action pause is legitimate — while still
+    /// catching the milliseconds-for-seconds class (the reference 1-hour
+    /// pre-window in ms is ~41 days).
+    uint64 public constant MAX_PAUSE_WINDOW = 30 days;
+
     /// @custom:storage-location erc7201:st0x.diavaultoracle.main
     struct MainStorage {
         // The DIA Data Association V2 oracle feed for the underlying asset.
@@ -365,21 +398,27 @@ contract DIAVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable 
         revert InitializeSignatureFn();
     }
 
-    /// @inheritdoc ICloneableV2
-    function initialize(bytes calldata data) external initializer returns (bytes32) {
-        DIAVaultOracleConfig memory config = abi.decode(data, (DIAVaultOracleConfig));
-
+    /// @dev Static field validation for `initialize`: zero/empty checks on
+    /// the externally-supplied fields plus the absolute `maxAge` scale
+    /// guard. Pure — everything that needs an external call stays in
+    /// `initialize`, which calls this first.
+    function _validateStaticConfig(DIAVaultOracleConfig memory config) private pure {
         if (address(config.diaOracle) == address(0)) revert ZeroDIAOracle();
         if (bytes(config.symbol).length == 0) revert EmptySymbol();
         if (config.vault == address(0)) revert ZeroVault();
         if (config.maxAge == 0) revert ZeroMaxAge();
+        // Absolute scale guard: the relative `pauseTimeAfter > maxAge`
+        // invariant (checked in `_validatePauseConfig`) is scale-invariant,
+        // so a uniformly wrong-units config passes it — only an absolute
+        // bound fails it closed.
+        if (config.maxAge > MAX_AGE_LIMIT) revert MaxAgeTooLarge(config.maxAge);
+    }
 
-        // The corporate-actions vault is the tStock the wtStock wraps — the
-        // priced vault's own `asset()`. Deriving it (rather than taking a
-        // separate config field) removes a mis-wiring surface.
-        address derivedCorporateActionsVault = IERC4626(config.vault).asset();
-        if (derivedCorporateActionsVault == address(0)) revert ZeroCorporateActionsVault();
-
+    /// @dev Pause-config validation for `initialize`, called after the
+    /// corporate-actions vault derivation: mask coherence, the mandatory
+    /// pre-window, both absolute window caps, and the relative cross-epoch
+    /// invariant.
+    function _validatePauseConfig(DIAVaultOracleConfig memory config) private pure {
         // Auto-pause is mandatory and must be coherently configured. The mask
         // must retain a real action bit AFTER the library strips
         // `ACTION_TYPE_INIT_V1` (the bootstrap node is not a real action) — a
@@ -394,6 +433,16 @@ contract DIAVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable 
         // as the post-action side below — see `ZeroPauseTimeBefore`.
         if (config.pauseTimeBefore == 0) {
             revert ZeroPauseTimeBefore();
+        }
+
+        // Same absolute scale guard for both windows (see `MaxAgeTooLarge` /
+        // `PauseWindowTooLarge`): each field is bounded individually so the
+        // revert names the offending value.
+        if (config.pauseTimeBefore > MAX_PAUSE_WINDOW) {
+            revert PauseWindowTooLarge(config.pauseTimeBefore);
+        }
+        if (config.pauseTimeAfter > MAX_PAUSE_WINDOW) {
+            revert PauseWindowTooLarge(config.pauseTimeAfter);
         }
 
         // Cross-epoch safety invariant: the post-action pause must STRICTLY
@@ -422,6 +471,21 @@ contract DIAVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable 
         if (config.pauseTimeAfter <= config.maxAge) {
             revert PauseTimeAfterBelowMaxAge(config.pauseTimeAfter, config.maxAge);
         }
+    }
+
+    /// @inheritdoc ICloneableV2
+    function initialize(bytes calldata data) external initializer returns (bytes32) {
+        DIAVaultOracleConfig memory config = abi.decode(data, (DIAVaultOracleConfig));
+
+        _validateStaticConfig(config);
+
+        // The corporate-actions vault is the tStock the wtStock wraps — the
+        // priced vault's own `asset()`. Deriving it (rather than taking a
+        // separate config field) removes a mis-wiring surface.
+        address derivedCorporateActionsVault = IERC4626(config.vault).asset();
+        if (derivedCorporateActionsVault == address(0)) revert ZeroCorporateActionsVault();
+
+        _validatePauseConfig(config);
 
         // Probe the corporate-actions vault once so an incompatible wiring — a
         // missing facet (ABI-decode revert) or a mask with no bits in the

--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -15,6 +15,8 @@ import {
     ZeroCorporateActionsVault,
     InvalidPauseConfig,
     ZeroPauseTimeBefore,
+    MaxAgeTooLarge,
+    PauseWindowTooLarge,
     PauseTimeAfterBelowMaxAge,
     OraclePausedCorporateAction,
     EmptySymbol,
@@ -179,6 +181,66 @@ contract DIAVaultOracleTest is Test {
         assertEq(ok, ICLONEABLE_V2_SUCCESS, "one-second pre-window must be accepted");
         assertEq(oracle.pauseTimeBefore(), 1);
         assertEq(oracle.pauseTimeAfter(), PAUSE_AFTER);
+    }
+
+    /// @notice The relative `pauseTimeAfter > maxAge` invariant is
+    /// scale-invariant, so the reference config expressed in MILLISECONDS
+    /// (maxAge 7_200_000, pauseTimeAfter 10_800_000 — "2 hours" and "3
+    /// hours" with the wrong units) passes it cleanly, stretching the
+    /// staleness window to ~83 days. The absolute `MAX_AGE_LIMIT` bound is
+    /// what rejects it, naming the offending value.
+    function testInitRevertsMillisecondScaleConfig() external {
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.maxAge = 7_200_000;
+        config.pauseTimeBefore = 3_600_000;
+        config.pauseTimeAfter = 10_800_000;
+        DIAVaultOracle oracle = _deployUninit();
+        vm.expectRevert(abi.encodeWithSelector(MaxAgeTooLarge.selector, uint256(7_200_000)));
+        oracle.initialize(abi.encode(config));
+    }
+
+    /// @notice `maxAge` exactly at `MAX_AGE_LIMIT` is accepted (with a
+    /// coherent pauseTimeAfter above it); one second over is rejected. The
+    /// cap is deliberately below `MAX_PAUSE_WINDOW` so the relative
+    /// invariant stays satisfiable at the bound.
+    function testInitMaxAgeCapEdges() external {
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.maxAge = 7 days;
+        config.pauseTimeAfter = 7 days + 1 hours;
+        DIAVaultOracle atCap = _deployUninit();
+        assertEq(atCap.initialize(abi.encode(config)), ICLONEABLE_V2_SUCCESS, "maxAge at the cap must be accepted");
+
+        config.maxAge = 7 days + 1;
+        DIAVaultOracle overCap = _deployUninit();
+        vm.expectRevert(abi.encodeWithSelector(MaxAgeTooLarge.selector, uint256(7 days + 1)));
+        overCap.initialize(abi.encode(config));
+    }
+
+    /// @notice Each pause window is individually capped at
+    /// `MAX_PAUSE_WINDOW`, and the revert carries the offending value so an
+    /// operator can tell WHICH window was mis-scaled.
+    function testInitRevertsPauseWindowOverCap() external {
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.pauseTimeBefore = uint64(30 days) + 1;
+        DIAVaultOracle oracle = _deployUninit();
+        vm.expectRevert(abi.encodeWithSelector(PauseWindowTooLarge.selector, uint64(30 days) + 1));
+        oracle.initialize(abi.encode(config));
+
+        DIAVaultOracleConfig memory config2 = _defaultConfig();
+        config2.pauseTimeAfter = uint64(30 days) + 1;
+        DIAVaultOracle oracle2 = _deployUninit();
+        vm.expectRevert(abi.encodeWithSelector(PauseWindowTooLarge.selector, uint64(30 days) + 1));
+        oracle2.initialize(abi.encode(config2));
+    }
+
+    /// @notice Both pause windows exactly at `MAX_PAUSE_WINDOW` are accepted
+    /// — the caps reject only what lies beyond them.
+    function testInitAcceptsPauseWindowsAtCap() external {
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.pauseTimeBefore = uint64(30 days);
+        config.pauseTimeAfter = uint64(30 days);
+        DIAVaultOracle oracle = _deployUninit();
+        assertEq(oracle.initialize(abi.encode(config)), ICLONEABLE_V2_SUCCESS, "windows at the cap must be accepted");
     }
 
     /// @notice The cross-epoch invariant is enforced at init: `pauseTimeAfter`
@@ -816,7 +878,7 @@ contract DIAVaultOracleTest is Test {
         uint64 pushOffset,
         uint64 elapsed
     ) external {
-        maxAgeSeconds = uint64(bound(maxAgeSeconds, 1, 30 days));
+        maxAgeSeconds = uint64(bound(maxAgeSeconds, 1, 7 days));
         // `pauseTimeAfter > maxAge` (strict) is the enforced invariant, so the
         // margin is at least 1. Keep it TIGHT: the property can only break where
         // the two windows meet, and a wide margin is the trivially-safe case the


### PR DESCRIPTION
## Protofire L02 — no upper bounds on `maxAge`, `pauseTimeBefore`, `pauseTimeAfter`

The relative invariant `pauseTimeAfter > maxAge` is scale-invariant: a units mistake scales both operands equally and passes cleanly. The report's example is exact — the README reference config expressed in milliseconds (`maxAge = 7_200_000`, `pauseTimeAfter = 10_800_000`) initialized fine and silently stretched the staleness window to ~83 days. Only absolute bounds catch this class.

### The fix

- `MAX_AGE_LIMIT = 7 days` → `MaxAgeTooLarge(maxAge)`. Deliberately **below** the pause cap so `pauseTimeAfter > maxAge` remains satisfiable at the bound (a shared 30-day cap would make `maxAge = 30 days` un-initializable).
- `MAX_PAUSE_WINDOW = 30 days` per window → `PauseWindowTooLarge(pauseTime)`, each field checked individually so the revert names which window is mis-scaled.
- Both mirror the signed-price stack's `MAX_VALIDITY_WINDOW` (H01 PR) — one absolute-scale-guard convention across both stacks.
- `initialize`'s checks are split into `_validateStaticConfig` / `_validatePauseConfig` (order preserved exactly) — the added branches pushed the initializer over slither's cyclomatic-complexity bound.

Tests: the ms-scale reference config is a named regression test; cap edges (at/over) pinned for all three fields; fuzz bounds tightened to the caps.

### Gates

`forge test` green (incl. Base fork test), slither 0 findings, `forge fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FTbsUf9TY7uEtBJETSViV
