### PR TITLE
fix(deploy): post-check the DEFAULT_ADMIN grant; align operator-facing docs

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -33,7 +33,7 @@ on:
         type: string
         default: ''
       st0x-signer:
-        description: 'signed-price-stack ONLY: global publisher signer address (checksummed).'
+        description: 'signed-price-stack ONLY: global publisher signer address (checksummed). Must NOT be the deploy key.'
         required: false
         type: string
         default: ''

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -40,12 +40,14 @@ bytes32 constant DEPLOYMENT_SUITE_SIGNED_PRICE_STACK = keccak256("signed-price-s
 /// environment variable; the broadcast key comes from DEPLOYMENT_KEY and the
 /// beacon owner from BEACON_INITIAL_OWNER (both required, no defaults).
 ///
-/// Run a suite manually with:
+/// Run a suite manually with (DEPLOYMENT_KEY must be in the ENVIRONMENT —
+/// `run()` reads it via `vm.envUint`, so a bare `--private-key` flag with an
+/// unexported shell variable aborts with "environment variable not found"):
 ///     DEPLOYMENT_SUITE=dia-vault-oracle \
 ///     BEACON_INITIAL_OWNER=0x<governance-multisig> \
+///     DEPLOYMENT_KEY=0x<deploy-key> \
 ///         forge script script/Deploy.sol:Deploy \
-///         --rpc-url $ETH_RPC_URL --broadcast \
-///         --private-key $DEPLOYMENT_KEY
+///         --rpc-url $ETH_RPC_URL --broadcast
 ///
 /// Omit `--broadcast` to dry-run.
 contract Deploy is Script {
@@ -132,10 +134,12 @@ contract Deploy is Script {
             MorphoPairAdapterBeaconSetDeployerConfig({initialOwner: beaconInitialOwner, central: central})
         );
 
-        // Postcondition: the central store carries the requested signer and the
-        // ORACLE_ADMIN_ROLE grant, so signer rotation is callable from
-        // day one and no post-deploy grant step is left dangling.
+        // Postcondition: the central store carries the requested signer and
+        // BOTH role grants, so signer rotation and role administration are
+        // callable from day one and no post-deploy grant step is left
+        // dangling.
         require(central.signer() == signer, "signer mismatch");
+        require(central.hasRole(central.DEFAULT_ADMIN_ROLE(), admin), "admin role not granted");
         require(central.hasRole(central.ORACLE_ADMIN_ROLE(), oracleAdmin), "oracle admin role not granted");
 
         // Postcondition: both beacons — which control the implementation behind


### PR DESCRIPTION
## Closes #327 — deploy-layer accuracy sweep

Three one-line fixes in the same layer:

1. `deploySignedPriceStack`'s postcondition block verified the signer, `ORACLE_ADMIN_ROLE` and both beacon owners, but never the most consequential grant — `admin`'s `DEFAULT_ADMIN_ROLE`. Now `require`d, making the "no dangling grant" NatSpec claim cover what it implies. (The external test-side assertion already existed; this is the script's own in-band check.)
2. The `st0x-signer` dispatch input gains the "Must NOT be the deploy key." warning its three sibling inputs already carry — the script enforces it, the description now says so.
3. The manual-run NatSpec example passed the key only as a `--private-key` flag while `run()` reads `vm.envUint("DEPLOYMENT_KEY")` — following it literally aborted with "environment variable not found". The example now sets `DEPLOYMENT_KEY` in the environment.

Gates: 246/246 incl. Base fork, slither 0, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FTbsUf9TY7uEtBJETSViV
