### PR TITLE
test(oracle): mutation-validated coverage for DIAVaultOracle (part 2)

### DIFF
--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -619,6 +619,32 @@ contract DIAVaultOracleTest is Test {
         assertEq(oracle.latestAnswer(), 100e8, "action outside the configured mask must not pause");
     }
 
+    /// @notice The configured `actionTypeMask` is stored EXACTLY as supplied,
+    /// including bits the pause library later ignores. `ACTION_TYPE_INIT_V1` is
+    /// stripped when the library evaluates a MATCH (the bootstrap node is not a
+    /// real action), but that stripping belongs to the match, not to the stored
+    /// config: the getter and the `DIAVaultOracleInitialized` event are the two
+    /// records an integrator reconciles against each other, and a mask
+    /// normalised on the way into storage would make them disagree while the
+    /// pause behaviour looked unchanged. The default config's split-only mask
+    /// carries no INIT bit, so no other test can see this.
+    function testActionTypeMaskStoredVerbatimIncludingInitBit() external {
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.actionTypeMask = ACTION_TYPE_STOCK_SPLIT_V1 | ACTION_TYPE_INIT_V1;
+        DIAVaultOracle oracle = _deployProxy(config);
+        assertEq(
+            oracle.actionTypeMask(),
+            ACTION_TYPE_STOCK_SPLIT_V1 | ACTION_TYPE_INIT_V1,
+            "every configured mask bit must survive into storage"
+        );
+
+        // The wildcard mask — the documented "every present and future action
+        // type" setting — is likewise stored whole, INIT bit included.
+        DIAVaultOracleConfig memory wildcard = _defaultConfig();
+        wildcard.actionTypeMask = type(uint256).max;
+        assertEq(_deployProxy(wildcard).actionTypeMask(), type(uint256).max, "the wildcard mask must be stored whole");
+    }
+
     // -------- Typed overload reverts --------
 
     function testTypedInitializeAlwaysReverts() external {


### PR DESCRIPTION
Mutation-probed the 26 DIAVaultOracle behaviours covering `initialize` storage writes, the init event and return value, the ERC-7201 slot, every config getter, `description`/`decimals`/`version`, and the `latestAnswer` / `latestRoundData` read paths. All 26 targeted mutants were already killed by the existing suite, so no new coverage was needed there.

A sharper follow-up probe found one real gap: `initialize` storing a normalised `actionTypeMask` (INIT bit stripped) survived, because the default config's split-only mask carries no INIT bit. `testActionTypeMaskStoredVerbatimIncludingInitBit` newly pins that the mask reaches storage byte-for-byte, for both a `SPLIT | INIT` mask and the documented wildcard. No existing test was weakened or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789824735&installation_model_id=19370&pr_number=316&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F316&signature=1f3f9c589f47eb912e4c1523a794c62eb512b370438df2d2d34b7b442482c9df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->