### PR TITLE
test(adapter): mutation-validated coverage for MorphoPairAdapter (part 1)

### DIFF
--- a/test/mocks/MockMalformedNavVaultToken.sol
+++ b/test/mocks/MockMalformedNavVaultToken.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @title MockMalformedNavVaultToken
+/// @notice A collateral stub whose `convertToAssets` SUCCEEDS but returns a
+/// caller-chosen number of bytes instead of the single 32-byte word ERC-4626
+/// mandates.
+///
+/// Neither `MockNavVaultToken` (a well-behaved word) nor
+/// `MockRevertingNavVaultToken` (a failed call) can express this arm of the
+/// adapter's fail-closed NAV probe: a call that reports success while saying
+/// nothing (empty returndata, e.g. a token with a permissive fallback) or
+/// saying too much (an over-long return whose leading word merely looks like
+/// a ratio). Both are unverifiable, not usable.
+///
+/// `decimals()` exists only so the adapter's `initialize` can precompute its
+/// scale; the rest of the ERC-4626 / ERC-20 surface is intentionally absent.
+contract MockMalformedNavVaultToken {
+    uint256 private _returnLength;
+    uint256 private _returnWord;
+
+    function decimals() external pure returns (uint8) {
+        return 18;
+    }
+
+    /// @param returnLength How many bytes the probe returns. At most 64 — the
+    /// scratch space the return is served from.
+    /// @param returnWord The word both returned slots carry.
+    function setProbeReturn(uint256 returnLength, uint256 returnWord) external {
+        require(returnLength <= 64, "return must fit scratch space");
+        _returnLength = returnLength;
+        _returnWord = returnWord;
+    }
+
+    /// @dev No declared return type: the probe is a low-level staticcall, so
+    /// only the raw success flag and returndata matter.
+    function convertToAssets(uint256) external view {
+        uint256 length = _returnLength;
+        uint256 word = _returnWord;
+        assembly ("memory-safe") {
+            mstore(0x00, word)
+            mstore(0x20, word)
+            return(0x00, length)
+        }
+    }
+}

--- a/test/mocks/MockWordRevertingNavVaultToken.sol
+++ b/test/mocks/MockWordRevertingNavVaultToken.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @title MockWordRevertingNavVaultToken
+/// @notice A collateral stub whose `convertToAssets` REVERTS but leaves
+/// exactly one 32-byte word in returndata — the same shape a successful
+/// `convertToAssets` produces.
+///
+/// `MockRevertingNavVaultToken` reverts with a plain `Error(string)`, whose
+/// returndata is far longer than a word, so it cannot distinguish a probe
+/// that keys off the call's success flag from one that keys off the returned
+/// data's shape. This stub can: the word it reverts with is caller-chosen, so
+/// a test can make it the very ratio the stored price was computed against.
+/// Anything that reads returndata without honouring the failure would decode
+/// a "matching" ratio out of a call that never succeeded.
+///
+/// `decimals()` exists only so the adapter's `initialize` can precompute its
+/// scale; the rest of the ERC-4626 / ERC-20 surface is intentionally absent.
+contract MockWordRevertingNavVaultToken {
+    uint256 private _revertWord;
+
+    function decimals() external pure returns (uint8) {
+        return 18;
+    }
+
+    function setRevertWord(uint256 v) external {
+        _revertWord = v;
+    }
+
+    /// @dev No declared return type: the probe is a low-level staticcall, so
+    /// only the raw success flag and returndata matter.
+    function convertToAssets(uint256) external view {
+        uint256 word = _revertWord;
+        assembly ("memory-safe") {
+            mstore(0x00, word)
+            revert(0x00, 0x20)
+        }
+    }
+}

--- a/test/src/concrete/adapter/MorphoPairAdapter.t.sol
+++ b/test/src/concrete/adapter/MorphoPairAdapter.t.sol
@@ -24,6 +24,8 @@ import {MorphoPairAdapterV2} from "../../../mocks/MorphoPairAdapterV2.sol";
 import {MockERC20Decimals} from "../../../mocks/MockERC20Decimals.sol";
 import {MockNavVaultToken} from "../../../mocks/MockNavVaultToken.sol";
 import {MockRevertingNavVaultToken} from "../../../mocks/MockRevertingNavVaultToken.sol";
+import {MockWordRevertingNavVaultToken} from "../../../mocks/MockWordRevertingNavVaultToken.sol";
+import {MockMalformedNavVaultToken} from "../../../mocks/MockMalformedNavVaultToken.sol";
 
 /// @title MorphoPairAdapterTest
 /// @notice Unit coverage for the `MorphoPairAdapter` beacon-proxied adapter:
