### PR TITLE
test(dia-vault-oracle): mutation-validated coverage for DIAVaultOracle (part 1)

### DIFF
--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -36,7 +36,12 @@ import {
 } from "../../../mocks/MockRevertingCorporateActions.sol";
 import {CorporateActionsListHarness} from "../../../mocks/CorporateActionsListHarness.sol";
 import {TestERC1967Proxy} from "../../../mocks/TestERC1967Proxy.sol";
-import {ACTION_TYPE_STOCK_SPLIT_V1, ACTION_TYPE_INIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
+import {
+    ICorporateActionsV1,
+    ACTION_TYPE_STOCK_SPLIT_V1,
+    ACTION_TYPE_INIT_V1
+} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
+import {CompletionFilter} from "st0x-deploy-0.1.1/src/lib/LibCorporateActionNode.sol";
 import {InvalidMask} from "st0x-deploy-0.1.1/src/error/ErrCorporateAction.sol";
 import {FixedDecimalOverflow} from "rain-math-float-0.1.1/src/error/ErrDecimalFloat.sol";
 
@@ -102,6 +107,24 @@ contract DIAVaultOracleTest is Test {
         MockERC4626 vaultNoAsset = new MockERC4626(); // asset() defaults to 0
         DIAVaultOracleConfig memory config = _defaultConfig();
         config.vault = address(vaultNoAsset);
+        DIAVaultOracle oracle = _deployUninit();
+        vm.expectRevert(ZeroCorporateActionsVault.selector);
+        oracle.initialize(abi.encode(config));
+    }
+
+    /// @notice The derived corporate-actions vault is checked BEFORE the
+    /// pause-config validation, so a config broken in BOTH ways — a vault
+    /// whose `asset()` is zero AND a pause config that is incoherent on every
+    /// count — reports the VAULT error. That is the root cause: the auto-pause
+    /// is wired to nothing, and an operator who "fixed" the mask and the
+    /// windows first would still be left with a silently disabled auto-pause.
+    function testInitReportsZeroCorporateActionsVaultBeforePauseConfig() external {
+        MockERC4626 vaultNoAsset = new MockERC4626(); // asset() defaults to 0
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.vault = address(vaultNoAsset);
+        config.actionTypeMask = 0;
+        config.pauseTimeBefore = 0;
+        config.pauseTimeAfter = 0;
         DIAVaultOracle oracle = _deployUninit();
         vm.expectRevert(ZeroCorporateActionsVault.selector);
         oracle.initialize(abi.encode(config));
@@ -329,6 +352,40 @@ contract DIAVaultOracleTest is Test {
         assertEq(ok.initialize(abi.encode(config)), ICLONEABLE_V2_SUCCESS, "valid mask must initialize");
     }
 
+    /// @notice The init probe hands each configured window to the side it
+    /// governs — `pauseTimeBefore` sizes the PENDING (pre-action) query,
+    /// `pauseTimeAfter` the COMPLETED (post-action) one. With a matching
+    /// pending action already inside the pre-window the probe is answered from
+    /// the pending side alone and the completed side is never consulted. A
+    /// probe that handed the windows over in the wrong order would size the
+    /// pre-window by the (much shorter) `pauseTimeAfter`, miss the pending
+    /// action and fall through to the completed query. The two windows are
+    /// deliberately far apart here so they are not interchangeable.
+    function testInitProbeAppliesPreWindowToThePendingSide() external {
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.maxAge = 1;
+        config.pauseTimeBefore = 1 hours;
+        // The tightest post-window the cross-epoch invariant allows.
+        config.pauseTimeAfter = 2;
+        // Pending split ten seconds out: inside the 1h pre-window, far outside
+        // the 2s post-window.
+        actions.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 10));
+
+        DIAVaultOracle oracle = _deployUninit();
+        vm.expectCall(
+            address(actions),
+            abi.encodeCall(
+                ICorporateActionsV1.latestActionOfType, (ACTION_TYPE_STOCK_SPLIT_V1, CompletionFilter.COMPLETED)
+            ),
+            0
+        );
+        assertEq(
+            oracle.initialize(abi.encode(config)),
+            ICLONEABLE_V2_SUCCESS,
+            "probe must resolve from the pending side alone"
+        );
+    }
+
     /// @notice Config fields are validated in DECLARATION order, so the FIRST
     /// offending field is the one reported. An integrator debugging a bad
     /// deploy config fixes one field at a time and expects the next error to
