### PR TITLE
test(oracle): mutation-validated coverage for leftovers (part 1)

### DIFF
--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -241,7 +241,11 @@ contract DIAVaultOracleTest is Test {
 
     /// @notice Each pause window is individually capped at
     /// `MAX_PAUSE_WINDOW`, and the revert carries the offending value so an
-    /// operator can tell WHICH window was mis-scaled.
+    /// operator can tell WHICH window was mis-scaled. The two caps are applied
+    /// in DECLARATION order (pre-window first), so when BOTH windows are
+    /// mis-scaled the value named is the PRE-window's — the operator fixes the
+    /// first offending field and the next error advances to the second, rather
+    /// than the revert naming a value they have not reached yet.
     function testInitRevertsPauseWindowOverCap() external {
         DIAVaultOracleConfig memory config = _defaultConfig();
         config.pauseTimeBefore = uint64(30 days) + 1;
@@ -254,6 +258,22 @@ contract DIAVaultOracleTest is Test {
         DIAVaultOracle oracle2 = _deployUninit();
         vm.expectRevert(abi.encodeWithSelector(PauseWindowTooLarge.selector, uint64(30 days) + 1));
         oracle2.initialize(abi.encode(config2));
+
+        // Both windows over the cap, by DIFFERENT amounts so the reported
+        // value identifies which check fired: the pre-window's.
+        DIAVaultOracleConfig memory both = _defaultConfig();
+        both.pauseTimeBefore = uint64(30 days) + 1;
+        both.pauseTimeAfter = uint64(30 days) + 2;
+        DIAVaultOracle oracle3 = _deployUninit();
+        vm.expectRevert(abi.encodeWithSelector(PauseWindowTooLarge.selector, uint64(30 days) + 1));
+        oracle3.initialize(abi.encode(both));
+
+        // ...and once the pre-window is back in range the post-window's own
+        // value is what the next revert names.
+        both.pauseTimeBefore = PAUSE_BEFORE;
+        DIAVaultOracle oracle4 = _deployUninit();
+        vm.expectRevert(abi.encodeWithSelector(PauseWindowTooLarge.selector, uint64(30 days) + 2));
+        oracle4.initialize(abi.encode(both));
     }
 
     /// @notice Both pause windows exactly at `MAX_PAUSE_WINDOW` are accepted
@@ -439,18 +459,49 @@ contract DIAVaultOracleTest is Test {
         vm.expectRevert(ZeroPauseTimeBefore.selector);
         oracle.initialize(abi.encode(config));
 
-        // Then the absolute pre-window cap, naming the offending value, still
-        // ahead of the relative invariant that the same config also violates.
+        // Then the per-field ABSOLUTE window caps speak, naming the offending
+        // value, still ahead of the relative invariant that the same config
+        // ALSO violates (`pauseTimeAfter` is still 0). The absolute caps catch
+        // a wrong-units config that the scale-invariant relative check cannot
+        // see, so they are the more informative error and are checked first.
         config.pauseTimeBefore = uint64(30 days) + 1;
         vm.expectRevert(abi.encodeWithSelector(PauseWindowTooLarge.selector, uint64(30 days) + 1));
         oracle.initialize(abi.encode(config));
 
+        // ...and once both windows are within their caps, the cross-epoch
+        // invariant speaks last.
         config.pauseTimeBefore = PAUSE_BEFORE;
-
-        // ...and once the mask is coherent, the invariant check speaks.
-        config.actionTypeMask = ACTION_TYPE_STOCK_SPLIT_V1;
         vm.expectRevert(abi.encodeWithSelector(PauseTimeAfterBelowMaxAge.selector, uint256(0), MAX_AGE));
         oracle.initialize(abi.encode(config));
+    }
+
+    /// @notice `_validatePauseConfig` runs BEFORE the corporate-actions
+    /// reachability probe, so a config that is BOTH internally invalid AND
+    /// wired to an unreachable facet reports the LOCAL config error. The
+    /// operator's own config is what they can fix without touching the tStock,
+    /// and surfacing the upstream `CorporateActionsUnavailable` first would
+    /// send them auditing facet wiring instead of the zero window they
+    /// actually typed.
+    function testInitValidatesPauseConfigBeforeProbingVault() external {
+        MockRevertingCorporateActions broken = new MockRevertingCorporateActions();
+        MockERC4626 vaultBroken = new MockERC4626();
+        vaultBroken.setAsset(address(broken));
+
+        DIAVaultOracleConfig memory config = _defaultConfig();
+        config.vault = address(vaultBroken);
+        config.pauseTimeBefore = 0;
+
+        DIAVaultOracle oracle = _deployUninit();
+        vm.expectRevert(ZeroPauseTimeBefore.selector);
+        oracle.initialize(abi.encode(config));
+
+        // Positive control: with the pause config repaired, the SAME wiring
+        // reaches the probe and surfaces the facet failure — so the revert
+        // above is the ordering, not the probe being unreachable.
+        config.pauseTimeBefore = PAUSE_BEFORE;
+        DIAVaultOracle probed = _deployUninit();
+        vm.expectRevert(CorporateActionsUnavailable.selector);
+        probed.initialize(abi.encode(config));
     }
 
     /// @notice Inside a matching action's window, every price read reverts
@@ -758,6 +809,37 @@ contract DIAVaultOracleTest is Test {
         assertTrue(
             implementation.MAX_AGE_LIMIT() < uint256(implementation.MAX_PAUSE_WINDOW()),
             "MAX_AGE_LIMIT must sit strictly below MAX_PAUSE_WINDOW"
+        );
+    }
+
+    /// @notice Both absolute scale guards are PUBLIC constants: deploy tooling
+    /// and reviewers read them off a deployed oracle through the auto-generated
+    /// getters rather than re-deriving them from source, so the exposure is
+    /// part of the surface, not an implementation detail. Every other test
+    /// pins them only obliquely, through hardcoded literals at the init
+    /// boundaries.
+    ///
+    /// The RELATION between them is a documented invariant in its own right:
+    /// `MAX_AGE_LIMIT` sits STRICTLY below `MAX_PAUSE_WINDOW`, so the
+    /// cross-epoch requirement `pauseTimeAfter > maxAge` stays satisfiable even
+    /// with `maxAge` at its own cap. Raising the age limit to (or past) the
+    /// window cap would leave a `maxAge` an operator is allowed to configure
+    /// with no legal `pauseTimeAfter` above it.
+    ///
+    /// Distinct from `testScaleGuardConstantsAreExposedAndExact`, which reads
+    /// the same guards off the IMPLEMENTATION: this reads them through a
+    /// DEPLOYED PROXY, which is the surface integrators actually call, and
+    /// additionally pins each cap's exact value in seconds.
+    function testScaleGuardConstantsAreExposedAndExactThroughDeployedProxy() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        assertEq(oracle.MAX_AGE_LIMIT(), 7 days, "MAX_AGE_LIMIT must be exactly 7 days");
+        assertEq(oracle.MAX_AGE_LIMIT(), 604800, "7 days in seconds");
+        assertEq(uint256(oracle.MAX_PAUSE_WINDOW()), 30 days, "MAX_PAUSE_WINDOW must be exactly 30 days");
+        assertEq(uint256(oracle.MAX_PAUSE_WINDOW()), 2592000, "30 days in seconds");
+        assertLt(
+            oracle.MAX_AGE_LIMIT(),
+            uint256(oracle.MAX_PAUSE_WINDOW()),
+            "MAX_AGE_LIMIT must stay strictly below MAX_PAUSE_WINDOW"
         );
     }
 

--- a/test/src/concrete/oracle/ST0xPriceOracle.t.sol
+++ b/test/src/concrete/oracle/ST0xPriceOracle.t.sol
@@ -98,6 +98,31 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         assertEq(oracle.signer(), rotated, "oracle admin rotates config at once");
     }
 
