### PR TITLE
docs: state the pause-window and DIA_FEED_BASE claims precisely

### DIFF
--- a/src/concrete/oracle/DIAVaultOracle.sol
+++ b/src/concrete/oracle/DIAVaultOracle.sol
@@ -166,8 +166,10 @@ error HistoricalRoundDataUnsupported(uint80 roundId);
 /// start pausing. Must be non-zero, sized above the worst-case ex-date →
 /// `effectiveTime` lead — see `ZeroPauseTimeBefore`.
 /// @param pauseTimeAfter Seconds after a completed action's `effectiveTime` to
-/// keep pausing. Both windows are individually mandatory (each has its own
-/// strict check), AND `pauseTimeAfter > maxAge` (STRICTLY) is REQUIRED and
+/// keep pausing. Both windows are mandatory: a zero `pauseTimeBefore` has its
+/// own strict check, and a zero `pauseTimeAfter` is subsumed by the
+/// cross-epoch invariant below (`maxAge` is non-zero, so zero can never
+/// exceed it). `pauseTimeAfter > maxAge` (STRICTLY) is REQUIRED and
 /// enforced at init
 /// (`PauseTimeAfterBelowMaxAge`) — the post-action pause must outlast the DIA
 /// staleness window so a pre-action price can never be served against the

--- a/test/src/lib/LibDIAFeed.t.sol
+++ b/test/src/lib/LibDIAFeed.t.sol
@@ -9,9 +9,11 @@ import {DIA_FEED_BASE} from "../../../src/lib/LibDIAFeed.sol";
 /// @notice `DIA_FEED_BASE` is the single repo-level constant for the live DIA
 /// push-oracle feed on Base. It is a deployment-address fact, not a derived
 /// value, so the only thing a test can prove offline is that it has not
-/// DRIFTED: every DIA-backed vault oracle is wired to whatever this literal
-/// says, and a silent edit (a fat-fingered nibble, a copy-paste from another
-/// chain's deployment) would point every oracle at an address with no feed.
+/// DRIFTED: no contract under `src/` reads it — per-vault oracles take their
+/// feed from config — but the fork test and the README wiring example both
+/// key off this literal, so a silent edit (a fat-fingered nibble, a
+/// copy-paste from another chain's deployment) would steer every operator
+/// copying the example to an address with no feed.
 ///
 /// Before this test the constant was referenced only by the fork test, which
 /// `vm.mockCall`s `getValue` AT that address — so the mock answers for any


### PR DESCRIPTION
## Closes #328 — state two documentation claims precisely

1. The `pauseTimeAfter` param doc claimed "each has its own strict check"; the zero post-window is actually subsumed by the cross-epoch invariant (`maxAge` is non-zero, so zero can never exceed it). The doc now states the real enforcement shape.
2. The `LibDIAFeed` test docstring claimed "every DIA-backed vault oracle is wired to whatever this literal says"; no contract under `src/` reads the constant — oracles take their feed from config, and the constant pins the fork test and the README wiring example. The docstring now says exactly that.

Docs-only. Gates: 246/246, slither 0, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FTbsUf9TY7uEtBJETSViV
