### PR TITLE
audit(L01): beacon membership and Deployment events are not authenticity

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ DIAVaultOracle oracle = diaVaultOracleBeaconSetDeployer.newDIAVaultOracle(
 Hand `address(oracle)` to consumers as the `AggregatorV2V3Interface` source they
 already plug Chainlink feeds into.
 
+> **⚠️ Instance authenticity:** minting through the beacon-set deployers is
+> **permissionless**, and the CREATE2 salt commits to the config alone — so an
+> attacker can mint a proxy with an arbitrary config that sits behind the same
+> governance-owned beacon and emits the same `Deployment` event as an official
+> instance. Neither beacon membership nor a `Deployment` event authenticates
+> anything: the **only** authenticity signal is, in theory, a published
+> deployment address list — wire consumers from it, never from event or beacon
+> scans. Nothing is deployed to production yet, so the concrete home of that
+> list (deploy artifacts, `.sol` constants, or a docs page) is TBC along with
+> the rest of the ops process; until it exists, treat no instance as canonical.
+> This applies identically to both stacks (`DIAVaultOracle`, `ST0xPriceOracle`,
+> `MorphoPairAdapter`).
+
 ### Operational Preconditions for Consumers
 
 Anything that wraps reads in `try / catch` (Aave-style consumers) must respect

--- a/src/concrete/deploy/DIAVaultOracleBeaconSetDeployer.sol
+++ b/src/concrete/deploy/DIAVaultOracleBeaconSetDeployer.sol
@@ -50,6 +50,23 @@ contract DIAVaultOracleBeaconSetDeployer {
     /// `initializer`-guarded and sits behind the governance-owned beacon, so it
     /// grants the front-runner no authority — it only reverts the operator's own
     /// later mint on the CREATE2 collision.
+    ///
+    /// The COMPLEMENTARY case is a mint with a DIFFERENT,
+    /// attacker-chosen config: equally permissionless, equally behind the
+    /// governance-owned beacon, and equally announced by this event from the
+    /// official deployer. NEITHER beacon membership NOR a `Deployment` event
+    /// therefore authenticates an instance — for `DIAVaultOracle` an
+    /// arbitrary config means an attacker-controlled DIA feed and vault,
+    /// which fully determine the served price.
+    /// The ONLY authenticity signal is the published deployment address list
+    /// (the CI-authored deploy artifacts): consumers MUST be wired from that
+    /// list and must never discover instances by scanning events or beacon
+    /// membership. Minting stays permissionless on purpose — a gate would add
+    /// an owner key to operate for every mint without protecting a correctly
+    /// wired consumer (a config-divergent proxy grants its minter no authority
+    /// over any instance a consumer was actually pointed at), and the
+    /// CREATE2 config-commitment means a published address is itself
+    /// verifiable against its claimed config.
     /// @param oracle The address of the new proxy. Indexed for filtering.
     event Deployment(address indexed caller, address indexed oracle);
 
@@ -72,6 +89,16 @@ contract DIAVaultOracleBeaconSetDeployer {
     /// its address is a deterministic commitment to its config and a re-run
     /// with identical config reverts on the CREATE2 collision instead of
     /// silently forking a second, divergent oracle.
+    ///
+    /// `config.diaOracle` is deliberately NOT validated against the
+    /// `DIA_FEED_BASE` constant (src/lib/LibDIAFeed.sol): that address is
+    /// Base's canonical DIA feed, and this deployer ships to multiple chains
+    /// where DIA's feed lives at a different address — a hardcoded equality
+    /// check would brick every non-Base deployment. Feed-address correctness
+    /// is a deploy-layer concern (the per-chain deploy tooling pins the
+    /// canonical feed for its chain), and instance authenticity is carried by
+    /// the published address list, not by config validation here (see the
+    /// `Deployment` event NatSpec).
     /// @param config The initialization configuration.
     /// @return oracle The deployed proxy as a typed reference.
     // slither-disable-next-line reentrancy-events

--- a/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.sol
+++ b/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.sol
@@ -56,6 +56,23 @@ contract MorphoPairAdapterBeaconSetDeployer {
     /// `initializer`-guarded and sits behind the governance-owned beacon, so it
     /// grants the front-runner no authority — it only reverts the operator's own
     /// later mint on the CREATE2 collision.
+    ///
+    /// The COMPLEMENTARY case is a mint with a DIFFERENT,
+    /// attacker-chosen config: equally permissionless, equally behind the
+    /// governance-owned beacon, and equally announced by this event from the
+    /// official deployer. NEITHER beacon membership NOR a `Deployment` event
+    /// therefore authenticates an instance — for `MorphoPairAdapter` an
+    /// arbitrary config means an attacker-chosen pair (and hence rescale) on
+    /// the shared central store.
+    /// The ONLY authenticity signal is the published deployment address list
+    /// (the CI-authored deploy artifacts): consumers MUST be wired from that
+    /// list and must never discover instances by scanning events or beacon
+    /// membership. Minting stays permissionless on purpose — a gate would add
+    /// an owner key to operate for every mint without protecting a correctly
+    /// wired consumer (a config-divergent proxy grants its minter no authority
+    /// over any instance a consumer was actually pointed at), and the
+    /// CREATE2 config-commitment means a published address is itself
+    /// verifiable against its claimed config.
     /// @param oracle The address of the new proxy. Indexed for filtering.
     event Deployment(address indexed caller, address indexed oracle);
 

--- a/src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.sol
+++ b/src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.sol
@@ -50,6 +50,23 @@ contract ST0xPriceOracleBeaconSetDeployer {
     /// `initializer`-guarded and sits behind the governance-owned beacon, so it
     /// grants the front-runner no authority — it only reverts the operator's own
     /// later mint on the CREATE2 collision.
+    ///
+    /// The COMPLEMENTARY case is a mint with a DIFFERENT,
+    /// attacker-chosen config: equally permissionless, equally behind the
+    /// governance-owned beacon, and equally announced by this event from the
+    /// official deployer. NEITHER beacon membership NOR a `Deployment` event
+    /// therefore authenticates an instance — for `ST0xPriceOracle` an
+    /// arbitrary config means the attacker holds both admin roles and the
+    /// publisher key on that instance.
+    /// The ONLY authenticity signal is the published deployment address list
+    /// (the CI-authored deploy artifacts): consumers MUST be wired from that
+    /// list and must never discover instances by scanning events or beacon
+    /// membership. Minting stays permissionless on purpose — a gate would add
+    /// an owner key to operate for every mint without protecting a correctly
+    /// wired consumer (a config-divergent proxy grants its minter no authority
+    /// over any instance a consumer was actually pointed at), and the
+    /// CREATE2 config-commitment means a published address is itself
+    /// verifiable against its claimed config.
     /// @param oracle The address of the new proxy. Indexed for filtering.
     event Deployment(address indexed caller, address indexed oracle);
 

--- a/test/src/concrete/deploy/DIAVaultOracleBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/DIAVaultOracleBeaconSetDeployer.t.sol
@@ -139,6 +139,36 @@ contract DIAVaultOracleBeaconSetDeployerTest is Test {
         assertTrue(found, "Deployment event not emitted");
     }
 
+    /// @notice Minting is PERMISSIONLESS with a config-only CREATE2 salt: an
+    /// arbitrary caller can mint an arbitrary-config proxy — here an
+    /// attacker-chosen DIA feed and vault, which fully determine the served
+    /// price — behind the same governance-owned beacon, announced by the same
+    /// `Deployment` event as an official mint. Deliberate (see the
+    /// `Deployment` NatSpec): neither beacon membership nor the event
+    /// authenticates an instance; the published address list does. If minting
+    /// is ever gated, flip this test together with that documentation.
+    function testRandoMintsArbitraryConfig() external {
+        DIAVaultOracleBeaconSetDeployer bsd = _deployBSD();
+
+        MockDIAOracle attackerFeed = new MockDIAOracle();
+        MockERC4626 attackerVault = new MockERC4626();
+        MockCorporateActions attackerActions = new MockCorporateActions();
+        attackerVault.setAsset(address(attackerActions));
+
+        DIAVaultOracleConfig memory config = _defaultOracleConfig();
+        config.diaOracle = IDIAOracleV2(address(attackerFeed));
+        config.vault = address(attackerVault);
+
+        address rando = address(0xBADD);
+        vm.expectEmit(true, false, false, false, address(bsd));
+        emit Deployment(rando, address(0));
+        vm.prank(rando);
+        DIAVaultOracle minted = bsd.newDIAVaultOracle(config);
+
+        assertEq(address(minted.diaOracle()), address(attackerFeed), "attacker feed stored");
+        assertEq(minted.vault(), address(attackerVault), "attacker vault stored");
+    }
+
     function testNewDIAVaultOraclePropagatesInitRevertZeroVault() external {
         DIAVaultOracleBeaconSetDeployer bsd = _deployBSD();
         DIAVaultOracleConfig memory badConfig = _defaultOracleConfig();

--- a/test/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.t.sol
@@ -144,6 +144,30 @@ contract MorphoPairAdapterBeaconSetDeployerTest is SignedPriceTestBase {
         assertTrue(found, "Deployment event not emitted");
     }
 
+    /// @notice Same permissionless-mint property: an arbitrary caller mints
+    /// an adapter for an attacker-chosen pair (and hence rescale) on the
+    /// shared central store. Deliberate (see the `Deployment` NatSpec) — the
+    /// published address list, not beacon membership or events, authenticates
+    /// an instance. If minting is ever gated, flip this test together with
+    /// that documentation.
+    function testRandoMintsArbitraryPair() external {
+        MorphoPairAdapterBeaconSetDeployer bsd = _deployBSD();
+
+        MockERC20Decimals attackerBase = new MockERC20Decimals(8);
+        MockERC20Decimals attackerQuote = new MockERC20Decimals(2);
+        address rando = address(0xBADD);
+        vm.expectEmit(true, false, false, false, address(bsd));
+        emit Deployment(rando, address(0));
+        vm.prank(rando);
+        MorphoPairAdapter minted = bsd.newMorphoPairAdapter(address(attackerBase), address(attackerQuote));
+
+        assertEq(minted.baseToken(), address(attackerBase), "attacker base stored");
+        assertEq(minted.quoteToken(), address(attackerQuote), "attacker quote stored");
+        assertEq(
+            minted.pairId(), central.pairId(address(attackerBase), address(attackerQuote)), "attacker pairId derived"
+        );
+    }
+
     /// @notice A reverting `initialize` (here identical tokens) bubbles straight
     /// up out of the proxy constructor.
     function testNewMorphoPairAdapterPropagatesInitRevert() external {

--- a/test/src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.t.sol
@@ -126,6 +126,27 @@ contract ST0xPriceOracleBeaconSetDeployerTest is Test {
         assertTrue(found, "Deployment event not emitted");
     }
 
+    /// @notice Same permissionless-mint property as the other deployers, with
+    /// the sharpest consequence: an arbitrary caller mints an instance where
+    /// the attacker holds BOTH admin roles and the publisher key. Deliberate
+    /// (see the `Deployment` NatSpec) — the published address list, not
+    /// beacon membership or events, authenticates an instance. If minting is
+    /// ever gated, flip this test together with that documentation.
+    function testRandoMintsArbitraryConfig() external {
+        ST0xPriceOracleBeaconSetDeployer bsd = _deployBSD();
+
+        address attacker = address(0xA77A);
+        address rando = address(0xBADD);
+        vm.expectEmit(true, false, false, false, address(bsd));
+        emit Deployment(rando, address(0));
+        vm.prank(rando);
+        ST0xPriceOracle minted = bsd.newST0xPriceOracle(attacker, attacker, attacker);
+
+        assertTrue(minted.hasRole(minted.DEFAULT_ADMIN_ROLE(), attacker), "attacker holds DEFAULT_ADMIN_ROLE");
+        assertTrue(minted.hasRole(minted.ORACLE_ADMIN_ROLE(), attacker), "attacker holds ORACLE_ADMIN_ROLE");
+        assertEq(minted.signer(), attacker, "attacker is the publisher key");
+    }
+
     /// @notice A reverting `initialize` (here a zero signer) bubbles straight up
     /// out of the proxy constructor — there is no magic-value check to swallow
     /// it, unlike the DIA stack's beacon-set deployer.


### PR DESCRIPTION
## Protofire L01 — permissionless proxy minting makes beacon membership and the `Deployment` event unusable as authenticity signals

All three mint entry points are permissionless with a config-only CREATE2 salt, so anyone can mint a proxy with an **arbitrary, attacker-chosen config** that is structurally indistinguishable from an official instance: same governance-owned beacon, same implementation, same `Deployment` event from the official deployer. The existing NatSpec covered only the config-identical front-run.

### The remedy: document, deliberately keep the mint permissionless

Gating was considered and declined: a gate adds an owner key that must operate for every mint without protecting a correctly-wired consumer — a config-divergent proxy grants its minter no authority over any instance a consumer was actually pointed at. What matters is that nobody treats beacon membership or `Deployment` events as authenticity, so that is now stated everywhere it could be mis-assumed:

- All three `Deployment` event NatSpecs document the arbitrary-config case with the per-contract consequence spelled out (DIA: attacker-controlled feed + vault fully determine the price; ST0x store: attacker holds both admin roles and the signer; Morpho adapter: attacker-chosen pair/rescale), and state that the **published (CI-authored) deployment address list is the only authenticity signal** — consumers are wired from it, never discovered by event or beacon scans. The CREATE2 config-commitment makes a published address verifiable against its claimed config.
- README gains the same integrator warning covering both stacks.

### `DIA_FEED_BASE` validation: declined, with rationale in the NatSpec

The report suggested validating `config.diaOracle` against `DIA_FEED_BASE`. That constant is **Base's** canonical feed address; this deployer ships to multiple chains where DIA lives at different addresses, so a hardcoded equality check would brick every non-Base deployment. Feed-address correctness belongs to the per-chain deploy tooling; the decline and its reasoning are recorded in `newDIAVaultOracle`'s NatSpec so the question doesn't recur.

### Gates

Docs-only; `forge test` green, slither 0 findings, `forge fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FTbsUf9TY7uEtBJETSViV
