### PR TITLE
test(dia): pin the pre-window pause end-to-end through the oracle reads

### DIFF
--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -382,6 +382,29 @@ contract DIAVaultOracleTest is Test {
         assertEq(oracle.latestAnswer(), 100e8, "prices normally outside the pause window");
     }
 
+    /// @notice PRE-window twin of `testAutoPauseRevertsInsideWindow`: a
+    /// PENDING action whose `effectiveTime` is within `pauseTimeBefore` of
+    /// now pauses BOTH read entry points. The pre-window predicate itself is
+    /// covered in LibCorporateActionsPause.t.sol; what this pins is the
+    /// ORACLE's wiring of `pauseTimeBefore` into that call — the interval the
+    /// zero-pre-window rejection exists to guard (the market's ex-date
+    /// revaluation precedes the on-chain `effectiveTime`).
+    function testAutoPauseRevertsInsidePreWindow() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        diaOracle.setValue(SYMBOL, 100e18, uint64(block.timestamp));
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+
+        // Pending split half a pre-window ahead → inside the pause window.
+        uint64 effectiveTime = uint64(block.timestamp + PAUSE_BEFORE / 2);
+        actions.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, effectiveTime);
+
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
+        oracle.latestAnswer();
+        vm.expectRevert(abi.encodeWithSelector(OraclePausedCorporateAction.selector, effectiveTime));
+        oracle.latestRoundData();
+    }
+
     // -------- ERC-7201 storage-layout pin (beacon-upgrade safety) --------
 
     /// @notice The `MainStorage` slot constant is a hardcoded hex literal with


### PR DESCRIPTION
Coverage follow-up for #302: a pending action inside `pauseTimeBefore` must pause both oracle read entry points end to end, not only the library predicate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789755043&installation_model_id=19370&pr_number=307&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F307&signature=f7a24efc14347140d3af979f95ee0d8a085d12680c2de65240ea773635ee7782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->