### PR TITLE
test(oracle,adapter,pause,deploy): mutation-validated coverage for leftovers (part 2)

### DIFF
--- a/test/src/concrete/adapter/MorphoPairAdapter.t.sol
+++ b/test/src/concrete/adapter/MorphoPairAdapter.t.sol
@@ -344,9 +344,40 @@ contract MorphoPairAdapterTest is SignedPriceTestBase {
         adapter.price();
     }
 
+    /// @notice PRECEDENCE between the two fail-closed paths. The NatSpec puts
+    /// the NAV-ratio gate BEFORE the rescale — the live ratio is asserted
+    /// "before serving anything" — so a market that would ALSO hit
+    /// `PriceRoundsToZero` still surfaces `RatioMismatch` while its ratio has
+    /// drifted. That ordering is what makes the reported error diagnostic: a
+    /// drifted ratio is a transient freeze the publisher's next update clears,
+    /// whereas a rounding collapse is a permanent decimals misconfiguration,
+    /// and an operator must not be pointed at the second when the first is what
+    /// happened. base=59dec collateral / quote=6dec loan scales by
+    /// `10^(36+6-59-18)`, so the canonical `1e18` price floors to zero and BOTH
+    /// guards are live for the same read — the discriminating configuration.
+    function test_MorphoPairAdapter_RatioGatePrecedesRescale() public {
+        MockNavVaultToken vaultBase59 = new MockNavVaultToken(59);
+        vaultBase59.setNavRatio(1.05e18);
+        MorphoPairAdapter adapter = _deployAdapter(address(vaultBase59), address(quote));
+        bytes32 id = oracle.pairId(address(vaultBase59), address(quote));
+        _push(id, 1e18, block.timestamp, block.timestamp + DEFAULT_VALIDITY, 1.05e18);
+
+        // Ratio intact: the gate passes and the rescale is what fails closed.
+        vm.expectRevert(abi.encodeWithSelector(PriceRoundsToZero.selector, uint256(1e18)));
+        adapter.price();
+
+        // The distribution steps the live NAV. The gate runs first, so the
+        // mismatch is what surfaces — not the rounding collapse behind it.
+        vaultBase59.setNavRatio(1.06e18);
+        vm.expectRevert(abi.encodeWithSelector(RatioMismatch.selector, uint256(1.05e18), uint256(1.06e18)));
+        adapter.price();
+    }
+
     /// @notice The zero "no ratio" sentinel is honoured ONLY for a collateral
     /// that does not probe as a vault: a plain ERC-20 with no
-    /// `convertToAssets` classifies as non-vault and prices normally.
+    /// `convertToAssets` classifies as non-vault and prices normally. A ZERO
+    /// stored ratio is the central store's "no ratio" sentinel, so the NAV
+    /// gate is skipped entirely for such a market.
     function test_MorphoPairAdapter_NonVaultCollateralZeroRatio_Serves() public {
         MorphoPairAdapter adapter = _deployAdapter(address(base), address(quote));
         _push(PAIR_A, 42e18, block.timestamp, block.timestamp + DEFAULT_VALIDITY, 0);

--- a/test/src/concrete/deploy/DIAVaultOracleBeaconSetDeployer.t.sol
+++ b/test/src/concrete/deploy/DIAVaultOracleBeaconSetDeployer.t.sol
@@ -96,6 +96,26 @@ contract DIAVaultOracleBeaconSetDeployerTest is Test {
         );
     }
 
