### PR TITLE
fix(dia): emit the derived corporateActionsVault in the init event

### DIFF
--- a/src/concrete/oracle/DIAVaultOracle.sol
+++ b/src/concrete/oracle/DIAVaultOracle.sol
@@ -378,10 +378,12 @@ contract DIAVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable 
     }
 
     /// @notice Emitted when the oracle is initialized. Single source of
-    /// truth for off-chain indexers — all immutable config in one event.
+    /// truth for off-chain indexers — all immutable state in one event.
     /// @param sender The caller that initialized the proxy.
     /// @param config The initialization configuration.
-    event DIAVaultOracleInitialized(address indexed sender, DIAVaultOracleConfig config);
+    /// @param corporateActionsVault The derived `ICorporateActionsV1` vault
+    /// gating the mandatory auto-pause.
+    event DIAVaultOracleInitialized(address indexed sender, DIAVaultOracleConfig config, address corporateActionsVault);
 
     constructor() {
         _disableInitializers();
@@ -547,7 +549,7 @@ contract DIAVaultOracle is AggregatorV2V3Interface, ICloneableV2, Initializable 
         $.pauseTimeBefore = config.pauseTimeBefore;
         $.pauseTimeAfter = config.pauseTimeAfter;
 
-        emit DIAVaultOracleInitialized(msg.sender, config);
+        emit DIAVaultOracleInitialized(msg.sender, config, derivedCorporateActionsVault);
 
         return ICLONEABLE_V2_SUCCESS;
     }

--- a/test/src/concrete/oracle/DIAVaultOracle.t.sol
+++ b/test/src/concrete/oracle/DIAVaultOracle.t.sol
@@ -59,7 +59,7 @@ contract DIAVaultOracleTest is Test {
     // clock skew, so the default config carries a 1h margin over the 1h maxAge.
     uint64 internal constant PAUSE_AFTER = 2 hours;
 
-    event DIAVaultOracleInitialized(address indexed sender, DIAVaultOracleConfig config);
+    event DIAVaultOracleInitialized(address indexed sender, DIAVaultOracleConfig config, address corporateActionsVault);
 
     function setUp() public {
         implementation = new DIAVaultOracle();
@@ -715,7 +715,7 @@ contract DIAVaultOracleTest is Test {
         DIAVaultOracleConfig memory config = _defaultConfig();
 
         vm.expectEmit(true, false, false, true, address(oracle));
-        emit DIAVaultOracleInitialized(address(this), config);
+        emit DIAVaultOracleInitialized(address(this), config, address(actions));
 
         bytes32 ok = oracle.initialize(abi.encode(config));
         assertEq(ok, ICLONEABLE_V2_SUCCESS);


### PR DESCRIPTION
## Closes #325 — emit the derived `corporateActionsVault` in the init event

`DIAVaultOracleInitialized` documents itself as the single source of truth for off-chain indexers ("all immutable config in one event"), but the corporate-actions vault — the address gating the mandatory auto-pause — is derived from `config.vault` at initialize rather than carried in the config, so log-only consumers could not reconstruct the full stored state without a follow-up `eth_call`.

The derived address is now a third event parameter. The config payload stays verbatim (its byte-identity with the CREATE2 salt preimage is untouched); the claim in the NatSpec becomes literally true. Event-shape change is free while nothing is deployed.

Gates: 246/246 incl. Base fork, slither 0, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FTbsUf9TY7uEtBJETSViV
