### PR TITLE
fix(adapter): a vault collateral refuses the zero "no ratio" sentinel

### DIFF
--- a/src/concrete/adapter/MorphoPairAdapter.sol
+++ b/src/concrete/adapter/MorphoPairAdapter.sol
@@ -46,6 +46,17 @@ error RatioMismatch(uint256 storedRatio, uint256 liveRatio);
 /// @param storedRatio The ratio the central price was computed against.
 error UnverifiableRatio(address baseToken, uint256 storedRatio);
 
+/// @dev The collateral token probes as a live wt-vault but the stored central
+/// price carries the zero "no ratio" sentinel. A real NAV ratio is never
+/// zero, so a vault-collateral price without the ratio it was computed
+/// against is not a price — the sentinel is only for markets whose collateral
+/// is not a vault at all. The read fails closed until the publisher signs a
+/// ratio-carrying update; while it does, this market's pricing (health checks
+/// and liquidations alike) freezes, exactly as in the `RatioMismatch` case.
+/// @param baseToken The vault collateral whose price arrived without a ratio.
+/// @param liveRatio The vault's current `convertToAssets(NAV_RATIO_SHARES)`.
+error NavRatioMissing(address baseToken, uint256 liveRatio);
+
 /// @title MorphoPairAdapter
 /// @notice Beacon-proxied adapter binding one Morpho Blue market to one pair
 /// on the central `ST0xPriceOracle`, converting the central store's
@@ -81,15 +92,31 @@ error UnverifiableRatio(address baseToken, uint256 storedRatio);
 /// # The NAV-ratio gate
 ///
 /// The central store serves each price atomically with the vault NAV ratio
-/// it was computed against. When that ratio is non-zero the collateral token
-/// is a wt-vault, and `price()` asserts the vault's live
-/// `convertToAssets(NAV_RATIO_SHARES)` still EXACTLY equals the stored ratio
-/// before serving anything — a price whose ratio has drifted is no price,
-/// and Morpho has no way to consume a "slightly stale" one, so the read
-/// fails closed (see `price()` for the full posture, including the intended
-/// pricing freeze between a vault distribution and the publisher's next
-/// update). A zero stored ratio is the store's "no ratio" sentinel and skips
-/// the gate.
+/// it was computed against, ZERO being its "no ratio" sentinel. The store is
+/// an opaque carrier — it only sees pairIds and cannot know whether a pair's
+/// base is a vault — but this adapter CAN know: it holds the collateral
+/// token address. Every `price()` read therefore starts by probing
+/// `convertToAssets(NAV_RATIO_SHARES)` on the collateral to classify the
+/// market (one extra staticcall per read, paid deliberately so the gate is
+/// symmetric), then applies the full truth table:
+///
+///  - vault collateral, non-zero stored ratio → the live probe must EXACTLY
+///    equal the stored ratio (`RatioMismatch` otherwise);
+///  - vault collateral, ZERO stored ratio → `NavRatioMissing` — a real NAV
+///    ratio is never zero, so a vault price without its ratio is not a
+///    price;
+///  - non-vault collateral (probe fails), zero ratio → genuinely ratio-less
+///    market, priced normally;
+///  - non-vault collateral, non-zero ratio → `UnverifiableRatio` — the
+///    adapter never serves a price whose ratio it cannot verify.
+///
+/// Both revert quadrants freeze this market's pricing — health checks AND
+/// liquidations — until the publisher's next well-formed update: across a
+/// vault distribution (mismatch), or for as long as a vault market's
+/// publisher omits the ratio (missing). Intended fail-closed windows, not
+/// outages: Morpho has no way to consume a price the publisher priced
+/// against a NAV that no longer exists, or a vault price whose NAV binding
+/// was never published.
 ///
 /// Every market's adapter is a `BeaconProxy` over one shared
 /// `UpgradeableBeacon`, so a single beacon upgrade retargets all deployed