@@ -366,6 +423,29 @@ contract DIAVaultOracleTest is Test {
         config.pauseTimeAfter = 0;
         vm.expectRevert(InvalidPauseConfig.selector);
         oracle.initialize(abi.encode(config));
+
+        // The mask-coherence check leads the whole pause ladder, not just the
+        // relative invariant: with the mask incoherent AND the mandatory
+        // pre-window zero it is still `InvalidPauseConfig` that surfaces. An
+        // incoherent mask means the auto-pause never fires at all, so it must
+        // be named before any question of how long the windows are.
+        config.pauseTimeBefore = 0;
+        vm.expectRevert(InvalidPauseConfig.selector);
+        oracle.initialize(abi.encode(config));
+
+        // With the mask coherent the mandatory pre-window speaks next, ahead
+        // of the absolute window caps and the cross-epoch invariant.
+        config.actionTypeMask = ACTION_TYPE_STOCK_SPLIT_V1;
+        vm.expectRevert(ZeroPauseTimeBefore.selector);
+        oracle.initialize(abi.encode(config));
+
+        // Then the absolute pre-window cap, naming the offending value, still
+        // ahead of the relative invariant that the same config also violates.
+        config.pauseTimeBefore = uint64(30 days) + 1;
+        vm.expectRevert(abi.encodeWithSelector(PauseWindowTooLarge.selector, uint64(30 days) + 1));
+        oracle.initialize(abi.encode(config));
+
+        config.pauseTimeBefore = PAUSE_BEFORE;
 
         // ...and once the mask is coherent, the invariant check speaks.
         config.actionTypeMask = ACTION_TYPE_STOCK_SPLIT_V1;
@@ -637,6 +717,22 @@ contract DIAVaultOracleTest is Test {
         assertEq(oracle.decimals(), 8);
         assertEq(oracle.description(), SYMBOL);
         assertEq(oracle.version(), 1);
+    }
+
+    /// @notice The two absolute scale guards are part of the PUBLIC surface —
+    /// a deploy script or an integrator sizing a config reads them off the
+    /// contract rather than restating the numbers. Pin both the exposure and
+    /// the exact values, plus the documented relation between them:
+    /// `MAX_AGE_LIMIT` sits strictly below `MAX_PAUSE_WINDOW` so the
+    /// cross-epoch invariant (`pauseTimeAfter > maxAge`) stays satisfiable
+    /// even with `maxAge` at its cap.
+    function testScaleGuardConstantsAreExposedAndExact() external view {
+        assertEq(implementation.MAX_AGE_LIMIT(), 7 days, "MAX_AGE_LIMIT must be exactly 7 days");
+        assertEq(uint256(implementation.MAX_PAUSE_WINDOW()), 30 days, "MAX_PAUSE_WINDOW must be exactly 30 days");
+        assertTrue(
+            implementation.MAX_AGE_LIMIT() < uint256(implementation.MAX_PAUSE_WINDOW()),
+            "MAX_AGE_LIMIT must sit strictly below MAX_PAUSE_WINDOW"
+        );
     }
 
     /// @notice `description()` deliberately returns the BARE DIA feed symbol


### PR DESCRIPTION
Mutation probing of `DIAVaultOracle` initialization found four uncovered behaviours. Newly pinned: the derived corporate-actions vault is validated BEFORE the pause config (a config broken in both ways reports the vault error); the mask-coherence check leads the whole pause ladder, not just the cross-epoch invariant, and the absolute pre-window cap precedes that invariant; the init probe hands `pauseTimeBefore` to the pending side and `pauseTimeAfter` to the completed side, so a pending action inside the pre-window resolves without consulting the completed side; and `MAX_AGE_LIMIT`/`MAX_PAUSE_WINDOW` are asserted through their public getters at their exact values plus the documented ordering between them.

`testInitValidatesConfigFieldsInDeclarationOrder` was strengthened in place with three more rungs of the validation ladder (every existing assertion kept verbatim); `testInitReportsZeroCorporateActionsVaultBeforePauseConfig`, `testInitProbeAppliesPreWindowToThePendingSide` and `testScaleGuardConstantsAreExposedAndExact` are new. Test-only change: 210 tests pass, up from 207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789825059&installation_model_id=19370&pr_number=320&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F320&signature=49a81d19ac648ebc71fdcf53eccb99c563f86139ff657657ac0a2ffc56d6b1eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->