+    /// @notice `ZeroImplementation` guards EXACTLY the zero address, nothing
+    /// wider: a non-zero implementation with no deployed code (an EOA, or an
+    /// address whose deployment has not landed) is rejected one layer down, by
+    /// `UpgradeableBeacon`'s own `BeaconInvalidImplementation` guard. Both
+    /// directions are fail-closed, but they are DIFFERENT errors and the split
+    /// is what tells an operator which mistake they made — a typo'd address
+    /// versus an omitted one. Pinned with the exact selector and argument so a
+    /// widened local guard (e.g. checking `code.length == 0`) cannot silently
+    /// absorb the beacon's case into `ZeroImplementation`.
+    function testConstructorRevertsCodelessImplementation() external {
+        address codeless = address(0xE0A);
+        assertEq(codeless.code.length, 0, "the fixture address must genuinely have no code");
+        vm.expectRevert(abi.encodeWithSelector(UpgradeableBeacon.BeaconInvalidImplementation.selector, codeless));
+        new DIAVaultOracleBeaconSetDeployer(
+            DIAVaultOracleBeaconSetDeployerConfig({
+                initialOwner: BEACON_OWNER, initialDIAVaultOracleImplementation: codeless
+            })
+        );
+    }
+
     function testConstructorHappyPathDeploysBeacon() external {
         DIAVaultOracleBeaconSetDeployer bsd = _deployBSD();
         address beacon = address(bsd.iDIAVaultOracleBeacon());

--- a/test/src/concrete/oracle/ST0xPriceOracle.t.sol
+++ b/test/src/concrete/oracle/ST0xPriceOracle.t.sol
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
+import {Vm} from "forge-std-1.16.1/src/Vm.sol";
 import {SignedPriceTestBase} from "../../lib/SignedPriceTestBase.sol";
 
 import {UpgradeableBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/UpgradeableBeacon.sol";
@@ -469,6 +470,46 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         assertTrue(oracle.updatePrice(PAIR_A, 42e18, ts, atCap, 0, capSig), "window exactly at the cap is accepted");
     }
 
+    /// @notice The validity-window cap is measured from the PAYLOAD's
+    /// `timestamp`, not from `block.timestamp`: `ValidityWindowTooLong` is
+    /// documented as "`expiry - timestamp` exceeds `MAX_VALIDITY_WINDOW`". The
+    /// existing cap test signs `timestamp == block.timestamp`, where the two
+    /// reference points coincide and are indistinguishable. Submitting a
+    /// payload observed well in the PAST separates them: with a 10-day-old
+    /// observation, `timestamp + MAX_VALIDITY_WINDOW + 1` is rejected even
+    /// though only 20 days and one second of it remain ahead of `now`, and
+    /// `timestamp + MAX_VALIDITY_WINDOW` is accepted at exactly the cap.
+    ///
+    /// The consequence the reference point carries: an accepted payload's
+    /// OBSERVATION AGE at read time is bounded only by the cap, while its
+    /// remaining validity may be far shorter — the price served below was
+    /// observed ten days ago and is still live, because the publisher's signed
+    /// horizon (not the observation age) is the staleness bound.
+    function test_UpdatePrice_ValidityWindowMeasuredFromPayloadTimestamp() public {
+        vm.warp(60 days);
+        uint256 cap = oracle.MAX_VALIDITY_WINDOW();
+        uint256 observedTs = block.timestamp - 10 days;
+
+        uint256 tooLong = observedTs + cap + 1;
+        assertLt(tooLong - block.timestamp, cap, "the window still ahead of now is well inside the cap");
+        bytes memory longSig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, observedTs, tooLong);
+        vm.expectRevert(
+            abi.encodeWithSelector(ST0xPriceOracle.ValidityWindowTooLong.selector, PAIR_A, observedTs, tooLong)
+        );
+        oracle.updatePrice(PAIR_A, 42e18, observedTs, tooLong, 0, longSig);
+
+        uint256 atCap = observedTs + cap;
+        bytes memory capSig = signPriceUpdate(oracle, SIGNER_PK, PAIR_A, 42e18, observedTs, atCap);
+        assertTrue(
+            oracle.updatePrice(PAIR_A, 42e18, observedTs, atCap, 0, capSig),
+            "a window exactly at the cap from the payload timestamp is accepted"
+        );
+
+        (, uint256 storedTs,,) = oracle.pairPrice(PAIR_A);
+        assertEq(storedTs, observedTs, "the ten-day-old observation timestamp is what is stored");
+        assertEq(_price(PAIR_A), 42e18, "and it is served: the signed horizon, not observation age, is the bound");
+    }
+
     /// @notice RECOVERY PATH (documented in the contract NatSpec): a
     /// strictly-newer payload with a TIGHTER window supersedes a stored
     /// long-window price. After the tight expiry passes, reads fail closed
@@ -881,6 +922,41 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
         oracle.price(PAIR_A);
     }
 