+    /// @notice `initialize` never calls `_setRoleAdmin`, so `ORACLE_ADMIN_ROLE`
+    /// is administered by the AccessControl DEFAULT — `DEFAULT_ADMIN_ROLE`.
+    /// That is the whole authority `admin` holds ("role administration only"),
+    /// and it is what makes recovery from a lost oracle-admin key possible
+    /// without a redeploy. Self-administration (or any stricter admin) would
+    /// strand the role the moment its only holder is lost.
+    function test_Initialize_OracleAdminRoleIsAdministeredByDefaultAdmin() public {
+        assertEq(
+            oracle.getRoleAdmin(oracle.ORACLE_ADMIN_ROLE()),
+            oracle.DEFAULT_ADMIN_ROLE(),
+            "ORACLE_ADMIN_ROLE must be administered by DEFAULT_ADMIN_ROLE"
+        );
+        assertEq(oracle.DEFAULT_ADMIN_ROLE(), bytes32(0), "DEFAULT_ADMIN_ROLE is the zero role");
+
+        // And that admin authority is real: DEFAULT_ADMIN can grant
+        // ORACLE_ADMIN_ROLE to a fresh holder, who can then rotate the signer.
+        bytes32 oracleAdminRole = oracle.ORACLE_ADMIN_ROLE();
+        vm.prank(ADMIN);
+        oracle.grantRole(oracleAdminRole, RANDO);
+        address rotated = vm.addr(uint256(keccak256("granted-oracle-admin")));
+        vm.prank(RANDO);
+        oracle.setSigner(rotated);
+        assertEq(oracle.signer(), rotated, "newly granted oracle admin can rotate the signer");
+    }
+
     function test_Initialize_ZeroAdmin_Reverts() public {
         ST0xPriceOracle impl = new ST0xPriceOracle();
         UpgradeableBeacon b = new UpgradeableBeacon(address(impl), ADMIN);
@@ -581,6 +606,100 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         oracle.updatePrice(PAIR_A, 42e18, ts, tooLong, 0, abi.encodePacked(wr, ws, wv));
     }
 
