### PR TITLE
test(oracle): mutation-validated coverage for DIAVaultOracle (part 3)

### DIFF
--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -671,6 +671,39 @@ contract DIAVaultOracleTest is Test {
         assertEq(answer, int256(200e8));
     }
 
+    /// @notice The DIA read keys off the symbol held in THIS oracle's storage,
+    /// so two oracles sharing one DIA feed contract price different equities.
+    /// Every other test configures the same symbol, so none of them can tell a
+    /// storage read from a constant that happens to match it — and a mispriced
+    /// feed key is silent: it returns a well-formed answer for the wrong stock.
+    ///
+    /// Same DIA contract, same vault ratio (1 asset per share), two symbols at
+    /// deliberately different prices: each oracle must report its own.
+    function testLatestAnswerReadsConfiguredSymbolFeed() external {
+        DIAVaultOracleConfig memory otherConfig = _defaultConfig();
+        otherConfig.symbol = "AMZN";
+
+        DIAVaultOracle coinOracle = _deployProxy(_defaultConfig());
+        DIAVaultOracle amznOracle = _deployProxy(otherConfig);
+
+        diaOracle.setValue(SYMBOL, 100e18, uint128(block.timestamp));
+        diaOracle.setValue("AMZN", 250e18, uint128(block.timestamp));
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+
+        assertEq(coinOracle.latestAnswer(), int256(100e8), "COIN oracle must serve the COIN feed");
+        assertEq(amznOracle.latestAnswer(), int256(250e8), "AMZN oracle must serve the AMZN feed");
+
+        // A symbol that was never pushed stays unset even while its siblings
+        // are populated — the read does not fall back to another key.
+        DIAVaultOracleConfig memory unpushedConfig = _defaultConfig();
+        unpushedConfig.symbol = "TSLA";
+        DIAVaultOracle tslaOracle = _deployProxy(unpushedConfig);
+
+        vm.expectRevert(DIAPriceNotSet.selector);
+        tslaOracle.latestAnswer();
+    }
+
     /// @notice A share price that is not exactly representable at 8 decimals is
     /// TRUNCATED toward zero, never rounded up. Expected value derived from the
     /// spec, not from the implementation: `vaultSharePrice = diaPrice *
@@ -694,6 +727,34 @@ contract DIAVaultOracleTest is Test {
         // The same read path through latestRoundData agrees on the direction.
         (, int256 roundAnswer,,,) = oracle.latestRoundData();
         assertEq(roundAnswer, int256(33333333), "latestRoundData must truncate identically");
+    }
+
+    /// @notice The share price is `diaPrice * totalAssets / totalSupply` —
+    /// the multiplication happens BEFORE the division, so a ratio whose
+    /// intermediate quotient is non-terminating still resolves exactly when
+    /// the product is divisible by the supply. Order of operations is the
+    /// assertion, not the magnitude.
+    ///
+    /// `$3` against a vault holding `1e18` assets over `3e18` shares is
+    /// exactly `$1.00000000`: the product `3 * 1e18` divides `3e18` cleanly.
+    /// Dividing first would evaluate `1e18 / 3e18` to a truncated
+    /// `0.333...3` and multiply the lost tail back up to `$0.99999999` — a
+    /// one-unit under-report of a price that is exactly representable at 8
+    /// decimals. Every existing happy-path case divides evenly either way,
+    /// so none of them can see the ordering.
+    function testLatestAnswerMultipliesBeforeDividing() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        // DIA: $3 at 18dp.
+        diaOracle.setValue(SYMBOL, 3e18, uint128(block.timestamp));
+        // Vault: 1/3 of an asset per share.
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(3e18);
+
+        assertEq(oracle.latestAnswer(), int256(1e8), "3 * 1e18 / 3e18 must be exactly $1 at 8dp");
+
+        // The same read path through latestRoundData agrees exactly.
+        (, int256 roundAnswer,,,) = oracle.latestRoundData();
+        assertEq(roundAnswer, int256(1e8), "latestRoundData must compute the price identically");
     }
 
     /// @notice Donations move the ratio and ARE served — the decided behaviour


### PR DESCRIPTION
Mutation-probed the `getRoundData`, `_validateNotPaused`, `_readDIAChecked` and `_vaultSharePrice` behaviours of `DIAVaultOracle` against the existing suite. Two gaps survived: nothing pinned that the DIA read keys off the symbol in *this* oracle's storage (the whole suite configures `"COIN"`, so a hardcoded constant was indistinguishable from a storage read), and nothing pinned that the share price multiplies before it divides (every happy path divides evenly either way, so an intermediate-quotient truncation was invisible).

`testLatestAnswerReadsConfiguredSymbolFeed` drives two oracles over one DIA contract at different symbols and prices and asserts each serves its own feed, plus that an unpushed symbol reverts `DIAPriceNotSet` rather than falling back to a populated sibling key. `testLatestAnswerMultipliesBeforeDividing` prices `$3` against a `1e18 / 3e18` vault and asserts exactly `$1.00000000`, which a divide-first implementation would under-report as `$0.99999999`.

No existing tests were changed — every other probed behaviour (the round-id echo, the pause-window argument order and its `effectiveTime`, both `DIAPriceNotSet` disjuncts, the fail-closed staleness edge, and the zero-supply / zero-price / 8-decimal / overflow guards) was already killed by tests in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789824662&installation_model_id=19370&pr_number=314&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F314&signature=13f6bf23c6ae4f31c6e2dc8cb17a98cca322ca825ce2737d600d264e849719d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->