@@ -119,6 +121,16 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
     function test_MorphoPairAdapter_IdenticalTokens_Reverts() public {
         vm.expectRevert(IdenticalTokens.selector);
         _deployAdapter(address(base), address(base));
+    }
+
+    /// @notice A zero base that is ALSO equal to a zero quote satisfies both
+    /// init guards at once. The zero-address guard is the one that reports, so
+    /// the operator is told the tokens are unset — the actionable fault —
+    /// rather than that the two unset tokens are "identical". Pins the guard
+    /// order the `initialize` NatSpec states.
+    function test_MorphoPairAdapter_BothTokensZero_ReportsZeroToken() public {
+        vm.expectRevert(ZeroToken.selector);
+        _deployAdapter(address(0), address(0));
     }
 
     /// @notice Fail-closed at init: a quote (loan) token with absurdly large
@@ -359,6 +371,46 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
         MorphoPairAdapter adapter = _deployAdapter(address(vaultBase), address(quote));
         bytes32 id = oracle.pairId(address(vaultBase), address(quote));
         _push(id, 42e18, block.timestamp, block.timestamp + DEFAULT_VALIDITY, 1.05e18);
+        vm.expectRevert(abi.encodeWithSelector(UnverifiableRatio.selector, address(vaultBase), uint256(1.05e18)));
+        adapter.price();
+    }
+
+    /// @notice A probe that REVERTS while leaving exactly one 32-byte word in
+    /// returndata — the shape of a successful `convertToAssets` — is still an
+    /// unverifiable probe. The call's success flag decides, not the shape of
+    /// what came back: here the reverted word is the stored ratio itself, so
+    /// reading it as data would produce a "matching" ratio out of a call that
+    /// never succeeded and serve a price against a NAV the vault never
+    /// reported. Fails closed with `UnverifiableRatio` instead.
+    function test_MorphoPairAdapter_ProbeRevertsWithWordSizedData_FailsClosed() public {
+        MockWordRevertingNavVaultToken vaultBase = new MockWordRevertingNavVaultToken();
+        vaultBase.setRevertWord(1.05e18);
+        MorphoPairAdapter adapter = _deployAdapter(address(vaultBase), address(quote));
+        bytes32 id = oracle.pairId(address(vaultBase), address(quote));
+        _push(id, 42e18, block.timestamp, block.timestamp + DEFAULT_VALIDITY, 1.05e18);
+
+        vm.expectRevert(abi.encodeWithSelector(UnverifiableRatio.selector, address(vaultBase), uint256(1.05e18)));
+        adapter.price();
+    }
+
+    /// @notice A probe that SUCCEEDS but does not return the single 32-byte
+    /// word ERC-4626 mandates carries no ratio the adapter can verify, so it
+    /// fails closed too. Both malformations are covered: an empty return (the
+    /// call reports success while saying nothing) and an over-long return
+    /// whose leading word happens to equal the stored ratio (so a decode that
+    /// ignored the length would serve a price on the strength of returndata no
+    /// conforming vault produces).
+    function test_MorphoPairAdapter_ProbeReturnsMalformedData_FailsClosed() public {
+        MockMalformedNavVaultToken vaultBase = new MockMalformedNavVaultToken();
+        MorphoPairAdapter adapter = _deployAdapter(address(vaultBase), address(quote));
+        bytes32 id = oracle.pairId(address(vaultBase), address(quote));
+        _push(id, 42e18, block.timestamp, block.timestamp + DEFAULT_VALIDITY, 1.05e18);
+
+        vaultBase.setProbeReturn(0, 0);
+        vm.expectRevert(abi.encodeWithSelector(UnverifiableRatio.selector, address(vaultBase), uint256(1.05e18)));
+        adapter.price();
+
+        vaultBase.setProbeReturn(64, 1.05e18);
         vm.expectRevert(abi.encodeWithSelector(UnverifiableRatio.selector, address(vaultBase), uint256(1.05e18)));
         adapter.price();
     }


### PR DESCRIPTION
Mutation-probing the pre-existing suite against 26 constructor / `initialize` / getter / NAV-gate behaviours of `MorphoPairAdapter` left three gaps, now pinned. `test_MorphoPairAdapter_BothTokensZero_ReportsZeroToken` fixes the guard order in `initialize`, so a base and quote that are both zero report `ZeroToken` (the actionable fault) rather than `IdenticalTokens`. `test_MorphoPairAdapter_ProbeRevertsWithWordSizedData_FailsClosed` and `test_MorphoPairAdapter_ProbeReturnsMalformedData_FailsClosed` pin the two NAV-probe arms no existing mock could express — a probe that reverts while leaving exactly one word in returndata, and a probe that succeeds with an empty or over-long return — both of which must fail closed with `UnverifiableRatio`; each new mock supplies the stored ratio as its payload so a check that read returndata without honouring the success flag or the length would visibly serve a price.

No existing tests were changed; the other 23 behaviours were already killed by the suite as it stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789824675&installation_model_id=19370&pr_number=315&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F315&signature=a9086de3aa6bb6c02125d1176e3530c6705f00e681a3c123d0d669b593630008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->