### PR TITLE
test(deploy): mutation-validated coverage for MorphoPairAdapter (part 2) + DIAVaultOracleBeaconSetDeployer

### DIFF
--- a/test/src/concrete/deploy/DIAVaultOracleBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/DIAVaultOracleBeaconSetDeployer.t.sol
@@ -82,6 +82,20 @@ contract DIAVaultOracleBeaconSetDeployerTest is Test {
         );
     }
 
+    /// @notice A config with BOTH fields zero reports `ZeroImplementation`:
+    /// the implementation guard is evaluated before the owner guard, so the
+    /// implementation — the field without which there is nothing to put behind
+    /// a beacon at all — is the one surfaced, rather than the operator being
+    /// walked through the guards one failed deploy at a time.
+    function testConstructorZeroImplementationPrecedesZeroBeaconOwner() external {
+        vm.expectRevert(ZeroImplementation.selector);
+        new DIAVaultOracleBeaconSetDeployer(
+            DIAVaultOracleBeaconSetDeployerConfig({
+                initialOwner: address(0), initialDIAVaultOracleImplementation: address(0)
+            })
+        );
+    }
+
     function testConstructorHappyPathDeploysBeacon() external {
         DIAVaultOracleBeaconSetDeployer bsd = _deployBSD();
         address beacon = address(bsd.iDIAVaultOracleBeacon());


### PR DESCRIPTION
Mutation-probing the existing suite across the `MorphoPairAdapter.price()` rescale/ratio-mismatch behaviours and all twelve `DIAVaultOracleBeaconSetDeployer` behaviours found the pre-existing tests already discriminating on every one except the constructor's guard ORDERING: with both `initialDIAVaultOracleImplementation` and `initialOwner` zero, nothing pinned which error surfaces, so swapping the two guards left the whole suite green.

This adds `testConstructorZeroImplementationPrecedesZeroBeaconOwner`, which pins the both-zero config to `ZeroImplementation` and matches the ordering the sibling `ST0xPriceOracleBeaconSetDeployer` uses. No existing test was changed or weakened; 208 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789824513&installation_model_id=19370&pr_number=311&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F311&signature=6aa26892b27a04da7ebba0e769476176deb8b9667665094866a12fea5ec63a36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->