+    /// @notice The two read views split the work differently and that split is
+    /// the contract: `pairPrice` is the RAW view and NEVER reverts — an unset
+    /// pair reads back as the all-zero sentinel, and an expired pair reads back
+    /// its exact stored fields — while `price()` is the CHECKED view and is the
+    /// only one that separates "absent" (`PriceUnset`) from "present but dead"
+    /// (`PriceExpired`). A consumer of the raw view therefore cannot tell those
+    /// two apart from its return values alone, which is precisely why the raw
+    /// view's NatSpec requires it to apply the expiry itself.
+    function test_PairPrice_RawSentinelViewVersusCheckedRead() public {
+        // Absent: zeros out of the raw view, no revert.
+        (uint256 rawPrice, uint256 rawTs, uint256 rawExpiry, uint256 rawRatio) = oracle.pairPrice(PAIR_UNKNOWN);
+        assertEq(rawPrice, 0, "unset pair reads back a zero price");
+        assertEq(rawTs, 0, "unset pair reads back a zero timestamp");
+        assertEq(rawExpiry, 0, "unset pair reads back a zero expiry");
+        assertEq(rawRatio, 0, "unset pair reads back a zero ratio");
+        // Only the checked read names it.
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceUnset.selector, PAIR_UNKNOWN));
+        oracle.price(PAIR_UNKNOWN);
+
+        // Present but dead: the raw view still serves every stored field.
+        uint256 ts = block.timestamp;
+        uint256 expiry = ts + DEFAULT_VALIDITY;
+        _push(PAIR_A, 42e18, ts, expiry, 7e18);
+        vm.warp(expiry);
+        (rawPrice, rawTs, rawExpiry, rawRatio) = oracle.pairPrice(PAIR_A);
+        assertEq(rawPrice, 42e18, "expired pair still reads back its stored price");
+        assertEq(rawTs, ts, "expired pair still reads back its stored timestamp");
+        assertEq(rawExpiry, expiry, "expired pair still reads back its stored expiry");
+        assertEq(rawRatio, 7e18, "expired pair still reads back its stored ratio");
+        // Only the checked read names it — and with a DIFFERENT error to the
+        // unset case, which is the whole distinction the raw view cannot make.
+        vm.expectRevert(abi.encodeWithSelector(ST0xPriceOracle.PriceExpired.selector, PAIR_A));
+        oracle.price(PAIR_A);
+    }
+
     /// @notice DELIBERATE ASYMMETRY against `price()`: the RAW view returns
     /// all four fields as ZEROS for a pair no update has ever landed on,
     /// rather than reverting `PriceUnset`. `pairPrice` exists for publishers