@@ -202,21 +229,21 @@ contract MorphoPairAdapter is Initializable, IOracle {
     /// Morpho Blue's `1e36 * 10^loanDec / 10^collDec` convention.
     /// @dev THE RATIO GATES THE PRICE. A price is only valid against the NAV
     /// ratio it was computed at; Morpho has no notion of "use it anyway,
-    /// slightly stale", so a stored ratio that no longer matches the live
-    /// vault means there is NO valid price and the only correct behaviour is
-    /// to revert. When the stored ratio is non-zero, the collateral token is
-    /// the wt-vault whose NAV the publisher priced against: the adapter
-    /// probes its live `convertToAssets(NAV_RATIO_SHARES)` and requires EXACT
-    /// equality (`RatioMismatch` otherwise). The ratio is piecewise-constant
-    /// — it steps only at vault distributions — so exact matching rejects
-    /// nothing in normal operation; from a distribution until the publisher's
-    /// next update this market's pricing (health checks AND liquidations)
-    /// reverts, which is the intended fail-closed window, not an outage. A
-    /// collateral token that cannot be probed for a live ratio while the
-    /// store carries a non-zero one fails closed too (`UnverifiableRatio`) —
-    /// the adapter never serves a price whose ratio it cannot verify. A ZERO
-    /// stored ratio is the store's "no ratio" sentinel (non-vault collateral):
-    /// no assertion is performed.
+    /// slightly stale", so the only correct behaviour outside the two valid
+    /// quadrants is to revert. The read first CLASSIFIES the collateral by
+    /// probing its live `convertToAssets(NAV_RATIO_SHARES)` — on EVERY read,
+    /// including the zero-ratio path, one extra staticcall paid deliberately
+    /// so vault-ness is established before the sentinel is trusted — then
+    /// applies the truth table (see the contract NatSpec, "The NAV-ratio
+    /// gate"): a probed vault requires a non-zero stored ratio
+    /// (`NavRatioMissing`) that EXACTLY equals the live one
+    /// (`RatioMismatch`); a non-vault collateral requires the zero sentinel
+    /// (`UnverifiableRatio` otherwise). The ratio is piecewise-constant — it
+    /// steps only at vault distributions — so exact matching rejects nothing
+    /// in normal operation; from a distribution (or a publisher omitting the
+    /// ratio on a vault market) until the next well-formed update this
+    /// market's pricing (health checks AND liquidations) reverts, which is
+    /// the intended fail-closed window, not an outage.
     /// @dev `Math.mulDiv` floors (rounds DOWN). This is deliberate and MUST NOT
     /// change: the result is the Morpho *collateral* price, and under-stating
     /// collateral is the conservative direction (less borrowing power, earlier
@@ -228,17 +255,19 @@ contract MorphoPairAdapter is Initializable, IOracle {
     function price() external view returns (uint256) {
         MainStorage storage $ = _main();
         (uint256 central, uint256 ratio) = iCentral.price($.pairId);
-        if (ratio != 0) {
-            address base = $.baseToken;
-            // Low-level staticcall rather than a typed call so EVERY probe
-            // failure — no code at the token, a reverting implementation, or
-            // malformed return data — lands in the same descriptive
-            // fail-closed revert instead of bubbling an opaque one.
-            // slither-disable-next-line low-level-calls
-            (bool ok, bytes memory data) = base.staticcall(abi.encodeCall(IERC4626.convertToAssets, (NAV_RATIO_SHARES)));
-            if (!ok || data.length != 32) revert UnverifiableRatio(base, ratio);
+        address base = $.baseToken;
+        // Low-level staticcall rather than a typed call so every probe
+        // failure — no code at the token, a reverting implementation, or
+        // malformed return data — uniformly classifies the collateral as
+        // not-a-vault instead of bubbling an opaque revert.
+        // slither-disable-next-line low-level-calls
+        (bool ok, bytes memory data) = base.staticcall(abi.encodeCall(IERC4626.convertToAssets, (NAV_RATIO_SHARES)));
+        if (ok && data.length == 32) {
             uint256 liveRatio = abi.decode(data, (uint256));
+            if (ratio == 0) revert NavRatioMissing(base, liveRatio);
             if (liveRatio != ratio) revert RatioMismatch(ratio, liveRatio);
+        } else if (ratio != 0) {
+            revert UnverifiableRatio(base, ratio);
         }
         uint256 scaled = Math.mulDiv(central, $.scaleNumerator, $.scaleDenominator);
         if (scaled == 0) revert PriceRoundsToZero(central);

--- a/test/src/concrete/adapter/MorphoPairAdapter.t.sol
+++ b/test/src/concrete/adapter/MorphoPairAdapter.t.sol
@@ -18,7 +18,8 @@ import {
     IdenticalTokens,
     PriceRoundsToZero,
     RatioMismatch,
-    UnverifiableRatio
+    UnverifiableRatio,
+    NavRatioMissing
 } from "../../../../src/concrete/adapter/MorphoPairAdapter.sol";
 import {MorphoPairAdapterV2} from "../../../mocks/MorphoPairAdapterV2.sol";
 import {MockERC20Decimals} from "../../../mocks/MockERC20Decimals.sol";
@@ -28,10 +29,11 @@ import {MockRevertingNavVaultToken} from "../../../mocks/MockRevertingNavVaultTo
 /// @title MorphoPairAdapterTest
 /// @notice Unit coverage for the `MorphoPairAdapter` beacon-proxied adapter:
 /// the publisher-scale → Morpho-convention rescale (known-answer), central
-/// expiry/unset passthrough, the NAV-ratio gate (exact live-vault match,
-/// fail-closed on drift or an unprobeable collateral, zero-ratio sentinel
-/// skip), constructor / initializer guards, and the shared beacon upgrade
-/// retargeting every deployed adapter proxy at once.
+/// expiry/unset passthrough, the NAV-ratio gate's full truth table (vault
+/// collateral: exact live-ratio match required and the zero sentinel
+/// refused; non-vault collateral: zero sentinel serves and a non-zero ratio
+/// fails closed), constructor / initializer guards, and the shared beacon
+/// upgrade retargeting every deployed adapter proxy at once.
 contract MorphoPairAdapterTest is SignedPriceTestBase {
     // SIGNER_PK / SIGNER are inherited from SignedPriceTestBase.
     address constant ADMIN = address(0xC0DE);
@@ -330,13 +332,28 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
         adapter.price();
     }
 
-    /// @notice A ZERO stored ratio is the central store's "no ratio" sentinel
-    /// (non-vault collateral): the gate is skipped entirely, so a collateral
-    /// token with no `convertToAssets` at all still prices normally.
-    function test_MorphoPairAdapter_ZeroRatio_SkipsGate() public {
+    /// @notice The zero "no ratio" sentinel is honoured ONLY for a collateral
+    /// that does not probe as a vault: a plain ERC-20 with no
+    /// `convertToAssets` classifies as non-vault and prices normally.
+    function test_MorphoPairAdapter_NonVaultCollateralZeroRatio_Serves() public {
         MorphoPairAdapter adapter = _deployAdapter(address(base), address(quote));
         _push(PAIR_A, 42e18, block.timestamp, block.timestamp + DEFAULT_VALIDITY, 0);
-        assertEq(adapter.price(), 42e24, "zero-ratio sentinel skips the vault probe");
+        assertEq(adapter.price(), 42e24, "non-vault market serves on the zero sentinel");
+    }
+
+    /// @notice A collateral that probes as a live wt-vault REFUSES the zero
+    /// sentinel: a real NAV ratio is never zero, so a vault price published
+    /// without its ratio is not a price. Fails closed with `NavRatioMissing`
+    /// until the publisher signs a ratio-carrying update — the same intended
+    /// pricing freeze (health checks and liquidations) as a ratio mismatch.
+    function test_MorphoPairAdapter_VaultCollateralZeroRatio_FailsClosed() public {
+        MockNavVaultToken vaultBase = new MockNavVaultToken(18);
+        vaultBase.setNavRatio(1.05e18);
+        MorphoPairAdapter adapter = _deployAdapter(address(vaultBase), address(quote));
+        bytes32 id = oracle.pairId(address(vaultBase), address(quote));
+        _push(id, 42e18, block.timestamp, block.timestamp + DEFAULT_VALIDITY, 0);
+        vm.expectRevert(abi.encodeWithSelector(NavRatioMissing.selector, address(vaultBase), uint256(1.05e18)));
+        adapter.price();
     }
 
     /// @notice A non-zero stored ratio for a collateral that cannot be probed
@@ -350,10 +367,9 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
         adapter.price();
     }
 
-    /// @notice A reverting `convertToAssets` implementation is the same
-    /// fail-closed `UnverifiableRatio`, not a bubbled opaque revert — pinned
-    /// via the mock's own probe-shares assertion by pointing the adapter at a
-    /// vault whose probe reverts.
+    /// @notice A reverting `convertToAssets` implementation classifies as
+    /// non-vault, so with a non-zero stored ratio it is the same fail-closed
+    /// `UnverifiableRatio`, not a bubbled opaque revert.
     function test_MorphoPairAdapter_RevertingProbeWithRatio_FailsClosed() public {
         MockRevertingNavVaultToken vaultBase = new MockRevertingNavVaultToken();
         MorphoPairAdapter adapter = _deployAdapter(address(vaultBase), address(quote));


### PR DESCRIPTION
## What

Makes `MorphoPairAdapter`'s NAV-ratio gate symmetric: a collateral that probes as a wt-vault now **refuses** the zero "no ratio" sentinel instead of skipping the assertion. Follow-up to #300, applying the rule now shared by every knowing consumer.

## Why

A real vault NAV ratio is never zero, so any consumer that can KNOW the target is a vault must reject a zero ratio rather than treat it as "no assertion needed". The adapter can know: it holds the collateral token address, and a successful `convertToAssets(NAV_RATIO_SHARES)` staticcall proves vault-ness. Only the central `ST0xPriceOracle` store — which sees nothing but pairIds — legitimately treats zero as an opaque sentinel, and it stays untouched.

## The truth table (as implemented)

Every `price()` read now classifies the collateral first (one extra staticcall per read, on the zero-ratio path too — deliberate), then:

| collateral probe | stored ratio | behaviour |
|---|---|---|
| vault | non-zero | exact live-ratio assert; drift → `RatioMismatch(storedRatio, liveRatio)` |
| vault | zero | **`NavRatioMissing(baseToken, liveRatio)`** — a vault price without its ratio is not a price |
| non-vault (probe fails) | zero | served normally |
| non-vault | non-zero | `UnverifiableRatio(baseToken, storedRatio)` |

**Intended consequence** (unchanged in kind from #300, extended to the new quadrant): a vault market whose publisher omits the ratio freezes — health checks *and liquidations* — until a ratio-carrying update lands. Fail-closed window, not an outage.

## Blast radius

- `ST0xPriceOracle` read/write surfaces unchanged — no shape change to `price` / `pairPrice` / `updatePrice`, so consumers pinning the oracle interface (e.g. `st0x.univ4.hook`) only need a soldeer repin, no interface edits.
- Morpho's own `IOracle.price()` signature on the adapter is unchanged.
- The DIA adapter path is untouched.

## Tests / gates

- New: vault collateral + zero ratio reverts `NavRatioMissing`; non-vault collateral still serves on the zero sentinel (renamed/re-documented from the old skip test).
- Full suite: **209 passing** (incl. the Base fork test). `forge fmt --check`, `slither` (0 results), `reuse lint`, single-contract check, suite-name-sync and soldeer-lock consistency all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQ3QV1QrwmaS7ACSf7cds7

Closes RAI-1750

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789824921&installation_model_id=19370&pr_number=318&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F318&signature=f7595ff88a36f51cb530b9a56d39186daa078cd2f588d7b0f9fe217de6498609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->