### PR TITLE
test(deploy): mutation-validated coverage for ST0xPriceOracleBeaconSetDeployer + MorphoPairAdapterBeaconSetDeployer

### DIFF
--- a/test/src/concrete/deploy/DeployerSaltDerivation.t.sol
+++ b/test/src/concrete/deploy/DeployerSaltDerivation.t.sol
@@ -49,6 +49,13 @@ contract DeployerSaltDerivationTest is Test {
     /// @notice Morpho salt MUST be keccak256(abi.encode(base, quote)). If the
     /// deployer drops `quote` (or otherwise changes the salt args), the deployed
     /// address will not match this independent prediction.
+    ///
+    /// The salt is also ORDER-SENSITIVE: `(base, quote)` and `(quote, base)` are
+    /// different markets (the rescale exponent inverts) and must therefore hash
+    /// to different salts. A salt that canonicalised the pair — sorting the two
+    /// addresses, say — would put one of the two mints at an address that is not
+    /// a commitment to its own argument order, so both orders are predicted
+    /// independently here.
     function testMorphoSaltIsKeccakBaseQuote() external {
         ST0xPriceOracle central;
         {
@@ -77,6 +84,20 @@ contract DeployerSaltDerivationTest is Test {
 
         MorphoPairAdapter adapter = bsd.newMorphoPairAdapter(address(base), address(quote));
         assertEq(address(adapter), predicted, "Morpho proxy must land at keccak256(base,quote) CREATE2 address");
+
+        // The same two tokens in the reversed roles is a DIFFERENT market and
+        // must land at keccak256(quote,base) — its own independent commitment.
+        address predictedReversed = _predict(
+            address(bsd),
+            keccak256(abi.encode(address(quote), address(base))),
+            address(bsd.iMorphoPairAdapterBeacon()),
+            abi.encodeCall(MorphoPairAdapter.initialize, (address(quote), address(base)))
+        );
+        MorphoPairAdapter reversed = bsd.newMorphoPairAdapter(address(quote), address(base));
+        assertEq(
+            address(reversed), predictedReversed, "reversed pair must land at keccak256(quote,base) CREATE2 address"
+        );
+        assertTrue(address(reversed) != address(adapter), "reversed pair is a distinct adapter");
     }
 
     /// @notice ST0x salt MUST be keccak256(abi.encode(admin, oracleAdmin,

--- a/test/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/MorphoPairAdapterBeaconSetDeployer.t.sol
@@ -68,6 +68,18 @@ contract MorphoPairAdapterBeaconSetDeployerTest is SignedPriceTestBase {
         );
     }
 
+    /// @notice Zero owner AND zero central together: the owner check runs
+    /// BEFORE the implementation is constructed, so the reported error is
+    /// `ZeroBeaconOwner`, not `ZeroCentral`. The cheap local guard fails first
+    /// rather than paying for an implementation deployment that is about to
+    /// revert anyway.
+    function testConstructorReportsZeroBeaconOwnerBeforeZeroCentral() external {
+        vm.expectRevert(ZeroBeaconOwner.selector);
+        new MorphoPairAdapterBeaconSetDeployer(
+            MorphoPairAdapterBeaconSetDeployerConfig({initialOwner: address(0), central: ST0xPriceOracle(address(0))})
+        );
+    }
+
     function testConstructorHappyPathDeploysBeacon() external {
         MorphoPairAdapterBeaconSetDeployer bsd = _deployBSD();
         address beacon = address(bsd.iMorphoPairAdapterBeacon());

--- a/test/src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/ST0xPriceOracleBeaconSetDeployer.t.sol
@@ -62,6 +62,19 @@ contract ST0xPriceOracleBeaconSetDeployerTest is Test {
         );
     }
 
+    /// @notice Both config fields zero: the implementation check runs FIRST, so
+    /// the reported error is `ZeroImplementation` and the owner check is never
+    /// reached. Matches the sibling DIA beacon-set deployer, so a misconfigured
+    /// deploy always names the implementation slot first across the family.
+    function testConstructorReportsZeroImplementationBeforeZeroBeaconOwner() external {
+        vm.expectRevert(ZeroImplementation.selector);
+        new ST0xPriceOracleBeaconSetDeployer(
+            ST0xPriceOracleBeaconSetDeployerConfig({
+                initialOwner: address(0), initialST0xPriceOracleImplementation: address(0)
+            })
+        );
+    }
+
     function testConstructorHappyPathDeploysBeacon() external {
         ST0xPriceOracleBeaconSetDeployer bsd = _deployBSD();
         address beacon = address(bsd.iST0xPriceOracleBeacon());
@@ -154,6 +167,27 @@ contract ST0xPriceOracleBeaconSetDeployerTest is Test {
         ST0xPriceOracleBeaconSetDeployer bsd = _deployBSD();
         vm.expectRevert(ST0xPriceOracle.ZeroSigner.selector);
         bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, address(0));
+    }
+
+    /// @notice `admin` and `oracleAdmin` are equally non-optional. A zero in
+    /// EITHER slot bubbles `ZeroAdmin` out of the proxy constructor, so the
+    /// deployer can never mint an oracle whose `DEFAULT_ADMIN_ROLE` or
+    /// `ORACLE_ADMIN_ROLE` is unassigned — the deployer must not substitute a
+    /// default (e.g. the caller) for a missing admin.
+    function testNewST0xPriceOraclePropagatesInitRevertZeroAdmin() external {
+        ST0xPriceOracleBeaconSetDeployer bsd = _deployBSD();
+
+        vm.expectRevert(ST0xPriceOracle.ZeroAdmin.selector);
+        bsd.newST0xPriceOracle(address(0), ORACLE_ADMIN, SIGNER);
+
+        vm.expectRevert(ST0xPriceOracle.ZeroAdmin.selector);
+        bsd.newST0xPriceOracle(ADMIN, address(0), SIGNER);
+
+        // Neither reverted mint left an instance behind — a well-formed mint
+        // still lands, and it holds the roles the caller actually asked for.
+        ST0xPriceOracle oracle = bsd.newST0xPriceOracle(ADMIN, ORACLE_ADMIN, SIGNER);
+        assertTrue(oracle.hasRole(oracle.DEFAULT_ADMIN_ROLE(), ADMIN), "admin has default admin role");
+        assertFalse(oracle.hasRole(oracle.DEFAULT_ADMIN_ROLE(), address(this)), "caller is not a default admin");
     }
 
     /// @notice The beacon is genuinely SHARED: deploy two singletons with


### PR DESCRIPTION
Mutation-probed all 24 assigned behaviours across the two beacon-set deployers; 20 were already killed by the existing suite and 4 survived. Newly pinned: the constructor validation precedence in both deployers (ST0x reports `ZeroImplementation` ahead of `ZeroBeaconOwner` when both config fields are zero, matching the sibling DIA deployer; Morpho reports `ZeroBeaconOwner` before paying to construct an implementation that would revert `ZeroCentral`), and the `ZeroAdmin` propagation path for a zero `admin` or `oracleAdmin`, which previously only had the `ZeroSigner` case. `testMorphoSaltIsKeccakBaseQuote` was strengthened in place to independently predict the reversed `(quote, base)` CREATE2 address, so a salt that canonicalised the pair by sorting can no longer pass. All 24 mutants are now killed and the suite is green at 210 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789824575&installation_model_id=19370&pr_number=312&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F312&signature=bf0b709862263959f04daffae2a163ca31384a71a92ad87e32c3c37e7da0b2c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->