### PR TITLE
fix(dia): bound forward DIA timestamp acceptance at maxAge

### DIFF
--- a/src/concrete/oracle/DIAVaultOracle.sol
+++ b/src/concrete/oracle/DIAVaultOracle.sol
@@ -98,6 +98,18 @@ error DIAPriceNotSet();
 /// @param timestamp The `block.timestamp` of the stale DIA push.
 error DIAPriceStale(uint256 timestamp);
 
+/// @dev Error raised when the DIA reading is stamped `maxAge` or more AHEAD
+/// of block time. Small forward source-clock skew is tolerated as fresh (age
+/// 0), but a stamp at wrong scale (e.g. milliseconds) or from a corrupt push
+/// would otherwise be served as perpetually fresh until wall clock caught up
+/// — staleness protection silently disabled for the whole overshoot. The
+/// accepted source-stamp window is therefore symmetric and open at both
+/// edges: `(block.timestamp - maxAge, block.timestamp + maxAge)`. A dedicated
+/// selector so integrators can tell a far-future push from a stale or unset
+/// one.
+/// @param timestamp The source timestamp of the far-future push.
+error DIAPriceFarFuture(uint256 timestamp);
+
 /// @dev Error raised on every read inside a corporate-action pause window.
 /// @param effectiveTime The `effectiveTime` of the action whose window is
 /// currently open. When a pending and a completed action's window overlap
@@ -580,11 +592,14 @@ contract DIAVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable 
     ///
     /// `startedAt`/`updatedAt` are the push's source timestamp CLAMPED to
     /// `block.timestamp`. `_readDIAChecked` deliberately accepts a future-dated
-    /// push (a feed running slightly ahead) as fresh; returning that raw
-    /// future timestamp here would make a Chainlink-style consumer computing
-    /// `block.timestamp - updatedAt` underflow-revert. Clamping reports such a
-    /// fresh push as age 0 — which is what "fresh" means — and never emits a
-    /// timestamp ahead of the block clock.
+    /// push as fresh up to `maxAge` ahead (beyond that it reverts
+    /// `DIAPriceFarFuture`); returning that raw future timestamp here would
+    /// make a Chainlink-style consumer computing `block.timestamp - updatedAt`
+    /// underflow-revert. Clamping reports such a fresh push as age 0 — which
+    /// is what "fresh" means — and never emits a timestamp ahead of the block
+    /// clock. The same bound is what keeps the `uint80` round id window
+    /// honest: a source stamp can never exceed `block.timestamp + maxAge`, so
+    /// truncation is unreachable for any plausible deployment lifetime.
     function latestRoundData()
         external
         view
@@ -644,10 +659,15 @@ contract DIAVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable 
         //
         // A push timestamped at or before `now` applies the `maxAge` window. A
         // push timestamped in the FUTURE (a feed running slightly ahead, or a
-        // chain-time regression / reorg) is treated as fresh (age 0), never
-        // stale: the `<= block.timestamp` guard short-circuits the subtraction
-        // so it can never underflow into a bare `Panic(0x11)` that integrators
-        // cannot disambiguate from `DIAPriceStale` / `DIAPriceNotSet`.
+        // chain-time regression / reorg) is treated as fresh (age 0) up to
+        // `maxAge` ahead: the `<= block.timestamp` guard short-circuits the
+        // subtraction so it can never underflow into a bare `Panic(0x11)` that
+        // integrators cannot disambiguate from `DIAPriceStale` /
+        // `DIAPriceNotSet`. Beyond that bound the push reverts
+        // `DIAPriceFarFuture`: unbounded forward acceptance would let a
+        // wrong-scale or corrupt stamp disable staleness until wall clock
+        // caught up. Both edges fail closed, so the accepted window is
+        // symmetric and open: `(now - maxAge, now + maxAge)`.
         //
         // The staleness edge fails closed (`>=`): a push exactly `maxAge` old is
         // STALE. This is deliberate — it tightens the cross-epoch invariant by
@@ -656,6 +676,10 @@ contract DIAVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable 
         // own make the invariant "airtight" — the margin `pauseTimeAfter -
         // maxAge` must still cover the feed's forward source-clock skew, which
         // is why init requires that margin to be strictly positive.