+    /// @notice Signature-before-content for the validity-window cap: a payload
+    /// whose window exceeds `MAX_VALIDITY_WINDOW` and carries a WRONG-key
+    /// signature reverts `PriceUpdateInvalidSignature`, NOT
+    /// `ValidityWindowTooLong`. The window-cap selector names the payload's
+    /// timestamp and expiry, so leaking it for an unauthenticated payload would
+    /// both misreport an unsigned probe as a publisher-pipeline scale fault and
+    /// echo attacker-chosen values back through operator monitoring.
+    function test_UpdatePrice_WronglySignedOverlongWindow_RevertsInvalidSignatureNotWindowTooLong() public {
+        uint256 wrongPk = uint256(keccak256("wrong-signer"));
+        uint256 ts = block.timestamp;
+        uint256 tooLong = ts + oracle.MAX_VALIDITY_WINDOW() + 1;
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, digestFor(oracle, PAIR_A, 42e18, ts, tooLong));
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUpdateInvalidSignature.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 42e18, ts, tooLong, 0, abi.encodePacked(r, s, v));
+
+        // Positive control: the SAME payload signed by the real publisher does
+        // reach the cap check, so the revert above is the ordering and not the
+        // window being within range.
+        bytes memory signed = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, ts, tooLong);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.ValidityWindowTooLong.selector, PAIR_A, ts, tooLong));
+        oracle.updatePrice(PAIR_A, 42e18, ts, tooLong, 0, signed);
+    }
+
+    /// @notice Signature-before-content for the zero-price guard: a
+    /// zero-priced payload with a WRONG-key signature reverts
+    /// `PriceUpdateInvalidSignature`, NOT `PriceZero`. `PriceZero` is an
+    /// operator-facing signal that the publisher's own pipeline emitted its
+    /// uninitialized default; an unauthenticated caller must not be able to
+    /// raise it.
+    function test_UpdatePrice_WronglySignedZeroPrice_RevertsInvalidSignatureNotPriceZero() public {
+        uint256 wrongPk = uint256(keccak256("wrong-signer"));
+        uint256 ts = block.timestamp;
+        uint256 expiry = ts + DEFAULT_VALIDITY;
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, digestFor(oracle, PAIR_A, 0, ts, expiry));
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUpdateInvalidSignature.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 0, ts, expiry, 0, abi.encodePacked(r, s, v));
+
+        // Positive control: correctly signed, the same zero price reaches the
+        // content check.
+        bytes memory signed = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 0, ts, expiry);
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceZero.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 0, ts, expiry, 0, signed);
+    }
+
+    /// @notice The four content checks run in the documented order —
+    /// `PriceFuture`, then `PriceExpired`, then `ValidityWindowTooLong`, then
+    /// `PriceZero` — so a payload violating several reports the FIRST. Two
+    /// things ride on this. A publisher debugging a rejected payload fixes one
+    /// field at a time and expects the next error to advance; and the
+    /// window-cap subtraction `newExpiry - newTimestamp` is only underflow-free
+    /// BECAUSE the future and expiry checks have already established
+    /// `newTimestamp <= block.timestamp < newExpiry` — hoisting it above them
+    /// would turn a backwards window into an undisambiguable arithmetic panic.
+    ///
+    /// Walks the whole ladder, each step repairing exactly the field the
+    /// previous step named.
+    function test_UpdatePrice_ContentChecksRunInDocumentedOrder() public {
+        vm.warp(block.timestamp + 1 days);
+
+        // Every payload is signed by the real publisher, so what each step
+        // observes is the content-check order and nothing else. Signatures are
+        // produced up front because signing reads the oracle.
+        uint256 futureTs = block.timestamp + 1 hours;
+        uint256 deadExpiry = block.timestamp - 1;
+        uint256 ts = block.timestamp;
+        uint256 tooLong = ts + oracle.MAX_VALIDITY_WINDOW() + 1;
+        uint256 expiry = ts + DEFAULT_VALIDITY;
+        bytes memory futureSig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 0, futureTs, deadExpiry);
+        bytes memory expiredSig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 0, ts, deadExpiry);
+        bytes memory windowSig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 0, ts, tooLong);
+        bytes memory zeroSig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 0, ts, expiry);
+        bytes memory goodSig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, ts, expiry);
+
+        // Future-dated AND already expired AND zero-priced: the future check
+        // is the one that speaks.
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceFuture.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 0, futureTs, deadExpiry, 0, futureSig);
+
+        // Timestamp repaired; the closed window is next.
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceExpired.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 0, ts, deadExpiry, 0, expiredSig);
+
+        // Expiry repaired (live) but mis-scaled; the cap is next.
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.ValidityWindowTooLong.selector, PAIR_A, ts, tooLong));
+        oracle.updatePrice(PAIR_A, 0, ts, tooLong, 0, windowSig);
+
+        // Window repaired; the zero price is last.
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceZero.selector, PAIR_A));
+        oracle.updatePrice(PAIR_A, 0, ts, expiry, 0, zeroSig);
+
+        // Everything repaired: it applies.
+        assertTrue(oracle.updatePrice(PAIR_A, 42e18, ts, expiry, 0, goodSig), "the repaired payload applies");
+    }
+
     /// @notice The boundary: a payload timestamped at EXACTLY block.timestamp
     /// is not in the future and applies. (`newTimestamp <= block.timestamp`
     /// is the accepted region.)
