### PR TITLE
test(dia): pin the confiscation ratio drop as served, not gated

### DIFF
--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -709,6 +709,36 @@ contract DIAVaultOracleTest is Test {
         assertEq(roundAnswer, int256(200e8), "latestRoundData must agree with latestAnswer");
     }
 
+    /// @notice DOWNWARD twin of `testDonationMovesRatioAndIsServed`, pinning
+    /// the accepted risk the "Vault trust model" NatSpec documents: the same
+    /// raw-`balanceOf` `totalAssets()` also moves DOWN when the upstream
+    /// confiscation role seizes tStock from the wrapper — a bare transfer
+    /// that burns no shares and creates no corporate-action node, so no pause
+    /// window opens. The lower price is arithmetically CORRECT (the vault
+    /// genuinely backs fewer assets per share) and must be served straight
+    /// through. Any drift limit or ratio anchor added to the read path would
+    /// reject this jump and fail this test — that is deliberate: halting the
+    /// oracle stops liquidations while positions keep moving, which is worse
+    /// for a lending market than pricing the true NAV.
+    function testConfiscationDropsRatioAndIsServed() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        diaOracle.setValue(SYMBOL, 100e18, uint128(block.timestamp));
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+        assertEq(oracle.latestAnswer(), int256(100e8), "baseline 1 asset per share");
+
+        // A confiscation halves the vault's holdings against an unchanged
+        // supply — a bare transfer out mints and burns nothing.
+        vault.setTotalAssets(0.5e18);
+
+        // Served, not rejected, and priced at the true new ratio.
+        assertEq(oracle.latestAnswer(), int256(50e8), "confiscation must be priced through, not gated");
+
+        // The same read path through latestRoundData agrees.
+        (, int256 roundAnswer,,,) = oracle.latestRoundData();
+        assertEq(roundAnswer, int256(50e8), "latestRoundData must agree with latestAnswer");
+    }
+
     // -------- latestAnswer DIA not set --------
 
     function testLatestAnswerRevertsDIAPriceNotSet() external {


### PR DESCRIPTION
Coverage follow-up for #304: the downward twin of the donation test. A `totalAssets` drop is served straight through, unpaused, and this test fails if anyone later adds a drift gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789755202&installation_model_id=19370&pr_number=308&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F308&signature=37b41a37625609b4d47b159c6b8c3ebf04e8078d598afdef87186015d7f2efbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->