### PR TITLE
test(deploy): pin permissionless arbitrary-config minting on all three deployers

### DIFF
--- a/test/src/concrete/deploy/DIAVaultOracleBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/DIAVaultOracleBeaconSetDeployer.t.sol
@@ -139,6 +139,36 @@ contract DIAVaultOracleBeaconSetDeployerTest is Test {
         assertTrue(found, "Deployment event not emitted");
     }
 
+    /// @notice Minting is PERMISSIONLESS with a config-only CREATE2 salt: an
+    /// arbitrary caller can mint an arbitrary-config proxy — here an
+    /// attacker-chosen DIA feed and vault, which fully determine the served
+    /// price — behind the same governance-owned beacon, announced by the same
+    /// `Deployment` event as an official mint. Deliberate (see the
+    /// `Deployment` NatSpec): neither beacon membership nor the event
+    /// authenticates an instance; the published address list does. If minting
+    /// is ever gated, flip this test together with that documentation.
+    function testRandoMintsArbitraryConfig() external {
+        DIAVaultOracleBeaconSetDeployer bsd = _deployBSD();
+
+        MockDIAOracle attackerFeed = new MockDIAOracle();
+        MockERC4626 attackerVault = new MockERC4626();
+        MockCorporateActions attackerActions = new MockCorporateActions();
+        attackerVault.setAsset(address(attackerActions));
+
+        DIAVaultOracleConfig memory config = _defaultOracleConfig();
+        config.diaOracle = IDIAOracleV2(address(attackerFeed));
+        config.vault = address(attackerVault);
+
+        address rando = address(0xBADD);
+        vm.expectEmit(true, false, false, false, address(bsd));
+        emit Deployment(rando, address(0));
+        vm.prank(rando);
+        DIAVaultOracle minted = bsd.newDIAVaultOracle(config);
+
+        assertEq(address(minted.diaOracle()), address(attackerFeed), "attacker feed stored");
+        assertEq(minted.vault(), address(attackerVault), "attacker vault stored");
+    }
+
     function testNewDIAVaultOraclePropagatesInitRevertZeroVault() external {
         DIAVaultOracleBeaconSetDeployer bsd = _deployBSD();
         DIAVaultOracleConfig memory badConfig = _defaultOracleConfig();

--- a/test/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.t.sol
@@ -144,6 +144,30 @@ contract MorphoPairAdapterBeaconSetDeployerTest is SignedPriceTestBase {
         assertTrue(found, "Deployment event not emitted");
     }
 
+    /// @notice Same permissionless-mint property: an arbitrary caller mints
+    /// an adapter for an attacker-chosen pair (and hence rescale) on the
+    /// shared central store. Deliberate (see the `Deployment` NatSpec) — the
+    /// published address list, not beacon membership or events, authenticates
+    /// an instance. If minting is ever gated, flip this test together with
+    /// that documentation.
+    function testRandoMintsArbitraryPair() external {
+        MorphoPairAdapterBeaconSetDeployer bsd = _deployBSD();
+
+        MockERC20Decimals attackerBase = new MockERC20Decimals(8);
+        MockERC20Decimals attackerQuote = new MockERC20Decimals(2);
+        address rando = address(0xBADD);
+        vm.expectEmit(true, false, false, false, address(bsd));
+        emit Deployment(rando, address(0));
+        vm.prank(rando);
+        MorphoPairAdapter minted = bsd.newMorphoPairAdapter(address(attackerBase), address(attackerQuote));
+
+        assertEq(minted.baseToken(), address(attackerBase), "attacker base stored");
+        assertEq(minted.quoteToken(), address(attackerQuote), "attacker quote stored");
+        assertEq(
+            minted.pairId(), central.pairId(address(attackerBase), address(attackerQuote)), "attacker pairId derived"
+        );
+    }
+
     /// @notice A reverting `initialize` (here identical tokens) bubbles straight
     /// up out of the proxy constructor.
     function testNewMorphoPairAdapterPropagatesInitRevert() external {

--- a/test/src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.t.sol
@@ -126,6 +126,27 @@ contract ST0xPriceOracleBeaconSetDeployerTest is Test {
         assertTrue(found, "Deployment event not emitted");
     }
 
+    /// @notice Same permissionless-mint property as the other deployers, with
+    /// the sharpest consequence: an arbitrary caller mints an instance where
+    /// the attacker holds BOTH admin roles and the publisher key. Deliberate
+    /// (see the `Deployment` NatSpec) — the published address list, not
+    /// beacon membership or events, authenticates an instance. If minting is
+    /// ever gated, flip this test together with that documentation.
+    function testRandoMintsArbitraryConfig() external {
+        ST0xPriceOracleBeaconSetDeployer bsd = _deployBSD();
+
+        address attacker = address(0xA77A);
+        address rando = address(0xBADD);
+        vm.expectEmit(true, false, false, false, address(bsd));
+        emit Deployment(rando, address(0));
+        vm.prank(rando);
+        ST0xPriceOracle minted = bsd.newST0xPriceOracle(attacker, attacker, attacker);
+
+        assertTrue(minted.hasRole(minted.DEFAULT_ADMIN_ROLE(), attacker), "attacker holds DEFAULT_ADMIN_ROLE");
+        assertTrue(minted.hasRole(minted.ORACLE_ADMIN_ROLE(), attacker), "attacker holds ORACLE_ADMIN_ROLE");
+        assertEq(minted.signer(), attacker, "attacker is the publisher key");
+    }
+
     /// @notice A reverting `initialize` (here a zero signer) bubbles straight up
     /// out of the proxy constructor — there is no magic-value check to swallow
     /// it, unlike the DIA stack's beacon-set deployer.


### PR DESCRIPTION
Coverage follow-up for #305: a rando can mint an arbitrary-config proxy on every deployer. These tests pin the documented permissionless design and flip if minting is ever gated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789755317&installation_model_id=19370&pr_number=309&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F309&signature=b17e82625eeaba9865590f8c00172cc766c1df38f127be4bf5c11075e206bfb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->