### PR TITLE
test(oracle): mutation-validated coverage for ST0xPriceOracle (part 1)

### DIFF
--- a/test/src/concrete/oracle/ST0xPriceOracle.t.sol
+++ b/test/src/concrete/oracle/ST0xPriceOracle.t.sol
@@ -119,6 +119,31 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, ORACLE_ADMIN, address(0))));
     }
 
+    /// @notice The zero-address guards are ORDERED: the `ZeroAdmin`
+    /// disjunction runs first, so a call carrying both a zero admin argument
+    /// and a zero `signer_` surfaces `ZeroAdmin` — the arguments are validated
+    /// in the order the signature declares them, and the first offending one
+    /// is what the caller is told about. Neither single-zero case above
+    /// distinguishes the ordering (each leaves the other argument valid), so
+    /// the two guards could swap and every other initialize test would still
+    /// pass while a caller with two bad arguments was pointed at the wrong
+    /// one. Both disjuncts are pinned: a zero `admin` and a zero `oracleAdmin`
+    /// each take precedence over the zero signer.
+    function test_Initialize_ZeroAdminTakesPrecedenceOverZeroSigner() public {
+        ST0xPriceOracle impl = new ST0xPriceOracle();
+        UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
+
+        vm.expectRevert(ST0xPriceOracle.ZeroAdmin.selector);
+        new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (address(0), ORACLE_ADMIN, address(0))));
+
+        vm.expectRevert(ST0xPriceOracle.ZeroAdmin.selector);
+        new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (ADMIN, address(0), address(0))));
+
+        // All three zero: still ZeroAdmin.
+        vm.expectRevert(ST0xPriceOracle.ZeroAdmin.selector);
+        new BeaconProxy(address(b), abi.encodeCall(ST0xPriceOracle.initialize, (address(0), address(0), address(0))));
+    }
+
     function test_Initialize_OnlyOnce() public {
         vm.expectRevert(Initializable.InvalidInitialization.selector);
         oracle.initialize(RANDO, ORACLE_ADMIN, SIGNER);


### PR DESCRIPTION
Mutation-probed 26 behaviours of `ST0xPriceOracle` — constructor initializer-disabling, `initialize` validation/role grants/event, the `ORACLE_ADMIN_ROLE` / `MAX_VALIDITY_WINDOW` / `PRICE_UPDATE_TYPEHASH` / `DOMAIN_SEPARATOR` constant pins, `setSigner`, `pairId` ordering, and the `updatePrice` stale-no-op and EIP-712 recovery path. 24 of 26 mutants were already killed by the existing suite; no existing test needed strengthening.

This adds one new test, `test_Initialize_ZeroAdminTakesPrecedenceOverZeroSigner`, pinning that the `ZeroAdmin` disjunction is evaluated before the `ZeroSigner` guard. The existing single-zero tests each leave the other argument valid, so swapping the two guards passed the whole suite while reporting the wrong offending argument to a caller. The one remaining survivor (dropping the `__AccessControl_init()` call) is semantically equivalent under OpenZeppelin 5.6.1, where that function's body is empty, so no test can distinguish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789824592&installation_model_id=19370&pr_number=313&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F313&signature=3e10a65e69e7c6fdf97e89389de10f4e577ae534da1c1766ec9621c1498afa1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->