### PR TITLE
ci: publish st0x-oracle to the soldeer registry on merge

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -1,0 +1,27 @@
+name: Package Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    # A LIBRARY repo on the rainix-autopublish next-version lifecycle:
+    # `[package].version` in foundry.toml is the next unpublished registry
+    # version; a content change on merge publishes it to soldeer, bumps the
+    # slot, tags `sol-v<version>` and cuts a GitHub release. Deploy repos use
+    # rainix-tag-release instead — this repo records no frozen deploy-pin
+    # snapshots, so it is not one.
+    #
+    # The reusable's job requests these scopes (it pushes the bump commit and
+    # tags); the caller must grant them or the run fails at startup.
+    permissions:
+      contents: write
+      id-token: write
+    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
+    with:
+      soldeer-package: st0x-oracle
+    # inherit, not an explicit list: CACHIX_AUTH_TOKEN is consumed by the
+    # reusable's nix-cachix-setup composite without being a declared
+    # workflow_call secret, so it only arrives via inherit. Publishing needs
+    # SOLDEER_API_TOKEN available to this repo (org or repo secret).
+    secrets: inherit

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,11 @@
+# Library-repo next-version lifecycle (rainix-autopublish): this is the NEXT,
+# unpublished registry version, one ahead of what is on soldeer. A content
+# change on merge to main publishes it and bumps this to the next; never bump
+# it by hand.
+[package]
+name = "st0x-oracle"
+version = "0.1.0"
+
 [profile.default]
 libs = ['dependencies']
 


### PR DESCRIPTION
## Publish st0x-oracle to the soldeer registry on merge

Downstream repos pin this repo as a soldeer **git-rev** dependency today because no registry package exists (no soldeer project, no tags, no publish workflow). This adopts the org's library lifecycle — `rainix-autopublish`, the counterpart to the tag-release lifecycle st0x-deploy uses — so consumers can pin `st0x-oracle = "x.y.z"`.

- `foundry.toml` gains the `[package]` block with the **next unpublished** version, `0.1.0` (matching the version label downstream git-rev pins already carry). On each content-changing merge to `main` the workflow publishes that version, bumps the slot, tags `sol-v<version>` and cuts a GitHub release.
- Caller uses `secrets: inherit` (the reusable consumes `CACHIX_AUTH_TOKEN` outside its declared `workflow_call` secrets, so an explicit list would drop it) and grants `contents: write` + `id-token: write` (the reusable's job requests both; an ungranted scope fails the run at startup).

### Before the first publish can succeed

1. **`SOLDEER_API_TOKEN` must be added to this repo or the ST0x-Technology org** — it currently exists only as an S01-Issuer org secret (where st0x.deploy publishes from). GitHub never exposes secret values, so this is a manual copy by someone with access to both.
2. If `forge soldeer push` does not auto-create projects, the `st0x-oracle` project may need creating on soldeer.xyz under the account that owns the token first.

Until those are done, the publish step of this workflow fails cleanly and can simply be re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FTbsUf9TY7uEtBJETSViV