@@ -760,6 +879,24 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         assertEq(deadRatio, 1.05e18, "expired pair still reads its stored ratio");
         vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceExpired.selector, PAIR_A));
         oracle.price(PAIR_A);
+    }
+
+    /// @notice DELIBERATE ASYMMETRY against `price()`: the RAW view returns
+    /// all four fields as ZEROS for a pair no update has ever landed on,
+    /// rather than reverting `PriceUnset`. `pairPrice` exists for publishers
+    /// sizing their next timestamp and for off-chain monitoring — both of
+    /// which must be able to ask about a brand-new pair (there is no
+    /// registration step) without handling a revert. The zeros are safe under
+    /// the documented consumer rule: a consumer applying
+    /// `block.timestamp < storedExpiry` fails closed on a zero expiry, and a
+    /// zero `storedTimestamp` is itself the "never updated" signal.
+    function test_PairPrice_UnsetPair_ReturnsZerosNotRevert() public view {
+        (uint256 storedPrice, uint256 storedTs, uint256 storedExpiry, uint256 storedRatio) =
+            oracle.pairPrice(PAIR_UNKNOWN);
+        assertEq(storedPrice, 0, "unset price reads zero");
+        assertEq(storedTs, 0, "unset timestamp reads zero");
+        assertEq(storedExpiry, 0, "unset expiry reads zero");
+        assertEq(storedRatio, 0, "unset ratio reads zero");
     }
 
     // -------- setSigner --------


### PR DESCRIPTION
Newly pinned: the pause-config validation ladder (absolute window caps outrank the relative cross-epoch invariant, and the pre-window cap outranks the post-window cap, each naming its own value), `_validatePauseConfig` running ahead of the corporate-actions reachability probe, the exact values and the documented `MAX_AGE_LIMIT < MAX_PAUSE_WINDOW` relation read through the public getters, `ORACLE_ADMIN_ROLE` being administered by `DEFAULT_ADMIN_ROLE`, signature-before-content for the `ValidityWindowTooLong` and `PriceZero` checks, the full `PriceFuture` → `PriceExpired` → `ValidityWindowTooLong` → `PriceZero` precedence ladder, and `pairPrice` returning zeros rather than reverting for a pair no update has landed on.

Strengthened in place: `testInitValidatesConfigFieldsInDeclarationOrder` now walks through the window caps before the cross-epoch invariant, and `testInitRevertsPauseWindowOverCap` now covers both windows being over the cap by different amounts so the reported value identifies which check fired.

Every added and strengthened assertion was validated by mutating the corresponding source line and confirming the suite goes red; 214 tests pass on the unmutated baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789826065&installation_model_id=19370&pr_number=322&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F322&signature=fda4a39b66224ae6b28310673cab70503ea1f2fa117020c1dc6d85ca80d69e18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->