@@ -930,6 +1006,30 @@ contract ST0xPriceOracleTest is SignedPriceTestBase {
 
         // Rotation preserved the previously stored state until then.
         assertEq(_price(PAIR_A), 43e18, "state advanced under the new key");
+    }
+
+    /// @notice `SignerSet`'s `signer` parameter is INDEXED — it is a topic, not
+    /// a data word. Off-chain key-rotation monitoring filters on that topic, so
+    /// dropping the `indexed` qualifier would move the address into the data
+    /// blob and silently break every such subscription. The two other rotation
+    /// tests emit the expectation through the contract's OWN event declaration,
+    /// so their expectation co-varies with any change to it and they cannot see
+    /// this; assert the raw log shape instead — two topics (signature +
+    /// signer), and an EMPTY data blob because `signer` is the only parameter.
+    function test_SignerSet_SignerParameterIsIndexed() public {
+        address rotated = vm.addr(uint256(keccak256("indexed-topic-test")));
+
+        vm.recordLogs();
+        vm.prank(ORACLE_ADMIN);
+        oracle.setSigner(rotated);
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        assertEq(entries.length, 1, "setSigner emits exactly one event");
+        assertEq(entries[0].emitter, address(oracle), "emitted by the oracle");
+        assertEq(entries[0].topics.length, 2, "signature topic plus one indexed parameter");
+        assertEq(entries[0].topics[0], keccak256("SignerSet(address)"), "event signature topic");
+        assertEq(entries[0].topics[1], bytes32(uint256(uint160(rotated))), "signer is carried as a topic");
+        assertEq(entries[0].data.length, 0, "no unindexed parameters remain in the data blob");
     }
 
     function test_SetSigner_RoleGated() public {

--- a/test/src/lib/LibCorporateActionsPause.t.sol
+++ b/test/src/lib/LibCorporateActionsPause.t.sol
@@ -103,19 +103,19 @@ contract LibCorporateActionsPauseTest is Test {
     /// so a codeless address reverts with EMPTY return data rather than being
     /// read as "no actions scheduled". A misconfigured (or self-destructed)
     /// vault must never silently degrade into a permanently un-pausable oracle.
-    /// Asserted via a raw external-call failure (not `vm.expectRevert`): forge
-    /// versions differ on whether a call into a code-less address is classified
-    /// as a plain revert, but every version agrees the call does NOT succeed.
-    /// Discriminating value: `ok == false` with empty return data, versus a
-    /// successful `(false, 0)` result if the disable short-circuit were
-    /// widened to "no code".
+    /// Asserted via a raw external-call failure (not `vm.expectRevert`), and
+    /// only on the success FLAG: forge versions differ both on whether a call
+    /// into a code-less address is classified as a plain revert and on what
+    /// reason bytes the halt carries, but every version agrees the call does
+    /// NOT succeed. Discriminating value: `ok == false`, versus a successful
+    /// `(false, 0)` pause result if the disable short-circuit were widened to
+    /// "no code".
     function testNonZeroVaultWithoutCodeFailsClosed() external {
         address codeless = address(0xDEAD);
         assertEq(codeless.code.length, 0, "the fixture address must genuinely have no code");
-        (bool ok, bytes memory ret) = address(this)
+        (bool ok,) = address(this)
             .call(abi.encodeCall(this.callInPauseWindow, (codeless, ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER)));
         assertFalse(ok, "a code-less corporate-actions vault must fail closed, never read as no actions");
-        assertEq(ret.length, 0, "the failure carries no reason data (solc extcodesize guard)");
     }
 
     /// The NatSpec states a gas contract: "each query is at most two view calls

--- a/test/src/lib/LibCorporateActionsPause.t.sol
+++ b/test/src/lib/LibCorporateActionsPause.t.sol
@@ -103,13 +103,19 @@ contract LibCorporateActionsPauseTest is Test {
     /// so a codeless address reverts with EMPTY return data rather than being
     /// read as "no actions scheduled". A misconfigured (or self-destructed)
     /// vault must never silently degrade into a permanently un-pausable oracle.
-    /// Discriminating value: a revert carrying no reason, versus `(false, 0)`
-    /// if the disable short-circuit were widened to "no code".
+    /// Asserted via a raw external-call failure (not `vm.expectRevert`): forge
+    /// versions differ on whether a call into a code-less address is classified
+    /// as a plain revert, but every version agrees the call does NOT succeed.
+    /// Discriminating value: `ok == false` with empty return data, versus a
+    /// successful `(false, 0)` result if the disable short-circuit were
+    /// widened to "no code".
     function testNonZeroVaultWithoutCodeFailsClosed() external {
         address codeless = address(0xDEAD);
         assertEq(codeless.code.length, 0, "the fixture address must genuinely have no code");
-        vm.expectRevert(bytes(""));
-        this.callInPauseWindow(codeless, ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        (bool ok, bytes memory ret) = address(this)
+            .call(abi.encodeCall(this.callInPauseWindow, (codeless, ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER)));
+        assertFalse(ok, "a code-less corporate-actions vault must fail closed, never read as no actions");
+        assertEq(ret.length, 0, "the failure carries no reason data (solc extcodesize guard)");
     }
 
     /// The NatSpec states a gas contract: "each query is at most two view calls

--- a/test/src/lib/LibCorporateActionsPause.t.sol
+++ b/test/src/lib/LibCorporateActionsPause.t.sol
@@ -3,9 +3,13 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {NODE_NONE} from "st0x-deploy-0.1.1/src/lib/LibCorporateActionNode.sol";
+import {CompletionFilter, NODE_NONE} from "st0x-deploy-0.1.1/src/lib/LibCorporateActionNode.sol";
 import {LibCorporateActionsPause} from "../../../src/lib/LibCorporateActionsPause.sol";
-import {ACTION_TYPE_INIT_V1, ACTION_TYPE_STOCK_SPLIT_V1} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
+import {
+    ICorporateActionsV1,
+    ACTION_TYPE_INIT_V1,
+    ACTION_TYPE_STOCK_SPLIT_V1
+} from "st0x-deploy-0.1.1/src/interface/ICorporateActionsV1.sol";
 import {MockCorporateActions} from "../../mocks/MockCorporateActions.sol";
 import {
     MockRevertingCorporateActions,
@@ -90,6 +94,67 @@ contract LibCorporateActionsPauseTest is Test {
         MockRevertingCorporateActions reverting = new MockRevertingCorporateActions();
         vm.expectRevert(CorporateActionsUnavailable.selector);
         this.callInPauseWindow(address(reverting), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+    }
+
+    /// A NON-ZERO vault address with no deployed code must fail CLOSED. Only
+    /// `address(0)` is the documented "auto-pause disabled" short-circuit; any
+    /// other address is asserted to implement `ICorporateActionsV1`, and a
+    /// high-level call expecting return data carries solc's extcodesize guard,
+    /// so a codeless address reverts with EMPTY return data rather than being
+    /// read as "no actions scheduled". A misconfigured (or self-destructed)
+    /// vault must never silently degrade into a permanently un-pausable oracle.
+    /// Discriminating value: a revert carrying no reason, versus `(false, 0)`
+    /// if the disable short-circuit were widened to "no code".
+    function testNonZeroVaultWithoutCodeFailsClosed() external {
+        address codeless = address(0xDEAD);
+        assertEq(codeless.code.length, 0, "the fixture address must genuinely have no code");
+        vm.expectRevert(bytes(""));
+        this.callInPauseWindow(codeless, ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+    }
+
+    /// The NatSpec states a gas contract: "each query is at most two view calls
+    /// into the vault". That bound is what justifies the whole earliest-pending
+    /// / latest-completed shape, and nothing else in the suite observes call
+    /// COUNTS, so a refactor that always performed both reads (or added a third)
+    /// would be invisible. This arm pins the cheap path: an open pending
+    /// pre-window is decided by the FIRST read, so the completed read is never
+    /// made at all — exactly ONE call into the vault.
+    function testOpenPendingPreWindowMakesExactlyOneVaultCall() external {
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + BEFORE / 2));
+        vm.expectCall(address(mock), _pendingCalldata(), 1);
+        vm.expectCall(address(mock), _completedCalldata(), 0);
+        (bool paused,) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, true, "the single pending read is enough to decide");
+    }
+
+    /// The other arm of the two-call bound: a pending action OUTSIDE its
+    /// pre-window falls through, and the completed read is then made exactly
+    /// once — two calls in total, never three.
+    function testPendingFallThroughMakesExactlyTwoVaultCalls() external {
+        mock.setEarliestPending(1, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp + 2 * BEFORE + 1));
+        mock.setLatestCompleted(2, ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp - AFTER / 2));
+        vm.expectCall(address(mock), _pendingCalldata(), 1);
+        vm.expectCall(address(mock), _completedCalldata(), 1);
+        (bool paused,) =
+            LibCorporateActionsPause.inPauseWindow(address(mock), ACTION_TYPE_STOCK_SPLIT_V1, BEFORE, AFTER);
+        assertEq(paused, true, "the fall-through decides on exactly one completed read");
+    }
+
+    /// The exact calldata of the PENDING read the library is specified to make:
+    /// `earliestActionOfType(mask, PENDING)`.
+    function _pendingCalldata() internal pure returns (bytes memory) {
+        return abi.encodeCall(
+            ICorporateActionsV1.earliestActionOfType, (ACTION_TYPE_STOCK_SPLIT_V1, CompletionFilter.PENDING)
+        );
+    }
+
+    /// The exact calldata of the COMPLETED read the library is specified to
+    /// make: `latestActionOfType(mask, COMPLETED)`.
+    function _completedCalldata() internal pure returns (bytes memory) {
+        return abi.encodeCall(
+            ICorporateActionsV1.latestActionOfType, (ACTION_TYPE_STOCK_SPLIT_V1, CompletionFilter.COMPLETED)
+        );
     }
 
     /// External wrapper around the internal library call so revert-propagation


### PR DESCRIPTION
Mutation-probed 26 leftover behaviours against the pre-existing suite; 19 were already killed by existing tests and 7 survived as real gaps. This adds seven discriminating tests, each proven to fail under its targeted mutation and pass on baseline: `SignerSet.signer` indexedness (asserted on the raw log topics, not through the contract's own event declaration), the validity-window cap being measured from the PAYLOAD timestamp rather than `block.timestamp`, the `pairPrice` raw-sentinel vs `price()` checked-read split (absent vs present-but-dead), a codeless non-zero corporate-actions vault failing closed, the "at most two view calls into the vault" gas contract on both arms, a codeless non-zero implementation being rejected by `UpgradeableBeacon.BeaconInvalidImplementation` rather than `ZeroImplementation`, and the NAV-ratio gate's precedence over the rescale so a drifted ratio surfaces `RatioMismatch` even where `PriceRoundsToZero` would also fire.

No existing test was weakened or deleted, and no source file changed. Suite goes from 207 to 215 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789826082&installation_model_id=19370&pr_number=323&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F323&signature=abf172c1072dc9621a982f4533de18c6d2dd5545e4f6ad583c5e5052e976d86a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->