### PR TITLE
ci: pass SOLDEER_API_TOKEN explicitly to the publish workflow

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -20,8 +20,12 @@ jobs:
     uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
     with:
       soldeer-package: st0x-oracle
-    # inherit, not an explicit list: CACHIX_AUTH_TOKEN is consumed by the
-    # reusable's nix-cachix-setup composite without being a declared
-    # workflow_call secret, so it only arrives via inherit. Publishing needs
-    # SOLDEER_API_TOKEN available to this repo (org or repo secret).
-    secrets: inherit
+    # Explicit, not `secrets: inherit`: inherit resolves every secret to
+    # empty across this cross-org reusable call (probed — the same secrets
+    # resolve fine in a workflow local to this repo), the same reason
+    # st0x.deploy's caller passes its secrets explicitly. Only secrets the
+    # reusable declares in `workflow_call` can be passed; CACHIX_AUTH_TOKEN
+    # is consumed by its nix-cachix-setup composite without being declared,
+    # so cachix pushing stays disabled here until rainix declares it.
+    secrets:
+      SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_API_TOKEN }}


### PR DESCRIPTION
## Make the soldeer publish actually receive its token

Every `Package Release` run has failed at the publish step with an empty `SOLDEER_API_TOKEN`. Root cause isolated by probing:

- A workflow **local to this repo** resolves both the repo-level `SOLDEER_API_TOKEN` and the org-level `CACHIX_AUTH_TOKEN` fine — values and visibility are not the problem.
- The reusable-workflow call (`rainlanguage/rainix` → `rainix-autopublish`) with `secrets: inherit` resolves **every** secret to empty. st0x.deploy's caller works because it passes secrets **explicitly** — this PR adopts the same form.

Caveat carried in a comment: `CACHIX_AUTH_TOKEN` is consumed by rainix's nix-cachix-setup composite without being declared in `workflow_call`, so it cannot be passed explicitly — cachix pushing stays disabled for this repo until rainix declares it (worth an upstream fix).

Once merged, the next content-changing push to `main` should publish `st0x-oracle~0.1.1` end-to-end with no manual steps — the gate already computes the right thing (last run: `remote=0.1.0 intent=0.1.0 publish=0.1.1`, changed content detected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FTbsUf9TY7uEtBJETSViV