### PR TITLE
chore: advance the soldeer version slot to 0.1.1

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@
 # it by hand.
 [package]
 name = "st0x-oracle"
-version = "0.1.0"
+version = "0.1.1"
 
 [profile.default]
 libs = ['dependencies']


### PR DESCRIPTION
## Advance the soldeer version slot to 0.1.1

`st0x-oracle~0.1.0` is now on the soldeer registry (published from `c4514e1`, the `next-v0.1.0` seed; tagged `sol-v0.1.0` with a GitHub release). The autopublish next-version lifecycle requires `[package].version` to sit one ahead of the newest published revision — until this merges, Package Release runs on `main` fail loud on the stale-toml guard by design.

Consumers can now pin `st0x-oracle = "0.1.0"` instead of git revs (e.g. the univ4 hook's `{ git, rev }` dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FTbsUf9TY7uEtBJETSViV