+        // slither-disable-next-line timestamp
+        if (uint256(timestamp) >= block.timestamp + $.maxAge) {
+            revert DIAPriceFarFuture(uint256(timestamp));
+        }
         // slither-disable-next-line timestamp
         if (uint256(timestamp) <= block.timestamp && block.timestamp - uint256(timestamp) >= $.maxAge) {
             revert DIAPriceStale(uint256(timestamp));

--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -22,6 +22,7 @@ import {
     EmptySymbol,
     DIAPriceNotSet,
     DIAPriceStale,
+    DIAPriceFarFuture,
     ZeroVaultSupply,
     ZeroVaultSharePrice,
     VaultSharePriceOverflow,
@@ -1068,6 +1069,46 @@ contract DIAVaultOracleTest is Test {
 
         int256 answer = oracle.latestAnswer();
         assertEq(answer, int256(100e8), "future-timestamped push is fresh, not stale");
+    }
+
+    /// @notice Forward acceptance is BOUNDED: a push stamped `maxAge` or more
+    /// ahead of block time reverts `DIAPriceFarFuture` carrying the offending
+    /// stamp. Unbounded acceptance would let a wrong-scale (e.g. milliseconds)
+    /// or corrupt stamp hold the feed "fresh" until wall clock caught up —
+    /// staleness protection disabled for the whole overshoot. The edge fails
+    /// closed, mirroring the stale edge: exactly `now + maxAge` is rejected.
+    function testFarFutureTimestampRejectedAtBound() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+
+        uint256 atBound = block.timestamp + MAX_AGE;
+        diaOracle.setValue(SYMBOL, 100e18, uint128(atBound));
+        vm.expectRevert(abi.encodeWithSelector(DIAPriceFarFuture.selector, atBound));
+        oracle.latestAnswer();
+
+        // A milliseconds-scale stamp (the wrong-units class) lands far past the
+        // bound and is rejected with the same selector.
+        uint256 msScale = block.timestamp * 1000;
+        diaOracle.setValue(SYMBOL, 100e18, uint128(msScale));
+        vm.expectRevert(abi.encodeWithSelector(DIAPriceFarFuture.selector, msScale));
+        oracle.latestAnswer();
+    }
+
+    /// @notice One second inside the forward bound is accepted and served as
+    /// fresh, with `latestRoundData` clamping the reported time to the block
+    /// clock. Pins the accepted window's upper edge as open at exactly
+    /// `now + maxAge`: `now + maxAge - 1` serves, `now + maxAge` reverts.
+    function testFarFutureBoundUpperEdgeIsOpen() external {
+        DIAVaultOracle oracle = _deployProxy(_defaultConfig());
+        vault.setTotalAssets(1e18);
+        vault.setTotalSupply(1e18);
+
+        uint256 justInside = block.timestamp + MAX_AGE - 1;
+        diaOracle.setValue(SYMBOL, 100e18, uint128(justInside));
+        (, int256 answer,, uint256 updatedAt,) = oracle.latestRoundData();
+        assertEq(answer, int256(100e8), "one second inside the bound is fresh");
+        assertEq(updatedAt, block.timestamp, "reported time is clamped to the block clock");
     }
 
     /// @notice The staleness edge fails closed: a push aged EXACTLY `maxAge`


### PR DESCRIPTION
## Closes #324 — bound forward DIA timestamp acceptance at `maxAge`

A push stamped `maxAge` or more ahead of block time now reverts a dedicated `DIAPriceFarFuture(timestamp)` instead of being served as perpetually fresh. Previously, forward acceptance was unbounded: a wrong-scale (milliseconds) or corrupt source stamp would hold the feed "fresh" (age 0) until wall clock caught up — staleness protection silently disabled for the whole overshoot, while the NatSpec framed the tolerance as covering a feed running *slightly* ahead.

- Small forward skew keeps its documented age-0 tolerance and the clamp behaviour in `latestRoundData`; the accepted source-stamp window is now symmetric and **open at both edges**: `(now − maxAge, now + maxAge)`, mirroring the stale edge's fail-closed convention.
- The rejection is a named selector (not an underflow panic), preserving the original diagnosability rationale for tolerating future stamps at all.
- The `uint80` roundId truncation facet of #324 becomes unreachable under the bound (a stamp can never approach 2^80) — pinned in the NatSpec.

Tests: bound edge fails closed at exactly `now + maxAge`, one second inside serves and clamps, the ms-scale wrong-units stamp rejects with the offending value; the existing near-skew test is unchanged and still passes.

Gates: 246/246 incl. Base fork, slither 0, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FTbsUf9TY7uEtBJETSViV
