### PR TITLE
audit(M01): document the downward trust-model direction (confiscation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ two constraints, or the pause feature is silently defeated:
    `DIAPriceStale(timestamp)` revert can surface, and the deployment loses the
    layered staleness signal. Set the consumer's threshold to be at least the
    oracle's `maxAge`.
+3. **Size liquidation parameters against downward jump risk.** The priced
+   vault's `totalAssets()` is a raw token balance, and the upstream
+   receipt-vault confiscation role (an RWA regulatory capability) can move it
+   DOWN discontinuously — a plain transfer that creates no corporate-action
+   node, so the auto-pause does not bracket it and the share price steps down
+   inside a single block. The lower price is arithmetically correct; what a
+   confiscation removes is the warning window borrowers would otherwise have to
+   top up. This is an accepted risk: choose LLTV margins and liquidation bonuses
+   as you would for any asset with jump risk, and see the contract NatSpec
+   ("Vault trust model") for the operational rule that a wrapper-vault
+   confiscation must be preceded by a scheduled corporate action so the pause
+   brackets the discontinuity.
 
 ## Signed-price stack
 

--- a/src/concrete/oracle/DIAVaultOracle.sol
+++ b/src/concrete/oracle/DIAVaultOracle.sol
@@ -228,13 +228,41 @@ struct DIAVaultOracleConfig {
 /// rather than price consumers, and is not addressable from an oracle — no
 /// check here would prevent it. It is out of scope for this contract.
 ///
+/// The DOWNWARD direction is NOT symmetric and is an ACCEPTED RISK. The same
+/// raw `balanceOf` that lets donations move the ratio up lets a privileged
+/// upstream role move it DOWN: `OffchainAssetReceiptVault.confiscateShares`
+/// transfers tStock out of any named holder — the wrapper vault included —
+/// via a bare `_transfer`, an RWA regulatory capability
+/// `ICorporateActionsV1` explicitly warns integrators exists. A confiscation
+/// from the wrapper reduces `totalAssets()` inside one transaction, and the
+/// share price falls by the same proportion on the very next read. The
+/// auto-pause CANNOT see it: confiscation is a plain transfer that creates
+/// no corporate-action node, so there is no pre-window, no post-window and
+/// no `OraclePausedCorporateAction` — unlike a split, which moves the same
+/// variable behind the full cross-epoch machinery. The resulting price is
+/// arithmetically CORRECT (the vault genuinely backs fewer assets per
+/// share); what is lost is the WARNING WINDOW — every wtStock-collateralised
+/// position can become liquidatable inside a single block with no chance to
+/// top up or repay. A ratio sanity band is deliberately NOT the fix (next
+/// paragraph): it would fail closed on legitimate moves and halt
+/// liquidations, which is strictly worse. Instead: (1) lending markets MUST
+/// size liquidation parameters (LLTV margin, liquidation bonus) against a
+/// discontinuous downward NAV move of the magnitude a confiscation could
+/// plausibly take, exactly as they would for any asset with jump risk; and
+/// (2) OPERATIONALLY, a confiscation targeting a wrapper vault must be
+/// preceded by a scheduled corporate action of a type inside this oracle's
+/// `actionTypeMask`, so the pause brackets the discontinuity the same way it
+/// brackets a split — a rule that lives in the st0x.deploy runbook because
+/// no oracle-side check can enforce upstream sequencing.
+///
 /// Deliberately NOT mitigated here: no sanity band, drift limit or ratio
 /// anchor gates reads. Such a gate would fail closed on a legitimate NAV move
-/// (a large dividend or redemption), and an oracle that stops answering is
-/// strictly worse for a lending market than one that answers correctly —
-/// liquidations halt while positions keep moving, which accrues bad debt. The
-/// real stale-ratio risk is the corporate-action rebalance, and that is
-/// handled by the mandatory auto-pause below.
+/// in EITHER direction (a large dividend or redemption upward, a confiscation
+/// downward), and an oracle that stops answering is strictly worse for a
+/// lending market than one that answers correctly — liquidations halt while
+/// positions keep moving, which accrues bad debt. The real stale-ratio risk
+/// is the corporate-action rebalance, and that is handled by the mandatory
+/// auto-pause below.
 ///
 /// Pointing this oracle at an arbitrary third-party ERC-4626 remains
 /// unsupported, for TWO reasons. First, nothing outside the ST0x stack
@@ -644,12 +672,15 @@ contract DIAVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable 
     /// so a direct transfer into the vault does move the ratio. That is
     /// intentional and not a manipulation surface — a donation adds real assets
     /// the shares genuinely redeem for, mints the donor nothing, and cannot be
-    /// withdrawn, so it is value-additive and negative-EV for the donor. No
-    /// sanity band gates this read; halting the oracle on an unexpected ratio
-    /// would stop liquidations, which is worse for a lending market than
-    /// pricing the (real) NAV. See the contract NatSpec ("Vault trust model")
-    /// for the full argument and for what IS mitigated — the corporate-action
-    /// rebalance, via the mandatory auto-pause.
+    /// withdrawn, so it is value-additive and negative-EV for the donor. The
+    /// same raw balance also moves DOWN under an upstream confiscation — a
+    /// discontinuous, auto-pause-invisible drop that is an accepted risk with
+    /// operational mitigations, see the contract NatSpec. No sanity band gates
+    /// this read; halting the oracle on an unexpected ratio would stop
+    /// liquidations, which is worse for a lending market than pricing the
+    /// (real) NAV. See the contract NatSpec ("Vault trust model") for the full
+    /// argument and for what IS mitigated — the corporate-action rebalance,
+    /// via the mandatory auto-pause.
     function _vaultSharePrice(uint128 diaPrice) internal view returns (int256) {
         // DIA's value is 18-decimal uint128 — pack as a float with decimal
         // count 18 to recover the natural quantity.

--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -732,6 +732,36 @@ contract DIAVaultOracleTest is Test {
         assertEq(roundAnswer, int256(200e8), "latestRoundData must agree with latestAnswer");
     }
 
+    /// @notice DOWNWARD twin of `testDonationMovesRatioAndIsServed`, pinning
+    /// the accepted risk the "Vault trust model" NatSpec documents: the same
+    /// raw-`balanceOf` `totalAssets()` also moves DOWN when the upstream
+    /// confiscation role seizes tStock from the wrapper — a bare transfer
+    /// that burns no shares and creates no corporate-action node, so no pause
+    /// window opens. The lower price is arithmetically CORRECT (the vault
+    /// genuinely backs fewer assets per share) and must be served straight
+    /// through. Any drift limit or ratio anchor added to the read path would
+    /// reject this jump and fail this test — that is deliberate: halting the
+    /// oracle stops liquidations while positions keep moving, which is worse
+    /// for a lending market than pricing the true NAV.
+    function testConfiscationDropsRatioAndIsServed() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        diaOracle.setValue(SYMBOL, 100e18, uint128(block.timestamp));
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+        assertEq(oracle.latestAnswer(), int256(100e8), "baseline 1 asset per share");
+
+        // A confiscation halves the vault's holdings against an unchanged
+        // supply — a bare transfer out mints and burns nothing.
+        vault.setTotalAssets(0.5e18);
+
+        // Served, not rejected, and priced at the true new ratio.
+        assertEq(oracle.latestAnswer(), int256(50e8), "confiscation must be priced through, not gated");
+
+        // The same read path through latestRoundData agrees.
+        (, int256 roundAnswer,,,) = oracle.latestRoundData();
+        assertEq(roundAnswer, int256(50e8), "latestRoundData must agree with latestAnswer");
+    }
+
     // -------- latestAnswer DIA not set --------
 
     function testLatestAnswerRevertsDIAPriceNotSet() external {


### PR DESCRIPTION
## Protofire M01 — confiscation drops the share price discontinuously with no corporate-action pause

`OffchainAssetReceiptVault.confiscateShares` moves tStock out of any named holder — the wrapper vault included — via a bare `_transfer`. That reduces the raw-`balanceOf` `totalAssets()` inside one transaction, and the share price falls proportionally on the very next read. The auto-pause cannot see it: a confiscation creates no corporate-action node, so no pre-window, no post-window, no `OraclePausedCorporateAction` — unlike a split, which moves the same variable behind the full cross-epoch machinery. The "Vault trust model" NatSpec analysed only the upward direction (donations).

### The remedy (docs-only, per the finding's own framing)

The report classifies this as a trust-model and documentation gap, not an exploitable bug — the post-confiscation price is arithmetically correct, and a ratio sanity band would fail closed on legitimate moves (halting liquidations, which is strictly worse). Accordingly:

- The "Vault trust model" NatSpec now covers the downward direction as an **accepted risk**: what is lost in a confiscation is the borrower warning window, not price correctness; lending markets must size liquidation parameters (LLTV margin, liquidation bonus) against discontinuous downward NAV moves, as for any asset with jump risk.
- The operational mitigation is recorded where integrators will read it: **a confiscation targeting a wrapper vault must be preceded by a scheduled corporate action of a type inside the oracle's `actionTypeMask`**, so the pause brackets the discontinuity the way it brackets a split. This rule needs to land in the st0x.deploy runbook — no oracle-side check can enforce upstream sequencing.
- README "Operational Preconditions for Consumers" gains the jump-risk sizing precondition.

### Gates

Docs-only; `forge test` green, slither 0 findings, `forge fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FTbsUf9TY7uEtBJETSViV
