### PR TITLE
ci: hyperevm network option + legacy-tx flag for manual deploys

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -11,6 +11,7 @@ on:
           - base_sepolia
           - ethereum
           - sepolia
+          - hyperevm
       suite:
         description: 'Suite to deploy'
         required: true
@@ -37,6 +38,12 @@ on:
         required: false
         type: string
         default: ''
+      legacy:
+        description: >-
+          Send type-0 (legacy) transactions. Needed for HyperEVM, whose RPC rejects the fee-history ranges EIP-1559 estimation asks for. Type-0 works everywhere, so setting it for other networks is safe too.
+        required: false
+        type: boolean
+        default: false
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -80,6 +87,7 @@ jobs:
           ST0X_ORACLE_ADMIN: ${{ inputs.st0x-oracle-admin }}
           ST0X_SIGNER: ${{ inputs.st0x-signer }}
           DEPLOY_BROADCAST: '1'
+          DEPLOY_LEGACY: ${{ inputs.legacy && '1' || '' }}
           DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
           ETH_RPC_URL: ${{ secrets[env.rpc_secret_name] || vars[env.rpc_secret_name] || '' }}
           ETHERSCAN_API_KEY: ${{ secrets[env.etherscan_api_key_secret_name] || vars[env.etherscan_api_key_secret_name] || ''}}


### PR DESCRIPTION
HyperEVM's RPC rejects the fee-history ranges EIP-1559 estimation asks
for, so its dispatches need type-0 transactions. The pinned rainix
rainix-sol-artifacts already honours DEPLOY_LEGACY (--legacy); this
plumbs a workflow input through to it, mirroring rain.orderbook's
deploy workflow, and adds hyperevm to the network choices (its RPC /
verifier config rides the existing CI_DEPLOY_<NETWORK>_* secret
convention — the org secrets must exist before the first dispatch).

Prerequisite for the HyperEVM leg of the ST0xPriceOracle store rollout
(RAI-2000).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.oracle/pr/338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790247597&installation_model_id=19370&pr_number=338&repository=ST0x-Technology%2Fst0x.oracle&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.oracle%2Fpull%2F338&signature=d2e4792e469d8e989134c62f4a2f0bc18ef0ce1cff52b2f68066fcb9b0c71f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->